### PR TITLE
fix: negative token savings from passthrough pollution

### DIFF
--- a/internal/tracking/schema.go
+++ b/internal/tracking/schema.go
@@ -25,7 +25,7 @@ const summarySQL = `
 SELECT
 	COUNT(*) as total_commands,
 	COALESCE(SUM(saved_tokens), 0) as total_saved,
-	COALESCE(AVG(savings_pct), 0) as avg_savings,
+	COALESCE(SUM(saved_tokens) * 100.0 / NULLIF(SUM(input_tokens), 0), 0) as avg_savings,
 	COALESCE(SUM(exec_time_ms), 0) as total_time_ms
 FROM commands;
 `
@@ -37,7 +37,7 @@ SELECT
 	SUM(input_tokens) as input_tokens,
 	SUM(output_tokens) as output_tokens,
 	SUM(saved_tokens) as saved_tokens,
-	AVG(savings_pct) as avg_savings
+	COALESCE(SUM(saved_tokens) * 100.0 / NULLIF(SUM(input_tokens), 0), 0) as avg_savings
 FROM commands
 WHERE timestamp >= datetime('now', ? || ' days')
 GROUP BY date(timestamp)


### PR DESCRIPTION
## Summary
- Stop tracking passthrough commands (72% of entries were 0/0 noise)
- Skip tracking when `input_tokens == 0` (no output to measure)
- Use weighted avg savings `SUM(saved)/SUM(input)*100` instead of `AVG(pct)` which gave equal weight to a 3-token `git status` and a 61K-token `go test`

## Test plan
- [x] `make test` passes
- [x] `golangci-lint run ./...` — 0 issues
- [ ] Run `snip gain` after a session and verify positive savings on filtered commands

Fixes #2