### PR TITLE
feat(filters): add Rails ecosystem filters

### DIFF
--- a/filters/bundle-install.yaml
+++ b/filters/bundle-install.yaml
@@ -1,0 +1,20 @@
+name: "bundle-install"
+version: 1
+description: "Condensed bundle install output"
+
+match:
+  command: "bundle"
+  subcommand: "install"
+
+pipeline:
+  - action: "keep_lines"
+    pattern: "\\S"
+  - action: "aggregate"
+    patterns:
+      installed: "^Installing "
+      using: "^Using "
+      fetching: "^Fetching "
+      complete: "^Bundle complete"
+    format: "Bundle complete ({{.using}} cached, {{.installed}} installed)"
+
+on_error: "passthrough"

--- a/filters/rails-migrate.yaml
+++ b/filters/rails-migrate.yaml
@@ -1,0 +1,25 @@
+name: "rails-migrate"
+version: 1
+description: "Condensed rails db:migrate output"
+
+match:
+  command: "rails"
+  subcommand: "db:migrate"
+
+pipeline:
+  - action: "keep_lines"
+    pattern: "\\S"
+  - action: "remove_lines"
+    pattern: "^\\s*(-|->)"
+  - action: "keep_lines"
+    pattern: "migrated"
+  - action: "regex_extract"
+    pattern: "== \\d+ (\\w+): migrated"
+    format: "- $1"
+  - action: "aggregate"
+    patterns:
+      migrated: "^-"
+  - action: "format_template"
+    template: "{{with .stats}}{{.migrated}} migrations executed:{{end}}\n{{.lines}}"
+
+on_error: "passthrough"

--- a/filters/rails-routes.yaml
+++ b/filters/rails-routes.yaml
@@ -1,0 +1,23 @@
+name: "rails-routes"
+version: 1
+description: "Summarized rails routes with count and truncation"
+
+match:
+  command: "rails"
+  subcommand: "routes"
+  exclude_flags: ["-g", "--grep", "-c", "--controller"]
+
+pipeline:
+  - action: "keep_lines"
+    pattern: "\\S"
+  - action: "remove_lines"
+    pattern: "^\\s*Prefix"
+  - action: "aggregate"
+    patterns:
+      routes: "(GET|POST|PUT|PATCH|DELETE)"
+  - action: "head"
+    n: 15
+  - action: "format_template"
+    template: "{{with .stats}}{{.routes}} routes total{{end}} (showing first 15):\n{{.lines}}"
+
+on_error: "passthrough"

--- a/filters/rspec.yaml
+++ b/filters/rspec.yaml
@@ -1,0 +1,17 @@
+name: "rspec"
+version: 1
+description: "Condensed RSpec output with pass/fail summary"
+
+match:
+  command: "rspec"
+  exclude_flags: ["--format", "-f"]
+
+pipeline:
+  - action: "keep_lines"
+    pattern: "\\S"
+  - action: "keep_lines"
+    pattern: "(^\\d+ examples|^rspec \\./)"
+  - action: "head"
+    n: 10
+
+on_error: "passthrough"

--- a/internal/filter/actions_integration_test.go
+++ b/internal/filter/actions_integration_test.go
@@ -215,6 +215,36 @@ func TestCargoTestFilterIntegration(t *testing.T) {
 	}
 }
 
+func TestRSpecFilterIntegration(t *testing.T) {
+	fixture := loadFixture(t, "rspec_raw.txt")
+	f := loadFilter(t, "rspec.yaml")
+
+	filtered, err := applyPipeline(f, fixture)
+	if err != nil {
+		t.Fatalf("apply pipeline: %v", err)
+	}
+
+	// Should be much shorter
+	if len(filtered) >= len(fixture) {
+		t.Errorf("filtered (%d) not shorter than input (%d)", len(filtered), len(fixture))
+	}
+
+	// Should contain summary
+	if !strings.Contains(filtered, "examples") {
+		t.Error("filtered output missing examples count")
+	}
+
+	// Should preserve failure paths (essential for debugging)
+	if strings.Contains(fixture, "rspec ./") && !strings.Contains(filtered, "rspec ./") {
+		t.Error("filtered output missing failure paths (rspec ./spec/...)")
+	}
+
+	inputTokens := utils.EstimateTokens(fixture)
+	outputTokens := utils.EstimateTokens(filtered)
+	savings := float64(inputTokens-outputTokens) / float64(inputTokens) * 100
+	t.Logf("rspec: %d -> %d tokens (%.1f%% savings)", inputTokens, outputTokens, savings)
+}
+
 // Edge case tests
 func TestFilterEmptyInput(t *testing.T) {
 	f := loadFilter(t, "git-log.yaml")
@@ -254,6 +284,82 @@ func TestFilterANSIInput(t *testing.T) {
 	if strings.Contains(filtered, "\x1b") {
 		t.Error("ANSI codes not stripped")
 	}
+}
+
+func TestBundleInstallFilterIntegration(t *testing.T) {
+	fixture := loadFixture(t, "bundle_install_raw.txt")
+	f := loadFilter(t, "bundle-install.yaml")
+
+	filtered, err := applyPipeline(f, fixture)
+	if err != nil {
+		t.Fatalf("apply pipeline: %v", err)
+	}
+
+	if len(filtered) >= len(fixture) {
+		t.Errorf("filtered (%d) not shorter than input (%d)", len(filtered), len(fixture))
+	}
+
+	if !strings.Contains(filtered, "Bundle complete") {
+		t.Error("filtered output missing Bundle complete")
+	}
+
+	// Calculate and log token savings
+	inputTokens := utils.EstimateTokens(fixture)
+	outputTokens := utils.EstimateTokens(filtered)
+	savings := float64(inputTokens-outputTokens) / float64(inputTokens) * 100
+	t.Logf("bundle-install: %d -> %d tokens (%.1f%% savings)", inputTokens, outputTokens, savings)
+}
+
+func TestRailsRoutesFilterIntegration(t *testing.T) {
+	fixture := loadFixture(t, "rails_routes_raw.txt")
+	f := loadFilter(t, "rails-routes.yaml")
+
+	filtered, err := applyPipeline(f, fixture)
+	if err != nil {
+		t.Fatalf("apply pipeline: %v", err)
+	}
+
+	// Should be shorter
+	if len(filtered) >= len(fixture) {
+		t.Errorf("filtered (%d) not shorter than input (%d)", len(filtered), len(fixture))
+	}
+
+	// Should contain routes total summary
+	if !strings.Contains(filtered, "routes total") {
+		t.Error("filtered output missing 'routes total'")
+	}
+
+	// Calculate and log token savings
+	inputTokens := utils.EstimateTokens(fixture)
+	outputTokens := utils.EstimateTokens(filtered)
+	savings := float64(inputTokens-outputTokens) / float64(inputTokens) * 100
+	t.Logf("rails-routes: %d -> %d tokens (%.1f%% savings)", inputTokens, outputTokens, savings)
+}
+
+func TestRailsMigrateFilterIntegration(t *testing.T) {
+	fixture := loadFixture(t, "rails_migrate_raw.txt")
+	f := loadFilter(t, "rails-migrate.yaml")
+
+	filtered, err := applyPipeline(f, fixture)
+	if err != nil {
+		t.Fatalf("apply pipeline: %v", err)
+	}
+
+	// Should be shorter
+	if len(filtered) >= len(fixture) {
+		t.Errorf("filtered (%d) not shorter than input (%d)", len(filtered), len(fixture))
+	}
+
+	// Should contain migrations executed summary
+	if !strings.Contains(filtered, "migrations executed") {
+		t.Error("filtered output missing 'migrations executed'")
+	}
+
+	// Calculate and log token savings
+	inputTokens := utils.EstimateTokens(fixture)
+	outputTokens := utils.EstimateTokens(filtered)
+	savings := float64(inputTokens-outputTokens) / float64(inputTokens) * 100
+	t.Logf("rails-migrate: %d -> %d tokens (%.1f%% savings)", inputTokens, outputTokens, savings)
 }
 
 func TestGracefulDegradation(t *testing.T) {

--- a/tests/fixtures/bundle_install_raw.txt
+++ b/tests/fixtures/bundle_install_raw.txt
@@ -1,0 +1,26 @@
+Fetching gem metadata from https://rubygems.org/...........
+Resolving dependencies...
+Using rake 13.0.6
+Using concurrent-ruby 1.2.2
+Using i18n 1.14.1
+Fetching minitest 5.20.0
+Installing minitest 5.20.0
+Using tzinfo 2.0.6
+Using activesupport 7.1.2
+Fetching nokogiri 1.15.4 (x86_64-linux)
+Installing nokogiri 1.15.4 (x86_64-linux)
+Using rack 3.0.8
+Using rack-test 2.1.0
+Using erubi 1.12.0
+Using rails-dom-testing 2.2.0
+Using rails-html-sanitizer 1.6.0
+Using actionview 7.1.2
+Using actionpack 7.1.2
+Fetching puma 6.4.0
+Installing puma 6.4.0 with native extensions
+Using railties 7.1.2
+Using sprockets 4.2.1
+Using sprockets-rails 3.4.2
+Using rails 7.1.2
+Bundle complete! 15 Gemfile dependencies, 78 gems now installed.
+Use `bundle info [gemname]` to see where a bundled gem is installed.

--- a/tests/fixtures/rails_migrate_raw.txt
+++ b/tests/fixtures/rails_migrate_raw.txt
@@ -1,0 +1,16 @@
+== 20240115123456 CreateUsers: migrating ======================================
+-- create_table(:users)
+   -> 0.0234s
+== 20240115123456 CreateUsers: migrated (0.0235s) =============================
+
+== 20240116789012 AddIndexToOrders: migrating =================================
+-- add_index(:orders, :user_id)
+   -> 0.0123s
+== 20240116789012 AddIndexToOrders: migrated (0.0124s) ========================
+
+== 20240117111111 CreateProducts: migrating ===================================
+-- create_table(:products)
+   -> 0.0456s
+-- add_index(:products, :category_id)
+   -> 0.0078s
+== 20240117111111 CreateProducts: migrated (0.0534s) ==========================

--- a/tests/fixtures/rails_routes_raw.txt
+++ b/tests/fixtures/rails_routes_raw.txt
@@ -1,0 +1,28 @@
+                                  Prefix Verb   URI Pattern                                                                                       Controller#Action
+                                    root GET    /                                                                                                 home#index
+                                   users GET    /users(.:format)                                                                                  users#index
+                                         POST   /users(.:format)                                                                                  users#create
+                                new_user GET    /users/new(.:format)                                                                              users#new
+                               edit_user GET    /users/:id/edit(.:format)                                                                         users#edit
+                                    user GET    /users/:id(.:format)                                                                              users#show
+                                         PATCH  /users/:id(.:format)                                                                              users#update
+                                         PUT    /users/:id(.:format)                                                                              users#update
+                                         DELETE /users/:id(.:format)                                                                              users#destroy
+                                  orders GET    /orders(.:format)                                                                                 orders#index
+                                         POST   /orders(.:format)                                                                                 orders#create
+                               new_order GET    /orders/new(.:format)                                                                             orders#new
+                              edit_order GET    /orders/:id/edit(.:format)                                                                        orders#edit
+                                   order GET    /orders/:id(.:format)                                                                             orders#show
+                                         PATCH  /orders/:id(.:format)                                                                             orders#update
+                                         PUT    /orders/:id(.:format)                                                                             orders#update
+                                         DELETE /orders/:id(.:format)                                                                             orders#destroy
+                                products GET    /products(.:format)                                                                               products#index
+                                         POST   /products(.:format)                                                                               products#create
+                             new_product GET    /products/new(.:format)                                                                           products#new
+                            edit_product GET    /products/:id/edit(.:format)                                                                      products#edit
+                                 product GET    /products/:id(.:format)                                                                           products#show
+                                         PATCH  /products/:id(.:format)                                                                           products#update
+                                         PUT    /products/:id(.:format)                                                                           products#update
+                                         DELETE /products/:id(.:format)                                                                           products#destroy
+                              categories GET    /categories(.:format)                                                                             categories#index
+                                         POST   /categories(.:format)                                                                             categories#create

--- a/tests/fixtures/rspec_raw.txt
+++ b/tests/fixtures/rspec_raw.txt
@@ -1,0 +1,26 @@
+Randomized with seed 12345
+
+UserController
+  GET /users
+    returns a list of users
+  POST /users
+    creates a new user
+    with invalid params
+      returns errors
+
+OrderService
+  #process
+    with valid order
+      processes payment
+      sends confirmation email
+    with invalid order
+      raises error
+
+Finished in 0.45623 seconds (files took 1.23 seconds to load)
+42 examples, 3 failures, 2 pending
+
+Failed examples:
+
+rspec ./spec/controllers/users_controller_spec.rb:25 # UserController POST /users with invalid params returns errors
+rspec ./spec/services/order_service_spec.rb:45 # OrderService #process with invalid order raises error
+rspec ./spec/services/order_service_spec.rb:52 # OrderService #process with invalid order logs error


### PR DESCRIPTION
## Summary

Add 4 new declarative YAML filters for Ruby on Rails projects to reduce LLM token consumption when working with common Rails CLI commands.

## Why

Rails developers using snip with Claude Code need filters for their most common commands. These filters provide significant token savings (50-99%) while preserving essential debugging information.

## How

Each filter uses the existing DSL actions (keep_lines, remove_lines, aggregate, regex_extract, head, format_template) with no Go code changes required. All filters implement graceful degradation with `on_error: passthrough`.

## Changes

- **filters/rspec.yaml** - Condense RSpec output to summary + failure paths (52% savings)
- **filters/bundle-install.yaml** - Summarize gem installation with counts (94% savings)
- **filters/rails-routes.yaml** - Truncate route listing with total count (99% savings)
- **filters/rails-migrate.yaml** - Extract migration names from verbose output (95% savings)
- **tests/fixtures/** - 4 new fixture files with realistic CLI output
- **internal/filter/actions_integration_test.go** - 4 new integration tests

## Testing

### Test Coverage
- [x] Integration tests added for all 4 filters
- [x] Token savings logging in each test

### How to Test
1. `make build`
2. `./snip rspec` in a Rails project
3. `./snip bundle install`
4. `./snip rails routes`
5. `./snip rails db:migrate`

### Test Results
```
TestRSpecFilterIntegration: 187 -> 89 tokens (52.4% savings)
TestBundleInstallFilterIntegration: 196 -> 11 tokens (94.4% savings)
TestRailsRoutesFilterIntegration: 1119 -> 12 tokens (98.9% savings)
TestRailsMigrateFilterIntegration: 165 -> 9 tokens (94.5% savings)
```

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [x] Tests pass locally (`make test`)
- [x] No sensitive data exposed
- [x] Filters use English for all names/descriptions

## Impact Assessment
- [x] **Breaking changes:** None
- [x] **New dependencies:** None (YAML filters only)