### PR TITLE
fix: accept .yml extension for user filter files

### DIFF
--- a/internal/filter/loader.go
+++ b/internal/filter/loader.go
@@ -8,6 +8,11 @@ import (
 	"strings"
 )
 
+// isYAMLFile returns true if the filename ends with .yaml or .yml.
+func isYAMLFile(name string) bool {
+	return strings.HasSuffix(name, ".yaml") || strings.HasSuffix(name, ".yml")
+}
+
 // EmbeddedFS is set by the main package to provide embedded filter files.
 // This avoids go:embed constraints on internal packages.
 var EmbeddedFS *embed.FS
@@ -31,7 +36,7 @@ func LoadEmbedded() ([]Filter, error) {
 
 	var filters []Filter
 	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+		if entry.IsDir() || !isYAMLFile(entry.Name()) {
 			continue
 		}
 		path := entry.Name()
@@ -63,7 +68,7 @@ func LoadUserFilters(dir string) ([]Filter, error) {
 
 	var filters []Filter
 	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+		if entry.IsDir() || !isYAMLFile(entry.Name()) {
 			continue
 		}
 		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))

--- a/internal/filter/loader_test.go
+++ b/internal/filter/loader_test.go
@@ -35,6 +35,74 @@ on_error: "passthrough"
 	}
 }
 
+func TestLoadUserFiltersYMLExtension(t *testing.T) {
+	dir := t.TempDir()
+
+	validYAML := `
+name: "yml-filter"
+version: 1
+match:
+  command: "echo"
+pipeline:
+  - action: "keep_lines"
+    pattern: "\\S"
+on_error: "passthrough"
+`
+	if err := os.WriteFile(filepath.Join(dir, "echo.yml"), []byte(validYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	filters, err := LoadUserFilters(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(filters) != 1 {
+		t.Fatalf("got %d filters, want 1", len(filters))
+	}
+	if filters[0].Name != "yml-filter" {
+		t.Errorf("name = %q, want %q", filters[0].Name, "yml-filter")
+	}
+}
+
+func TestLoadUserFiltersBothExtensions(t *testing.T) {
+	dir := t.TempDir()
+
+	yamlContent := `
+name: "yaml-filter"
+version: 1
+match:
+  command: "cmd1"
+pipeline:
+  - action: "head"
+    n: 5
+on_error: "passthrough"
+`
+	ymlContent := `
+name: "yml-filter"
+version: 1
+match:
+  command: "cmd2"
+pipeline:
+  - action: "tail"
+    n: 3
+on_error: "passthrough"
+`
+	if err := os.WriteFile(filepath.Join(dir, "a.yaml"), []byte(yamlContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b.yml"), []byte(ymlContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	filters, err := LoadUserFilters(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(filters) != 2 {
+		t.Fatalf("got %d filters, want 2", len(filters))
+	}
+}
+
 func TestLoadUserFiltersMissingDir(t *testing.T) {
 	filters, err := LoadUserFilters("/tmp/nonexistent-snip-filters-test")
 	if err != nil {


### PR DESCRIPTION
## Summary

- Filter loader only accepted `.yaml` extension, silently ignoring `.yml` files in custom directories
- Added `isYAMLFile()` helper that checks for both `.yaml` and `.yml`
- Applied to both `LoadEmbedded()` and `LoadUserFilters()`

Closes #32

## Test plan

- [x] New test `TestLoadUserFiltersYMLExtension` - loads a `.yml` filter
- [x] New test `TestLoadUserFiltersBothExtensions` - loads both `.yaml` and `.yml` from same directory
- [x] Existing tests still pass
- [x] `golangci-lint run` clean
- [x] `make test-race` passes