### PR TITLE
feat: add Homebrew tap distribution

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,5 +30,5 @@ jobs:
           version: "~> v2"
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN || secrets.GITHUB_TOKEN }}
           GOPRIVATE: github.com/edouard-claude/snip

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,6 +26,13 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
+homebrew_casks:
+  - repository:
+      owner: edouard-claude
+      name: homebrew-tap
+    homepage: "https://github.com/edouard-claude/snip"
+    description: "CLI proxy that reduces LLM token consumption by 60-90% by filtering shell output"
+
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
## Summary
- Add `homebrew_casks` config to `.goreleaser.yaml` for automatic Homebrew formula publishing
- Use `HOMEBREW_TAP_TOKEN` secret for cross-repo push to `edouard-claude/homebrew-tap`
- Install: `brew install edouard-claude/tap/snip`

## Test plan
- [x] `goreleaser check` passes with no warnings
- [ ] Next tag push triggers release + Homebrew formula update