### PR TITLE
feat: add run subcommand to avoid shadowing built-in commands

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -50,8 +50,8 @@ func Run(args []string) int {
 
 	// Commands that cannot be proxied: they must run in the parent shell
 	// to have any effect. Running them in a subprocess is a silent no-op.
-	if unproxyableReason(command) != "" {
-		fmt.Fprintf(os.Stderr, "snip: %s cannot be proxied (%s)\n", command, unproxyableReason(command))
+	if reason := unproxyableReason(command); reason != "" {
+		fmt.Fprintf(os.Stderr, "snip: %s cannot be proxied (%s)\n", command, reason)
 		return 1
 	}
 
@@ -180,15 +180,19 @@ func Run(args []string) int {
 			display.PrintError("run requires -- separator: snip run -- <command> [args...]")
 			return 1
 		}
-		runArgs := cmdArgs[sepIdx+1:]
+		if sepIdx > 0 {
+			display.PrintError(fmt.Sprintf("run: unexpected arguments before -- (%s)", strings.Join(cmdArgs[:sepIdx], " ")))
+			return 1
+		}
+		runArgs := cmdArgs[1:]
 		if len(runArgs) == 0 {
 			display.PrintError("run requires a command after --")
 			return 1
 		}
 		runCmd := runArgs[0]
 		runCmdArgs := runArgs[1:]
-		if unproxyableReason(runCmd) != "" {
-			display.PrintError(fmt.Sprintf("%s cannot be proxied (%s)", runCmd, unproxyableReason(runCmd)))
+		if reason := unproxyableReason(runCmd); reason != "" {
+			display.PrintError(fmt.Sprintf("%s cannot be proxied (%s)", runCmd, reason))
 			return 1
 		}
 		return runPipeline(runCmd, runCmdArgs, flags)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -168,6 +168,31 @@ func Run(args []string) int {
 	case "untrust":
 		return runUntrust(cmdArgs)
 
+	case "run":
+		sepIdx := -1
+		for i, a := range cmdArgs {
+			if a == "--" {
+				sepIdx = i
+				break
+			}
+		}
+		if sepIdx < 0 {
+			display.PrintError("run requires -- separator: snip run -- <command> [args...]")
+			return 1
+		}
+		runArgs := cmdArgs[sepIdx+1:]
+		if len(runArgs) == 0 {
+			display.PrintError("run requires a command after --")
+			return 1
+		}
+		runCmd := runArgs[0]
+		runCmdArgs := runArgs[1:]
+		if unproxyableReason(runCmd) != "" {
+			display.PrintError(fmt.Sprintf("%s cannot be proxied (%s)", runCmd, unproxyableReason(runCmd)))
+			return 1
+		}
+		return runPipeline(runCmd, runCmdArgs, flags)
+
 	case "proxy":
 		// Direct passthrough without filtering
 		if len(cmdArgs) == 0 {
@@ -265,19 +290,20 @@ func printUsage() {
 Usage: snip [flags] <command> [args...]
 
 Commands:
-  <command>    Run command through snip filter pipeline
-  init         Install agent integration (default: claude-code)
-  hook         Handle agent PreToolUse/shell hook
-  hook-audit   Show recent hook activity (set SNIP_HOOK_AUDIT=1 to log)
-  gain         Show token savings report
-  cc-economics Show financial impact of token savings by API tier
-  discover     Scan sessions for missed filter opportunities
-  learn        Detect CLI error-correction patterns in sessions
-  verify       Run inline filter tests (--require-all to enforce coverage)
-  config       Show current configuration
-  trust        Trust project-local filter file(s) by SHA-256 hash
-  untrust      Remove filter file(s) from the trust store
-  proxy        Passthrough without filtering
+  run             Run command through snip filter pipeline (use -- to separate)
+  <command>       Run command through snip filter pipeline (implicit)
+  init            Install agent integration (default: claude-code)
+  hook            Handle agent PreToolUse/shell hook
+  hook-audit      Show recent hook activity (set SNIP_HOOK_AUDIT=1 to log)
+  gain            Show token savings report
+  cc-economics    Show financial impact of token savings by API tier
+  discover        Scan sessions for missed filter opportunities
+  learn           Detect CLI error-correction patterns in sessions
+  verify          Run inline filter tests (--require-all to enforce coverage)
+  config          Show current configuration
+  trust           Trust project-local filter file(s) by SHA-256 hash
+  untrust         Remove filter file(s) from the trust store
+  proxy           Passthrough without filtering
 
 Init flags:
   --agent <name>  Agent to configure:
@@ -293,6 +319,8 @@ Flags:
   --help        Show this help
 
 Examples:
+  snip run -- git log -10
+  snip run -- docker build -t app .
   snip git log -10
   snip go test ./...
   snip gain --daily

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -56,6 +56,27 @@ func TestRunSubcommandRejectsUnproxyable(t *testing.T) {
 	}
 }
 
+func TestRunSubcommandRejectsArgsBeforeSeparator(t *testing.T) {
+	code := Run([]string{"snip", "run", "foo", "--", "bar"})
+	if code != 1 {
+		t.Errorf("Run(run foo -- bar) = %d, want 1", code)
+	}
+}
+
+func TestRunGlobalHelpBeforeSeparator(t *testing.T) {
+	code := Run([]string{"snip", "run", "--help", "--", "foo", "bar"})
+	if code != 0 {
+		t.Errorf("Run(run --help -- foo bar) = %d, want 0", code)
+	}
+}
+
+func TestRunCommandHelpAfterSeparator(t *testing.T) {
+	code := Run([]string{"snip", "run", "--", "git", "--help"})
+	if code != 0 {
+		t.Errorf("Run(run -- git --help) = %d, want 0", code)
+	}
+}
+
 func TestRunSubcommandWithFlags(t *testing.T) {
 	flags, remaining := ParseFlags([]string{"-v", "run", "--", "git", "log", "-10"})
 	if flags.Verbose != 1 {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,6 +1,9 @@
 package cli
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestUnproxyableCommands(t *testing.T) {
 	tests := []struct {
@@ -29,5 +32,37 @@ func TestRunRejectsCd(t *testing.T) {
 	code := Run([]string{"snip", "cd", "/tmp"})
 	if code != 1 {
 		t.Errorf("Run(cd) = %d, want 1", code)
+	}
+}
+
+func TestRunSubcommandMissingSeparator(t *testing.T) {
+	code := Run([]string{"snip", "run", "git", "log"})
+	if code != 1 {
+		t.Errorf("Run(run without --) = %d, want 1", code)
+	}
+}
+
+func TestRunSubcommandEmptyAfterSeparator(t *testing.T) {
+	code := Run([]string{"snip", "run", "--"})
+	if code != 1 {
+		t.Errorf("Run(run --) = %d, want 1", code)
+	}
+}
+
+func TestRunSubcommandRejectsUnproxyable(t *testing.T) {
+	code := Run([]string{"snip", "run", "--", "cd", "/tmp"})
+	if code != 1 {
+		t.Errorf("Run(run -- cd) = %d, want 1", code)
+	}
+}
+
+func TestRunSubcommandWithFlags(t *testing.T) {
+	flags, remaining := ParseFlags([]string{"-v", "run", "--", "git", "log", "-10"})
+	if flags.Verbose != 1 {
+		t.Errorf("flags.Verbose = %d, want 1", flags.Verbose)
+	}
+	wantRemaining := []string{"run", "--", "git", "log", "-10"}
+	if !reflect.DeepEqual(remaining, wantRemaining) {
+		t.Errorf("remaining = %v, want %v", remaining, wantRemaining)
 	}
 }

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -64,7 +64,7 @@ func isStackedVerboseFlag(arg string) bool {
 
 func isBuiltInCommand(arg string) bool {
 	switch arg {
-	case "init", "gain", "cc-economics", "config", "proxy", "hook", "hook-audit", "discover", "learn", "verify", "trust", "untrust":
+	case "run", "init", "gain", "cc-economics", "config", "proxy", "hook", "hook-audit", "discover", "learn", "verify", "trust", "untrust":
 		return true
 	default:
 		return false

--- a/internal/cli/flags_test.go
+++ b/internal/cli/flags_test.go
@@ -127,6 +127,18 @@ func TestParseFlags(t *testing.T) {
 			wantFlags: Flags{},
 			wantArgs:  []string{"-v", "git", "log"},
 		},
+		{
+			name:      "run is a built-in command",
+			args:      []string{"run", "--", "git", "log"},
+			wantFlags: Flags{},
+			wantArgs:  []string{"run", "--", "git", "log"},
+		},
+		{
+			name:      "run with snip flags before it",
+			args:      []string{"-v", "run", "--", "git", "log"},
+			wantFlags: Flags{Verbose: 1},
+			wantArgs:  []string{"run", "--", "git", "log"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -92,7 +92,7 @@ func Run(r io.Reader, w io.Writer, commands []string, snipBin string) error {
 
 	// Build rewritten command.
 	rest := ti.Command[len(firstSegment):]
-	rewritten := prefix + envVars + quotedBin + " -- " + bareCmd + rest
+	rewritten := prefix + envVars + quotedBin + " run -- " + bareCmd + rest
 
 	// Preserve all original tool_input fields, replacing command.
 	var originalInput map[string]any

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -43,7 +43,7 @@ func TestRunRewriteSupported(t *testing.T) {
 	}
 
 	rewritten := extractRewrittenCommand(t, out.String())
-	want := `"/usr/local/bin/snip" -- git log -10`
+	want := `"/usr/local/bin/snip" run -- git log -10`
 	if rewritten != want {
 		t.Errorf("rewritten = %q, want %q", rewritten, want)
 	}
@@ -69,7 +69,7 @@ func TestRunAlreadyRewritten(t *testing.T) {
 	commands := []string{"git"}
 	snipBin := "/usr/local/bin/snip"
 
-	alreadyRewritten := `"/usr/local/bin/snip" -- git status`
+	alreadyRewritten := `"/usr/local/bin/snip" run -- git status`
 	input := makePayload("Bash", alreadyRewritten)
 	var out bytes.Buffer
 	err := Run(strings.NewReader(input), &out, commands, snipBin)
@@ -94,7 +94,7 @@ func TestRunMultiSegment(t *testing.T) {
 	}
 
 	rewritten := extractRewrittenCommand(t, out.String())
-	want := `"/usr/local/bin/snip" -- git add . && git commit -m 'fix'`
+	want := `"/usr/local/bin/snip" run -- git add . && git commit -m 'fix'`
 	if rewritten != want {
 		t.Errorf("rewritten = %q, want %q", rewritten, want)
 	}
@@ -112,7 +112,7 @@ func TestRunEnvVarPrefix(t *testing.T) {
 	}
 
 	rewritten := extractRewrittenCommand(t, out.String())
-	want := `CGO_ENABLED=0 "/usr/local/bin/snip" -- go test ./...`
+	want := `CGO_ENABLED=0 "/usr/local/bin/snip" run -- go test ./...`
 	if rewritten != want {
 		t.Errorf("rewritten = %q, want %q", rewritten, want)
 	}
@@ -204,7 +204,7 @@ func TestRunMultipleEnvVars(t *testing.T) {
 	}
 
 	rewritten := extractRewrittenCommand(t, out.String())
-	want := `FOO=1 BAR=2 "/usr/local/bin/snip" -- make build`
+	want := `FOO=1 BAR=2 "/usr/local/bin/snip" run -- make build`
 	if rewritten != want {
 		t.Errorf("rewritten = %q, want %q", rewritten, want)
 	}


### PR DESCRIPTION
Introduces `snip run -- <cmd> [args...]` as an explicit, unambiguous way to route a command through the filter pipeline. This allows wrapping external commands that share names with built-in commands (e.g., init).

The `--` separator is required after `run` to prevent snip from consuming flags meant for the wrapped command. The implicit `snip <cmd>` path remains for backward compatibility.

- Add `run` case to the CLI command switch with separator validation
- Register `run` as a built-in command in flag parsing
- Update hook rewrite format to use `snip run -- <cmd>`
- Add tests for run subcommand error paths and flag handling