### PR TITLE
feat: suppress passthrough message when filter exists but flags excluded it

### DIFF
--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -35,9 +35,12 @@ func (p *Pipeline) Run(command string, args []string) int {
 	// Match filter
 	f := p.Registry.Match(command, subcommand, filterArgs)
 
-	// No filter found: passthrough with hint so LLMs know snip is unnecessary
+	// No filter found: passthrough.
+	// Only print a hint when no filter is registered at all — if a filter exists
+	// but was excluded by flags (e.g. go test -v), stay silent to avoid the
+	// misleading "no filter for go" message.
 	if f == nil {
-		if !p.QuietNoFilter {
+		if !p.QuietNoFilter && !p.Registry.HasAnyFilter(command, subcommand) {
 			fmt.Fprintf(os.Stderr, "snip: no filter for %q, passing through -- you can run %q directly\n", command, command)
 		}
 		return p.Passthrough(command, args)

--- a/internal/filter/registry.go
+++ b/internal/filter/registry.go
@@ -103,6 +103,19 @@ func (r *Registry) ShouldInject(f *Filter, args []string) ([]string, bool) {
 	return result, true
 }
 
+// HasAnyFilter returns true if any filter is registered for the given command
+// and subcommand, regardless of flag constraints. Use this to distinguish
+// "no filter at all" from "filter exists but was excluded by flags".
+func (r *Registry) HasAnyFilter(command, subcommand string) bool {
+	if subcommand != "" {
+		if _, ok := r.byKey[command+":"+subcommand]; ok {
+			return true
+		}
+	}
+	_, ok := r.byKey[command]
+	return ok
+}
+
 // Commands returns a sorted, unique list of base command names in the registry.
 // Keys like "git:log" are split on ":" and only the base command "git" is kept.
 func (r *Registry) Commands() []string {

--- a/internal/filter/registry_test.go
+++ b/internal/filter/registry_test.go
@@ -125,6 +125,34 @@ func TestRegistryCommandsEmpty(t *testing.T) {
 	}
 }
 
+func TestHasAnyFilter(t *testing.T) {
+	f := Filter{
+		Name:    "go-test",
+		Version: 1,
+		Match:   Match{Command: "go", Subcommand: "test", ExcludeFlags: []string{"-v"}},
+		OnError: "passthrough",
+	}
+	reg := NewRegistry([]Filter{f})
+
+	// Key scenario: Match returns nil due to -v, but HasAnyFilter must still return true.
+	// This is what suppresses the misleading "no filter for go" message.
+	if reg.Match("go", "test", []string{"-v"}) != nil {
+		t.Error("Match should return nil when -v is excluded")
+	}
+	if !reg.HasAnyFilter("go", "test") {
+		t.Error("HasAnyFilter should return true even when flags exclude the filter")
+	}
+
+	// Known command, unknown subcommand — no command-only entry
+	if reg.HasAnyFilter("go", "build") {
+		t.Error("expected HasAnyFilter=false for go build (no filter)")
+	}
+	// Completely unknown command
+	if reg.HasAnyFilter("python", "") {
+		t.Error("expected HasAnyFilter=false for python")
+	}
+}
+
 func TestShouldInject(t *testing.T) {
 	f := Filter{
 		Name: "git-log",


### PR DESCRIPTION


Previously, running a command like `go test -v` would print "snip: no filter for 'go'" even though a go-test filter exists. The message was misleading because the filter was simply bypassed due to an exclude_flag (-v), not missing entirely.

Now the message is only shown when no filter is registered at all for that command. Commands excluded by flags pass through silently.

Example from the snip repo:
Before:
```
:~/snip$ snip go test -v
snip: no filter for "go", passing through -- you can run "go" directly
=== RUN   TestRun_VersionFlag
[rest of output stripped...]
```
After:
```
:~/snip$ snip go test -v
=== RUN   TestRun_VersionFlag
[rest of output stripped...]
```

