### PR TITLE
feat: enhanced gain dashboard

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -163,6 +163,10 @@ Examples:
   snip git log -10
   snip go test ./...
   snip gain --daily
+  snip gain --weekly
+  snip gain --monthly
+  snip gain --top 10
+  snip gain --history 20
   snip init
 `
 	fmt.Printf(usage, version)

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -16,6 +16,9 @@ var (
 	DimStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
 	StatStyle    = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("14"))
 	WarnStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("11"))
+	GreenStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("10"))
+	YellowStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("11"))
+	RedStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
 )
 
 // IsTerminal returns true if stdout is a TTY.
@@ -45,21 +48,151 @@ func FormatSeparator(width int) string {
 	return strings.Repeat("═", width)
 }
 
+// ColorSavings returns a savings percentage string colored by tier.
+// ≥70% green, 30-70% yellow, <30% red.
+func ColorSavings(pct float64) string {
+	text := fmt.Sprintf("%.1f%%", pct)
+	if !IsTerminal() {
+		return text
+	}
+	switch {
+	case pct >= 70:
+		return GreenStyle.Render(text)
+	case pct >= 30:
+		return YellowStyle.Render(text)
+	default:
+		return RedStyle.Render(text)
+	}
+}
+
+// TierLabel returns an efficiency tier label based on savings percentage.
+func TierLabel(pct float64) string {
+	switch {
+	case pct >= 90:
+		return "Elite"
+	case pct >= 70:
+		return "Great"
+	case pct >= 50:
+		return "Good"
+	case pct >= 30:
+		return "Fair"
+	default:
+		return "Low"
+	}
+}
+
+// ColorTier returns a tier label colored by level.
+func ColorTier(tier string) string {
+	if !IsTerminal() {
+		return tier
+	}
+	switch tier {
+	case "Elite":
+		return GreenStyle.Bold(true).Render(tier)
+	case "Great":
+		return GreenStyle.Render(tier)
+	case "Good":
+		return YellowStyle.Render(tier)
+	case "Fair":
+		return WarnStyle.Render(tier)
+	default:
+		return RedStyle.Render(tier)
+	}
+}
+
+// ColorBar returns a colored impact bar (green filled, dim empty).
+// Guarantees at least 1 filled block when value > 0.
+func ColorBar(value, maxVal, width int) string {
+	if maxVal <= 0 || width <= 0 {
+		return strings.Repeat("░", width)
+	}
+	filled := min(max(value*width/maxVal, 0), width)
+	if filled == 0 && value > 0 {
+		filled = 1
+	}
+	filledStr := strings.Repeat("█", filled)
+	emptyStr := strings.Repeat("░", width-filled)
+	if !IsTerminal() {
+		return filledStr + emptyStr
+	}
+	return GreenStyle.Render(filledStr) + DimStyle.Render(emptyStr)
+}
+
+// FormatBar renders a horizontal bar proportional to value/maxVal.
+func FormatBar(value, maxVal, width int) string {
+	if maxVal <= 0 || width <= 0 {
+		return strings.Repeat("░", width)
+	}
+	filled := min(max(value*width/maxVal, 0), width)
+	return strings.Repeat("█", filled) + strings.Repeat("░", width-filled)
+}
+
+// FormatSparkline renders a sparkline from a slice of values.
+// Uses Unicode block characters ▁▂▃▄▅▆▇█.
+func FormatSparkline(values []float64) string {
+	blocks := []rune("▁▂▃▄▅▆▇█")
+
+	if len(values) == 0 {
+		return ""
+	}
+
+	max := values[0]
+	for _, v := range values[1:] {
+		if v > max {
+			max = v
+		}
+	}
+
+	var b strings.Builder
+	for _, v := range values {
+		idx := 0
+		if max > 0 {
+			idx = int(v / max * float64(len(blocks)-1))
+		}
+		if idx >= len(blocks) {
+			idx = len(blocks) - 1
+		}
+		if idx < 0 {
+			idx = 0
+		}
+		b.WriteRune(blocks[idx])
+	}
+	return b.String()
+}
+
+// visualWidth returns the visible width of a string, ignoring ANSI escape codes.
+func visualWidth(s string) int {
+	return lipgloss.Width(s)
+}
+
+// padRight pads a string to the target visual width with spaces,
+// correctly handling ANSI escape codes.
+func padRight(s string, targetWidth int) string {
+	vw := visualWidth(s)
+	if vw >= targetWidth {
+		return s
+	}
+	return s + strings.Repeat(" ", targetWidth-vw)
+}
+
 // FormatTable formats data as a simple aligned table.
+// Handles ANSI-colored cells correctly for alignment.
 func FormatTable(headers []string, rows [][]string) string {
 	if len(headers) == 0 {
 		return ""
 	}
 
-	// Calculate column widths
+	// Calculate column widths using visual width (ANSI-safe)
 	widths := make([]int, len(headers))
 	for i, h := range headers {
-		widths[i] = len(h)
+		widths[i] = visualWidth(h)
 	}
 	for _, row := range rows {
 		for i, cell := range row {
-			if i < len(widths) && len(cell) > widths[i] {
-				widths[i] = len(cell)
+			if i < len(widths) {
+				if w := visualWidth(cell); w > widths[i] {
+					widths[i] = w
+				}
 			}
 		}
 	}
@@ -71,7 +204,7 @@ func FormatTable(headers []string, rows [][]string) string {
 		if i > 0 {
 			b.WriteString("  ")
 		}
-		fmt.Fprintf(&b, "%-*s", widths[i], h)
+		b.WriteString(padRight(h, widths[i]))
 	}
 	b.WriteString("\n")
 
@@ -91,7 +224,7 @@ func FormatTable(headers []string, rows [][]string) string {
 				b.WriteString("  ")
 			}
 			if i < len(widths) {
-				fmt.Fprintf(&b, "%-*s", widths[i], cell)
+				b.WriteString(padRight(cell, widths[i]))
 			}
 		}
 		b.WriteString("\n")

--- a/internal/display/display_test.go
+++ b/internal/display/display_test.go
@@ -38,3 +38,84 @@ func TestFormatTableEmpty(t *testing.T) {
 		t.Errorf("expected empty, got %q", result)
 	}
 }
+
+func TestFormatBar(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    int
+		maxVal   int
+		width    int
+		wantLen  int
+		wantFull bool
+	}{
+		{"full bar", 100, 100, 10, 10, true},
+		{"half bar", 50, 100, 10, 10, false},
+		{"empty bar", 0, 100, 10, 10, false},
+		{"zero max", 50, 0, 10, 10, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bar := FormatBar(tt.value, tt.maxVal, tt.width)
+			runes := []rune(bar)
+			if len(runes) != tt.wantLen {
+				t.Errorf("bar rune len = %d, want %d", len(runes), tt.wantLen)
+			}
+			if tt.wantFull {
+				for _, r := range runes {
+					if r != '█' {
+						t.Errorf("expected all filled, got %c", r)
+						break
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestFormatSparkline(t *testing.T) {
+	values := []float64{10, 50, 80, 30, 100}
+	spark := FormatSparkline(values)
+	runes := []rune(spark)
+	if len(runes) != 5 {
+		t.Errorf("sparkline len = %d, want 5", len(runes))
+	}
+	// Last value is max (100), should be highest block
+	if runes[4] != '█' {
+		t.Errorf("max value should be █, got %c", runes[4])
+	}
+}
+
+func TestFormatSparklineEmpty(t *testing.T) {
+	spark := FormatSparkline(nil)
+	if spark != "" {
+		t.Errorf("expected empty, got %q", spark)
+	}
+}
+
+func TestTierLabel(t *testing.T) {
+	tests := []struct {
+		pct  float64
+		want string
+	}{
+		{95, "Elite"},
+		{75, "Great"},
+		{55, "Good"},
+		{35, "Fair"},
+		{10, "Low"},
+	}
+	for _, tt := range tests {
+		got := TierLabel(tt.pct)
+		if got != tt.want {
+			t.Errorf("TierLabel(%.0f) = %q, want %q", tt.pct, got, tt.want)
+		}
+	}
+}
+
+func TestColorSavingsNonTTY(t *testing.T) {
+	// Non-TTY: should return plain text (no ANSI codes)
+	result := ColorSavings(85.3)
+	if !strings.Contains(result, "85.3%") {
+		t.Errorf("expected 85.3%%, got %q", result)
+	}
+}

--- a/internal/display/gain_test.go
+++ b/internal/display/gain_test.go
@@ -18,6 +18,14 @@ func newTestTracker(t *testing.T) *tracking.Tracker {
 	return tracker
 }
 
+func seedTracker(t *testing.T, tracker *tracking.Tracker) {
+	t.Helper()
+	_ = tracker.Track("git log", "snip git log", 1000, 200, 50)
+	_ = tracker.Track("go test", "snip go test", 2000, 300, 100)
+	_ = tracker.Track("git log", "snip git log", 800, 100, 40)
+	_ = tracker.Track("ls -la", "snip ls -la", 50, 30, 5)
+}
+
 func TestRunGainNoData(t *testing.T) {
 	tracker := newTestTracker(t)
 	err := RunGain(tracker, nil)
@@ -28,9 +36,7 @@ func TestRunGainNoData(t *testing.T) {
 
 func TestRunGainWithData(t *testing.T) {
 	tracker := newTestTracker(t)
-
-	_ = tracker.Track("git log", "snip git log", 1000, 200, 50)
-	_ = tracker.Track("go test", "snip go test", 2000, 300, 100)
+	seedTracker(t, tracker)
 
 	err := RunGain(tracker, nil)
 	if err != nil {
@@ -40,7 +46,7 @@ func TestRunGainWithData(t *testing.T) {
 
 func TestRunGainDaily(t *testing.T) {
 	tracker := newTestTracker(t)
-	_ = tracker.Track("cmd", "snip cmd", 500, 100, 30)
+	seedTracker(t, tracker)
 
 	err := RunGain(tracker, []string{"--daily"})
 	if err != nil {
@@ -48,12 +54,81 @@ func TestRunGainDaily(t *testing.T) {
 	}
 }
 
+func TestRunGainWeekly(t *testing.T) {
+	tracker := newTestTracker(t)
+	seedTracker(t, tracker)
+
+	err := RunGain(tracker, []string{"--weekly"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunGainMonthly(t *testing.T) {
+	tracker := newTestTracker(t)
+	seedTracker(t, tracker)
+
+	err := RunGain(tracker, []string{"--monthly"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunGainTop(t *testing.T) {
+	tracker := newTestTracker(t)
+	seedTracker(t, tracker)
+
+	err := RunGain(tracker, []string{"--top", "5"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunGainTopDefault(t *testing.T) {
+	tracker := newTestTracker(t)
+	seedTracker(t, tracker)
+
+	err := RunGain(tracker, []string{"--top"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestRunGainHistory(t *testing.T) {
 	tracker := newTestTracker(t)
-	_ = tracker.Track("cmd1", "snip cmd1", 500, 100, 30)
-	_ = tracker.Track("cmd2", "snip cmd2", 800, 200, 40)
+	seedTracker(t, tracker)
 
 	err := RunGain(tracker, []string{"--history", "5"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunGainHistoryDefault(t *testing.T) {
+	tracker := newTestTracker(t)
+	seedTracker(t, tracker)
+
+	err := RunGain(tracker, []string{"--history"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunGainJSON(t *testing.T) {
+	tracker := newTestTracker(t)
+	seedTracker(t, tracker)
+
+	err := RunGain(tracker, []string{"--json"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunGainCSV(t *testing.T) {
+	tracker := newTestTracker(t)
+	seedTracker(t, tracker)
+
+	err := RunGain(tracker, []string{"--csv"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- **By-command breakdown**: top commands ranked by tokens saved with colored impact bars (`--top N`)
- **Period aggregations**: weekly (`--weekly`) and monthly (`--monthly`) views
- **14-day sparkline trend**: ASCII `▁▂▃▄▅▆▇█` graph in default dashboard
- **Efficiency tier**: Elite/Great/Good/Fair/Low based on avg savings
- **Colored output**: lipgloss green/yellow/red savings, colored bars, styled headers
- **ANSI-safe table alignment**: `FormatTable` uses `lipgloss.Width()` for correct column padding
- Default `snip gain` now shows full dashboard (summary + sparkline + top 10)

Closes #4

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] Race detector clean (`go test -race ./...`)
- [x] golangci-lint 0 issues
- [x] Manual test: `snip gain`, `snip gain --weekly`, `snip gain --monthly`, `snip gain --top 5`, `snip gain --history 5`, `snip gain --json`, `snip gain --csv`
- [x] Non-TTY output (piped) has no ANSI codes
- [x] TTY output has proper lipgloss colors and alignment