### PR TITLE
fix(cli): use '--' separator to prevent snip from consuming proxied command flags

### DIFF
--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -12,11 +12,19 @@ type Flags struct {
 }
 
 // ParseFlags extracts global flags from args and returns remaining args.
+// A "--" separator stops flag parsing: everything after it is passed
+// verbatim to the underlying command, preventing snip from consuming
+// flags like --help or --version that belong to the proxied tool.
 func ParseFlags(args []string) (Flags, []string) {
 	var flags Flags
 	var remaining []string
 
-	for _, arg := range args {
+	for i, arg := range args {
+		if arg == "--" {
+			// Everything after "--" belongs to the underlying command.
+			remaining = append(remaining, args[i+1:]...)
+			break
+		}
 		switch {
 		case arg == "-vv":
 			flags.Verbose = 2

--- a/internal/cli/flags_test.go
+++ b/internal/cli/flags_test.go
@@ -53,6 +53,37 @@ func TestParseFlags(t *testing.T) {
 			wantFlags: Flags{Verbose: 1, UltraCompact: true},
 			wantArgs:  []string{"git", "status"},
 		},
+		// "--" separator: everything after it is passed verbatim to the command.
+		{
+			name:      "double dash passes remaining verbatim",
+			args:      []string{"--", "opencode", "--help"},
+			wantFlags: Flags{},
+			wantArgs:  []string{"opencode", "--help"},
+		},
+		{
+			name:      "snip flags before double dash, command flags after",
+			args:      []string{"-v", "--", "go", "test", "--version"},
+			wantFlags: Flags{Verbose: 1},
+			wantArgs:  []string{"go", "test", "--version"},
+		},
+		{
+			name:      "double dash alone produces empty remaining",
+			args:      []string{"--"},
+			wantFlags: Flags{},
+			wantArgs:  nil,
+		},
+		{
+			name:      "double dash before --help prevents snip help",
+			args:      []string{"--", "--help"},
+			wantFlags: Flags{},
+			wantArgs:  []string{"--help"},
+		},
+		{
+			name:      "double dash before -v prevents snip verbose",
+			args:      []string{"--", "-v", "git", "log"},
+			wantFlags: Flags{},
+			wantArgs:  []string{"-v", "git", "log"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/initcmd/init.go
+++ b/internal/initcmd/init.go
@@ -49,8 +49,10 @@ BASE=$(echo "$BARE_CMD" | awk '{print $1}')
 REWRITE=""
 case "$BASE" in
   git|go|cargo|npm|npx|yarn|pnpm|docker|kubectl|make|pip|pytest|jest|tsc|eslint|rustc)
-    # Rewrite: prefix with snip
-    REWRITE=$(echo "$CMD" | sed "s|$BARE_CMD|snip $BARE_CMD|")
+    # Rewrite: prefix with "snip --" so flags like --help or --version in the
+    # original command are passed verbatim to the underlying tool, not parsed
+    # by snip itself.
+    REWRITE=$(echo "$CMD" | sed "s|$BARE_CMD|snip -- $BARE_CMD|")
     ;;
 esac
 

--- a/internal/initcmd/init_test.go
+++ b/internal/initcmd/init_test.go
@@ -243,8 +243,8 @@ func TestHookScriptMultilineCommand(t *testing.T) {
 	updated, _ := hookOut["updatedInput"].(map[string]any)
 	rewritten, _ := updated["command"].(string)
 
-	if !strings.HasPrefix(rewritten, "snip git add ") {
-		t.Errorf("expected rewritten command to start with 'snip git add', got: %s", rewritten)
+	if !strings.HasPrefix(rewritten, "snip -- git add ") {
+		t.Errorf("expected rewritten command to start with 'snip -- git add', got: %s", rewritten)
 	}
 }
 


### PR DESCRIPTION
ParseFlags now stops consuming snip flags when it encounters '--'. Everything
after the separator is passed verbatim to the underlying command, so flags
like --help or --version in the original invocation reach the proxied tool
instead of being interpreted by snip.

The hook script is updated to rewrite commands as 'snip -- <cmd>' instead of
'snip <cmd>', ensuring the separator is always injected automatically.

Existing users must re-run 'snip init' to update the installed hook script.