### PR TITLE
feat: Improve gain command display

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ snip gain --weekly          # weekly breakdown
 snip gain --monthly         # monthly breakdown
 snip gain --top 10          # top N commands by tokens saved
 snip gain --history 20      # last 20 commands
-snip gain --nocommand-truncate  # disable command truncation
+snip gain --no-truncate     # disable command truncation
 snip gain --json            # machine-readable output
 snip gain --csv             # CSV export
 snip -v <command>           # verbose mode (show filter details)

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ snip gain --weekly          # weekly breakdown
 snip gain --monthly         # monthly breakdown
 snip gain --top 10          # top N commands by tokens saved
 snip gain --history 20      # last 20 commands
+snip gain --nocommand-truncate  # disable command truncation
 snip gain --json            # machine-readable output
 snip gain --csv             # CSV export
 snip -v <command>           # verbose mode (show filter details)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -229,7 +229,7 @@ Examples:
   snip gain --monthly
   snip gain --top 10
   snip gain --history 20
-  snip gain --nocommand-truncate
+  snip gain --no-truncate
   snip init
 `
 	fmt.Printf(usage, version)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -229,6 +229,7 @@ Examples:
   snip gain --monthly
   snip gain --top 10
   snip gain --history 20
+  snip gain --nocommand-truncate
   snip init
 `
 	fmt.Printf(usage, version)

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/term"
 	"github.com/mattn/go-isatty"
 )
 
@@ -24,6 +25,15 @@ var (
 // IsTerminal returns true if stdout is a TTY.
 func IsTerminal() bool {
 	return isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
+}
+
+// TerminalWidth returns the current terminal width, or 80 if unavailable.
+func TerminalWidth() int {
+	w, _, err := term.GetSize(os.Stdout.Fd())
+	if err != nil || w <= 0 {
+		return 80
+	}
+	return w
 }
 
 // PrintFiltered prints filtered output with optional verbosity header.

--- a/internal/display/gain.go
+++ b/internal/display/gain.go
@@ -60,7 +60,7 @@ func RunGain(tracker *tracking.Tracker, args []string) error {
 			if historyN <= 0 {
 				historyN = 10
 			}
-		case "--nocommand-truncate":
+		case "--no-truncate":
 			noTruncate = true
 		}
 	}

--- a/internal/display/gain.go
+++ b/internal/display/gain.go
@@ -25,6 +25,7 @@ func RunGain(tracker *tracking.Tracker, args []string) error {
 		showJSON    bool
 		showCSV     bool
 		showTop     bool
+		noTruncate  bool
 		historyN    int
 		topN        int
 		days        = 7
@@ -59,6 +60,8 @@ func RunGain(tracker *tracking.Tracker, args []string) error {
 			if historyN <= 0 {
 				historyN = 10
 			}
+		case "--nocommand-truncate":
+			noTruncate = true
 		}
 	}
 
@@ -75,12 +78,12 @@ func RunGain(tracker *tracking.Tracker, args []string) error {
 	}
 
 	if historyN > 0 {
-		return showHistory(tracker, historyN)
+		return showHistory(tracker, historyN, noTruncate)
 	}
 
 	if showTop {
 		printSummary(summary)
-		return showByCommand(tracker, topN)
+		return showByCommand(tracker, topN, noTruncate)
 	}
 
 	if showWeekly {
@@ -100,7 +103,7 @@ func RunGain(tracker *tracking.Tracker, args []string) error {
 	// Default: full dashboard (summary + sparkline + top commands)
 	printSummary(summary)
 	showSparkline(tracker)
-	_ = showByCommand(tracker, 10)
+	_ = showByCommand(tracker, 10, noTruncate)
 	return nil
 }
 
@@ -156,7 +159,17 @@ func printSummary(s *tracking.Summary) {
 	fmt.Println()
 }
 
-func showByCommand(tracker *tracking.Tracker, limit int) error {
+// cmdColWidth returns the Command column truncation width given terminal width
+// and the total width consumed by all other columns + separators.
+func cmdColWidth(termWidth, fixedWidth int) int {
+	w := termWidth - fixedWidth
+	if w < 20 {
+		return 20
+	}
+	return w
+}
+
+func showByCommand(tracker *tracking.Tracker, limit int, noTruncate bool) error {
 	stats, err := tracker.GetByCommand(limit)
 	if err != nil {
 		return err
@@ -185,10 +198,12 @@ func showByCommand(tracker *tracking.Tracker, limit int) error {
 
 	headers := []string{"Command", "Runs", "Saved", "Savings", "Impact"}
 	var rows [][]string
+	// Fixed columns: Runs(4) + Saved(5) + Savings(7) + Impact(12) + 4×sep(8) = 36
+	maxCmd := cmdColWidth(TerminalWidth(), 36)
 	for _, s := range stats {
 		cmd := s.Command
-		if len(cmd) > 25 {
-			cmd = cmd[:22] + "..."
+		if !noTruncate && len(cmd) > maxCmd {
+			cmd = cmd[:maxCmd-3] + "..."
 		}
 		bar := ColorBar(s.SavedTokens, maxSaved, 12)
 		rows = append(rows, []string{
@@ -298,7 +313,7 @@ func showPeriodReport(tracker *tracking.Tracker, period string) error {
 	return nil
 }
 
-func showHistory(tracker *tracking.Tracker, n int) error {
+func showHistory(tracker *tracking.Tracker, n int, noTruncate bool) error {
 	records, err := tracker.GetRecent(n)
 	if err != nil {
 		return err
@@ -306,10 +321,12 @@ func showHistory(tracker *tracking.Tracker, n int) error {
 
 	headers := []string{"Command", "Input", "Output", "Saved", "Time"}
 	var rows [][]string
+	// Fixed columns: Input(6) + Output(6) + Saved(6) + Time(6) + 4×sep(8) = 32
+	maxCmd := cmdColWidth(TerminalWidth(), 32)
 	for _, r := range records {
 		cmd := r.OriginalCmd
-		if len(cmd) > 30 {
-			cmd = cmd[:27] + "..."
+		if !noTruncate && len(cmd) > maxCmd {
+			cmd = cmd[:maxCmd-3] + "..."
 		}
 		rows = append(rows, []string{
 			cmd,

--- a/internal/display/gain_test.go
+++ b/internal/display/gain_test.go
@@ -3,7 +3,11 @@
 package display
 
 import (
+	"bytes"
+	"io"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/edouard-claude/snip/internal/tracking"
@@ -140,5 +144,56 @@ func TestRunGainNilTracker(t *testing.T) {
 	err := RunGain(nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestCmdColWidth verifies that cmdColWidth returns the correct column width
+// for various terminal widths, clamping to a minimum of 20.
+func TestCmdColWidth(t *testing.T) {
+	tests := []struct {
+		termWidth  int
+		fixedWidth int
+		want       int
+	}{
+		{120, 36, 84}, // nominal: plenty of room
+		{30, 36, 20},  // narrow: clamped to minimum
+		{56, 36, 20},  // boundary: w==20, clamped
+	}
+	for _, tc := range tests {
+		got := cmdColWidth(tc.termWidth, tc.fixedWidth)
+		if got != tc.want {
+			t.Errorf("cmdColWidth(%d, %d) = %d, want %d", tc.termWidth, tc.fixedWidth, got, tc.want)
+		}
+	}
+}
+
+// TestRunGainNoTruncate verifies that --no-truncate causes long command names
+// to appear untruncated in the output.
+func TestRunGainNoTruncate(t *testing.T) {
+	tracker := newTestTracker(t)
+
+	longCmd := strings.Repeat("x", 200)
+	_ = tracker.Track(longCmd, "snip "+longCmd, 5000, 100, 200)
+
+	// Capture stdout
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	runErr := RunGain(tracker, []string{"--top", "1", "--no-truncate"})
+
+	w.Close()
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	os.Stdout = old
+
+	if runErr != nil {
+		t.Fatalf("unexpected error: %v", runErr)
+	}
+	if !strings.Contains(buf.String(), longCmd) {
+		t.Errorf("expected long command (%d chars) to appear untruncated in output", len(longCmd))
 	}
 }

--- a/internal/display/gain_test.go
+++ b/internal/display/gain_test.go
@@ -185,7 +185,7 @@ func TestRunGainNoTruncate(t *testing.T) {
 
 	runErr := RunGain(tracker, []string{"--top", "1", "--no-truncate"})
 
-	w.Close()
+	_ = w.Close()
 	var buf bytes.Buffer
 	_, _ = io.Copy(&buf, r)
 	os.Stdout = old


### PR DESCRIPTION
- Detect terminal width and adapt the command column dynamically
- Add --nocommand-truncate flag to disable truncation entirely
- Update help text and README