### PR TITLE
Add check subcommand and expand coverage of unproxyable shell builtins

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -186,8 +186,8 @@ func Run(args []string) int {
 			display.PrintError(errMsg)
 			return 1
 		}
-		if r := unproxyableReason(targetCmd); r != "" {
-			display.PrintError(fmt.Sprintf("%s is a shell builtin (%s)", targetCmd, r))
+		if reason := unproxyableReason(targetCmd); reason != "" {
+			display.PrintError(fmt.Sprintf("%s cannot be proxied (%s)", targetCmd, reason))
 			return 1
 		}
 		return runCheck(targetCmd, targetArgs, flags)
@@ -338,19 +338,26 @@ func runCheck(command string, args []string, flags Flags) int {
 		return 1
 	}
 
-	enabled := true
-	if cfg.Filters.Enable != nil {
-		if e, ok := cfg.Filters.Enable[f.Name]; ok && !e {
-			enabled = false
-		}
-	}
-	if !enabled {
+	if !isFilterEnabled(cfg, f.Name) {
 		fmt.Printf("filter disabled: %s\n", f.Name)
 		return 1
 	}
 
 	fmt.Printf("filter: %s\n", f.Name)
 	return 0
+}
+
+// isFilterEnabled returns whether a filter is enabled. A nil map means all
+// enabled; a missing entry defaults to enabled; only explicit false disables.
+func isFilterEnabled(cfg *config.Config, name string) bool {
+	if cfg.Filters.Enable == nil {
+		return true
+	}
+	enabled, ok := cfg.Filters.Enable[name]
+	if !ok {
+		return true
+	}
+	return enabled
 }
 
 func printUsage() {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -197,6 +197,31 @@ func Run(args []string) int {
 		}
 		return runPipeline(runCmd, runCmdArgs, flags)
 
+	case "check":
+		sepIdx := -1
+		for i, a := range cmdArgs {
+			if a == "--" {
+				sepIdx = i
+				break
+			}
+		}
+		if sepIdx < 0 {
+			display.PrintError("check requires -- separator: snip check -- <command> [args...]")
+			return 1
+		}
+		checkArgs := cmdArgs[sepIdx+1:]
+		if len(checkArgs) == 0 {
+			display.PrintError("check requires a command after --")
+			return 1
+		}
+		checkCmd := checkArgs[0]
+		checkCmdArgs := checkArgs[1:]
+		if r := unproxyableReason(checkCmd); r != "" {
+			fmt.Printf("shell builtin: %s\n", r)
+			return 1
+		}
+		return runCheck(checkCmd, checkCmdArgs, flags)
+
 	case "proxy":
 		// Direct passthrough without filtering
 		if len(cmdArgs) == 0 {
@@ -288,6 +313,52 @@ func runPipeline(command string, args []string, flags Flags) int {
 	return pipeline.Run(command, args)
 }
 
+func runCheck(command string, args []string, flags Flags) int {
+	cfg, err := config.Load()
+	if err != nil {
+		cfg = config.DefaultConfig()
+	}
+
+	filters, err := filter.LoadAll(cfg.Filters.Dirs())
+	if err != nil {
+		display.PrintError(fmt.Sprintf("load filters: %v", err))
+		return 1
+	}
+
+	registry := filter.NewRegistry(filters)
+
+	subcommand := ""
+	filterArgs := args
+	if len(args) > 0 {
+		subcommand = args[0]
+		filterArgs = args[1:]
+	}
+
+	f := registry.Match(command, subcommand, filterArgs)
+	if f == nil {
+		if registry.HasAnyFilter(command, subcommand) {
+			fmt.Println("no filter: excluded by flags")
+		} else {
+			fmt.Println("no filter")
+		}
+		return 1
+	}
+
+	enabled := true
+	if cfg.Filters.Enable != nil {
+		if e, ok := cfg.Filters.Enable[f.Name]; ok && !e {
+			enabled = false
+		}
+	}
+	if !enabled {
+		fmt.Printf("filter disabled: %s\n", f.Name)
+		return 1
+	}
+
+	fmt.Printf("filter: %s\n", f.Name)
+	return 0
+}
+
 func printUsage() {
 	usage := `snip v%s — CLI Token Killer
 
@@ -295,6 +366,7 @@ Usage: snip [flags] <command> [args...]
 
 Commands:
   run             Run command through snip filter pipeline (use -- to separate)
+  check           Check if a command would be filtered (use -- to separate)
   <command>       Run command through snip filter pipeline (implicit)
   init            Install agent integration (default: claude-code)
   hook            Handle agent PreToolUse/shell hook
@@ -347,12 +419,28 @@ Examples:
 
 // unproxyableReason returns a human-readable reason if the command cannot be
 // proxied through an external process, or "" if it can.
+// Commands are grouped by the shell feature they affect; each group covers
+// bash, zsh, and fish builtins that would be a silent no-op in a subprocess.
 func unproxyableReason(command string) string {
 	switch command {
-	case "cd":
+	case "cd", "chdir", "pushd", "popd":
 		return "it must run in the parent shell to change directory"
 	case "source", ".":
 		return "it must run in the parent shell to modify the environment"
+	case "export", "unset", "alias", "unalias", "readonly", "declare", "typeset", "local", "shift", "read", "mapfile", "readarray", "let", "getopts":
+		return "it must run in the parent shell to modify the environment"
+	case "set", "shopt", "setopt", "unsetopt", "emulate":
+		return "it must run in the parent shell to set shell options"
+	case "eval":
+		return "it must run in the parent shell to evaluate in current context"
+	case "exec":
+		return "it must run in the parent shell to replace the current process"
+	case "exit", "logout", "return", "break", "continue":
+		return "it must run in the parent shell to control flow"
+	case "wait", "bg", "fg", "disown", "jobs", "suspend":
+		return "it must run in the parent shell to access the job table"
+	case "bindkey", "bind", "complete", "compopt", "compinit", "zstyle", "autoload", "zmodload", "enable", "disable", "abbr", "functions", "hash", "trap", "umask", "ulimit":
+		return "it must run in the parent shell to configure the shell"
 	}
 	return ""
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -51,7 +51,7 @@ func Run(args []string) int {
 	// Commands that cannot be proxied: they must run in the parent shell
 	// to have any effect. Running them in a subprocess is a silent no-op.
 	if reason := unproxyableReason(command); reason != "" {
-		fmt.Fprintf(os.Stderr, "snip: %s cannot be proxied (%s)\n", command, reason)
+		display.PrintError(fmt.Sprintf("%s cannot be proxied (%s)", command, reason))
 		return 1
 	}
 
@@ -187,10 +187,10 @@ func Run(args []string) int {
 			return 1
 		}
 		if r := unproxyableReason(targetCmd); r != "" {
-			fmt.Printf("shell builtin: %s\n", r)
+			display.PrintError(fmt.Sprintf("%s is a shell builtin (%s)", targetCmd, r))
 			return 1
 		}
-		return runCheck(targetCmd, targetArgs)
+		return runCheck(targetCmd, targetArgs, flags)
 
 	case "proxy":
 		// Direct passthrough without filtering
@@ -304,9 +304,12 @@ func runPipeline(command string, args []string, flags Flags) int {
 	return pipeline.Run(command, args)
 }
 
-func runCheck(command string, args []string) int {
+func runCheck(command string, args []string, flags Flags) int {
 	cfg, err := config.Load()
 	if err != nil {
+		if flags.Verbose > 0 {
+			fmt.Fprintf(os.Stderr, "snip: config error: %v, using defaults\n", err)
+		}
 		cfg = config.DefaultConfig()
 	}
 
@@ -417,7 +420,7 @@ func unproxyableReason(command string) string {
 	case "cd", "chdir", "pushd", "popd":
 		return "it must run in the parent shell to change directory"
 	case "source", ".":
-		return "it must run in the parent shell to modify the environment"
+		return "it must run in the parent shell to execute in the current context"
 	case "export", "unset", "alias", "unalias", "readonly", "declare", "typeset", "local", "shift", "read", "mapfile", "readarray", "let", "getopts":
 		return "it must run in the parent shell to modify the environment"
 	case "set", "shopt", "setopt", "unsetopt", "emulate":

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -169,58 +169,28 @@ func Run(args []string) int {
 		return runUntrust(cmdArgs)
 
 	case "run":
-		sepIdx := -1
-		for i, a := range cmdArgs {
-			if a == "--" {
-				sepIdx = i
-				break
-			}
-		}
-		if sepIdx < 0 {
-			display.PrintError("run requires -- separator: snip run -- <command> [args...]")
+		targetCmd, targetArgs, errMsg := parseSeparatorArgs(cmdArgs, "run")
+		if errMsg != "" {
+			display.PrintError(errMsg)
 			return 1
 		}
-		if sepIdx > 0 {
-			display.PrintError(fmt.Sprintf("run: unexpected arguments before -- (%s)", strings.Join(cmdArgs[:sepIdx], " ")))
+		if reason := unproxyableReason(targetCmd); reason != "" {
+			display.PrintError(fmt.Sprintf("%s cannot be proxied (%s)", targetCmd, reason))
 			return 1
 		}
-		runArgs := cmdArgs[1:]
-		if len(runArgs) == 0 {
-			display.PrintError("run requires a command after --")
-			return 1
-		}
-		runCmd := runArgs[0]
-		runCmdArgs := runArgs[1:]
-		if reason := unproxyableReason(runCmd); reason != "" {
-			display.PrintError(fmt.Sprintf("%s cannot be proxied (%s)", runCmd, reason))
-			return 1
-		}
-		return runPipeline(runCmd, runCmdArgs, flags)
+		return runPipeline(targetCmd, targetArgs, flags)
 
 	case "check":
-		sepIdx := -1
-		for i, a := range cmdArgs {
-			if a == "--" {
-				sepIdx = i
-				break
-			}
-		}
-		if sepIdx < 0 {
-			display.PrintError("check requires -- separator: snip check -- <command> [args...]")
+		targetCmd, targetArgs, errMsg := parseSeparatorArgs(cmdArgs, "check")
+		if errMsg != "" {
+			display.PrintError(errMsg)
 			return 1
 		}
-		checkArgs := cmdArgs[sepIdx+1:]
-		if len(checkArgs) == 0 {
-			display.PrintError("check requires a command after --")
-			return 1
-		}
-		checkCmd := checkArgs[0]
-		checkCmdArgs := checkArgs[1:]
-		if r := unproxyableReason(checkCmd); r != "" {
+		if r := unproxyableReason(targetCmd); r != "" {
 			fmt.Printf("shell builtin: %s\n", r)
 			return 1
 		}
-		return runCheck(checkCmd, checkCmdArgs, flags)
+		return runCheck(targetCmd, targetArgs)
 
 	case "proxy":
 		// Direct passthrough without filtering
@@ -234,6 +204,27 @@ func Run(args []string) int {
 
 	// Filter pipeline
 	return runPipeline(command, cmdArgs, flags)
+}
+
+func parseSeparatorArgs(args []string, cmdName string) (string, []string, string) {
+	sepIdx := -1
+	for i, a := range args {
+		if a == "--" {
+			sepIdx = i
+			break
+		}
+	}
+	if sepIdx < 0 {
+		return "", nil, fmt.Sprintf("%s requires -- separator: snip %s -- <command> [args...]", cmdName, cmdName)
+	}
+	if sepIdx > 0 {
+		return "", nil, fmt.Sprintf("%s: unexpected arguments before -- (%s)", cmdName, strings.Join(args[:sepIdx], " "))
+	}
+	after := args[sepIdx+1:]
+	if len(after) == 0 {
+		return "", nil, fmt.Sprintf("%s requires a command after --", cmdName)
+	}
+	return after[0], after[1:], ""
 }
 
 // runHook handles the "snip hook" subcommand for Claude Code PreToolUse.
@@ -313,7 +304,7 @@ func runPipeline(command string, args []string, flags Flags) int {
 	return pipeline.Run(command, args)
 }
 
-func runCheck(command string, args []string, flags Flags) int {
+func runCheck(command string, args []string) int {
 	cfg, err := config.Load()
 	if err != nil {
 		cfg = config.DefaultConfig()

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -182,5 +184,42 @@ func TestCheckShellBuiltinExit(t *testing.T) {
 	code := Run([]string{"snip", "check", "--", "exit"})
 	if code != 1 {
 		t.Errorf("Run(check -- exit) = %d, want 1", code)
+	}
+}
+
+func TestCheckFilterFound(t *testing.T) {
+	home := t.TempDir()
+	filterDir := filepath.Join(home, ".config", "snip", "filters")
+	if err := os.MkdirAll(filterDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	filterYAML := `name: "git-log"
+version: 1
+description: "Test filter"
+match:
+  command: "git"
+  subcommand: "log"
+  exclude_flags: ["--format", "--pretty", "--graph", "--oneline"]
+inject:
+  args: ["--pretty=format:%h %s", "--no-merges"]
+  defaults:
+    "-n": "10"
+  skip_if_present: ["--merges", "--format", "--pretty", "--oneline"]
+pipeline:
+  - action: "keep_lines"
+    pattern: "\\S"
+on_error: "passthrough"
+`
+	if err := os.WriteFile(filepath.Join(filterDir, "git-log.yaml"), []byte(filterYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", filepath.Join(home, ".config", "snip", "config.toml"))
+
+	code := Run([]string{"snip", "check", "--", "git", "log"})
+	if code != 0 {
+		t.Errorf("expected exit code 0, got %d", code)
 	}
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -9,6 +9,19 @@ import (
 	"testing"
 )
 
+// captureStderr captures stderr during fn execution and returns the captured output.
+func captureStderr(fn func()) string {
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	fn()
+	_ = w.Close()
+	os.Stderr = old
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	return buf.String()
+}
+
 func TestUnproxyableCommands(t *testing.T) {
 	tests := []struct {
 		command string
@@ -87,27 +100,6 @@ func TestUnproxyableCommands(t *testing.T) {
 	}
 }
 
-func TestRunRejectsCd(t *testing.T) {
-	old := os.Stderr
-	r, w, _ := os.Pipe()
-	os.Stderr = w
-	code := Run([]string{"snip", "cd", "/tmp"})
-	_ = w.Close()
-	os.Stderr = old
-	var buf bytes.Buffer
-	if _, err := buf.ReadFrom(r); err != nil {
-		t.Fatalf("ReadFrom: %v", err)
-	}
-
-	if code != 1 {
-		t.Errorf("Run(cd) = %d, want 1", code)
-	}
-	output := buf.String()
-	if !strings.Contains(output, "cd") {
-		t.Errorf("expected stderr to contain 'cd', got %q", output)
-	}
-}
-
 func TestRunSubcommandMissingSeparator(t *testing.T) {
 	code := Run([]string{"snip", "run", "git", "log"})
 	if code != 1 {
@@ -165,142 +157,6 @@ func TestCheckEmptyAfterSeparator(t *testing.T) {
 	code := Run([]string{"snip", "check", "--"})
 	if code != 1 {
 		t.Errorf("Run(check --) = %d, want 1", code)
-	}
-}
-
-func TestCheckShellBuiltin(t *testing.T) {
-	code := Run([]string{"snip", "check", "--", "cd", "/tmp"})
-	if code != 1 {
-		t.Errorf("Run(check -- cd) = %d, want 1", code)
-	}
-}
-
-func TestCheckShellBuiltinExport(t *testing.T) {
-	code := Run([]string{"snip", "check", "--", "export", "FOO=bar"})
-	if code != 1 {
-		t.Errorf("Run(check -- export) = %d, want 1", code)
-	}
-}
-
-func TestCheckShellBuiltinSet(t *testing.T) {
-	code := Run([]string{"snip", "check", "--", "set", "-e"})
-	if code != 1 {
-		t.Errorf("Run(check -- set) = %d, want 1", code)
-	}
-}
-
-func TestCheckShellBuiltinExit(t *testing.T) {
-	code := Run([]string{"snip", "check", "--", "exit"})
-	if code != 1 {
-		t.Errorf("Run(check -- exit) = %d, want 1", code)
-	}
-}
-
-func TestRunRejectsSource(t *testing.T) {
-	old := os.Stderr
-	r, w, _ := os.Pipe()
-	os.Stderr = w
-	code := Run([]string{"snip", "source", "script.sh"})
-	_ = w.Close()
-	os.Stderr = old
-var buf bytes.Buffer
-	if _, err := buf.ReadFrom(r); err != nil {
-		t.Fatalf("ReadFrom: %v", err)
-	}
-	if code != 1 {
-		t.Errorf("Run(source) = %d, want 1", code)
-	}
-	output := buf.String()
-	if !strings.Contains(output, "source") {
-		t.Errorf("expected stderr to contain 'source', got %q", output)
-	}
-	if !strings.Contains(output, "cannot be proxied") {
-		t.Errorf("expected stderr to contain 'cannot be proxied', got %q", output)
-	}
-}
-
-func TestRunRejectsDot(t *testing.T) {
-	old := os.Stderr
-	r, w, _ := os.Pipe()
-	os.Stderr = w
-	code := Run([]string{"snip", ".", "script.sh"})
-	_ = w.Close()
-	os.Stderr = old
-var buf bytes.Buffer
-	if _, err := buf.ReadFrom(r); err != nil {
-		t.Fatalf("ReadFrom: %v", err)
-	}
-	if code != 1 {
-		t.Errorf("Run(.) = %d, want 1", code)
-	}
-	output := buf.String()
-	if !strings.Contains(output, ".") {
-		t.Errorf("expected stderr to contain '.', got %q", output)
-	}
-	if !strings.Contains(output, "cannot be proxied") {
-		t.Errorf("expected stderr to contain 'cannot be proxied', got %q", output)
-	}
-}
-
-func TestRunSubcommandRejectsUnproxyableErrorMessage(t *testing.T) {
-	old := os.Stderr
-	r, w, _ := os.Pipe()
-	os.Stderr = w
-	code := Run([]string{"snip", "run", "--", "cd", "/tmp"})
-	_ = w.Close()
-	os.Stderr = old
-	var buf bytes.Buffer
-	if _, err := buf.ReadFrom(r); err != nil {
-		t.Fatalf("ReadFrom: %v", err)
-	}
-
-	if code != 1 {
-		t.Errorf("Run(run -- cd) = %d, want 1", code)
-	}
-	output := buf.String()
-	if !strings.Contains(output, "cd") {
-		t.Errorf("expected stderr to contain 'cd', got %q", output)
-	}
-	if !strings.Contains(output, "cannot be proxied") {
-		t.Errorf("expected stderr to contain 'cannot be proxied', got %q", output)
-	}
-}
-
-func TestRunGlobalUnproxyableErrorMessage(t *testing.T) {
-	old := os.Stderr
-	r, w, _ := os.Pipe()
-	os.Stderr = w
-	code := Run([]string{"snip", "cd", "/tmp"})
-	_ = w.Close()
-	os.Stderr = old
-	var buf bytes.Buffer
-	if _, err := buf.ReadFrom(r); err != nil {
-		t.Fatalf("ReadFrom: %v", err)
-	}
-
-	if code != 1 {
-		t.Errorf("Run(cd) = %d, want 1", code)
-	}
-	output := buf.String()
-	if !strings.Contains(output, "cd") {
-		t.Errorf("expected stderr to contain 'cd', got %q", output)
-	}
-	if !strings.Contains(output, "cannot be proxied") {
-		t.Errorf("expected stderr to contain 'cannot be proxied', got %q", output)
-	}
-}
-
-func TestCheckRejectsSource(t *testing.T) {
-	code := Run([]string{"snip", "check", "--", "source", "script.sh"})
-	if code != 1 {
-		t.Errorf("Run(check -- source) = %d, want 1", code)
-	}
-}
-
-func TestCheckRejectsDot(t *testing.T) {
-	code := Run([]string{"snip", "check", "--", ".", "script.sh"})
-	if code != 1 {
-		t.Errorf("Run(check -- .) = %d, want 1", code)
 	}
 }
 
@@ -390,78 +246,6 @@ on_error: "passthrough"
 	}
 }
 
-func TestCheckShellBuiltinOutputIncludesCommand(t *testing.T) {
-	old := os.Stderr
-	r, w, _ := os.Pipe()
-	os.Stderr = w
-	code := Run([]string{"snip", "check", "--", "cd", "/tmp"})
-	_ = w.Close()
-	os.Stderr = old
-	var buf bytes.Buffer
-	if _, err := buf.ReadFrom(r); err != nil {
-		t.Fatalf("ReadFrom: %v", err)
-	}
-
-	if code != 1 {
-		t.Errorf("expected exit code 1, got %d", code)
-	}
-	output := buf.String()
-	if !strings.Contains(output, "cd") {
-		t.Errorf("expected output to contain 'cd', got %q", output)
-	}
-	if !strings.HasPrefix(strings.TrimSpace(output), "snip: cd is") {
-		t.Errorf("expected output to start with 'snip: cd is', got %q", output)
-	}
-}
-
-func TestCheckShellBuiltinSourceOutput(t *testing.T) {
-	old := os.Stderr
-	r, w, _ := os.Pipe()
-	os.Stderr = w
-	code := Run([]string{"snip", "check", "--", "source", "script.sh"})
-	_ = w.Close()
-	os.Stderr = old
-	var buf bytes.Buffer
-	if _, err := buf.ReadFrom(r); err != nil {
-		t.Fatalf("ReadFrom: %v", err)
-	}
-
-	if code != 1 {
-		t.Errorf("expected exit code 1, got %d", code)
-	}
-	output := buf.String()
-	if !strings.Contains(output, "source") {
-		t.Errorf("expected output to contain 'source', got %q", output)
-	}
-	if !strings.Contains(output, "shell builtin") {
-		t.Errorf("expected output to contain 'shell builtin', got %q", output)
-	}
-}
-
-func TestCheckShellBuiltinDotOutput(t *testing.T) {
-	old := os.Stderr
-	r, w, _ := os.Pipe()
-	os.Stderr = w
-	code := Run([]string{"snip", "check", "--", ".", "script.sh"})
-	_ = w.Close()
-	os.Stderr = old
-	var buf bytes.Buffer
-	if _, err := buf.ReadFrom(r); err != nil {
-		t.Fatalf("ReadFrom: %v", err)
-	}
-
-	if code != 1 {
-		t.Errorf("expected exit code 1, got %d", code)
-	}
-	output := buf.String()
-	if !strings.Contains(output, ".") {
-		t.Errorf("expected output to contain '.', got %q", output)
-	}
-	if !strings.Contains(output, "shell builtin") {
-		t.Errorf("expected output to contain 'shell builtin', got %q", output)
-	}
-}
-
 func TestCheckFilterFoundOutput(t *testing.T) {
 	home := t.TempDir()
 	filterDir := filepath.Join(home, ".config", "snip", "filters")
@@ -514,12 +298,12 @@ on_error: "passthrough"
 
 func TestParseSeparatorArgs(t *testing.T) {
 	tests := []struct {
-		name      string
-		args      []string
-		cmdName   string
-		wantCmd   string
-		wantArgs  []string
-		wantErr   string
+		name     string
+		args     []string
+		cmdName  string
+		wantCmd  string
+		wantArgs []string
+		wantErr  string
 	}{
 		{
 			name:     "normal case",
@@ -781,59 +565,6 @@ func TestCheckBareCommandNoFilter(t *testing.T) {
 	}
 }
 
-func TestCheckUnproxyableEval(t *testing.T) {
-	old := os.Stderr
-	r, w, _ := os.Pipe()
-	os.Stderr = w
-	code := Run([]string{"snip", "check", "--", "eval", "echo", "hi"})
-	_ = w.Close()
-	os.Stderr = old
-	var buf bytes.Buffer
-	if _, err := buf.ReadFrom(r); err != nil {
-		t.Fatalf("ReadFrom: %v", err)
-	}
-
-	if code != 1 {
-		t.Errorf("expected exit code 1, got %d", code)
-	}
-	if !strings.Contains(buf.String(), "eval") {
-		t.Errorf("expected stderr to contain 'eval', got %q", buf.String())
-	}
-	if !strings.Contains(buf.String(), "shell builtin") {
-		t.Errorf("expected stderr to contain 'shell builtin', got %q", buf.String())
-	}
-}
-
-func TestCheckUnproxyableWait(t *testing.T) {
-	code := Run([]string{"snip", "check", "--", "wait"})
-	if code != 1 {
-		t.Errorf("expected exit code 1, got %d", code)
-	}
-}
-
-func TestRunUnproxyableExec(t *testing.T) {
-	old := os.Stderr
-	r, w, _ := os.Pipe()
-	os.Stderr = w
-	code := Run([]string{"snip", "run", "--", "exec", "ls"})
-	_ = w.Close()
-	os.Stderr = old
-	var buf bytes.Buffer
-	if _, err := buf.ReadFrom(r); err != nil {
-		t.Fatalf("ReadFrom: %v", err)
-	}
-
-	if code != 1 {
-		t.Errorf("expected exit code 1, got %d", code)
-	}
-	if !strings.Contains(buf.String(), "exec") {
-		t.Errorf("expected stderr to contain 'exec', got %q", buf.String())
-	}
-	if !strings.Contains(buf.String(), "cannot be proxied") {
-		t.Errorf("expected stderr to contain 'cannot be proxied', got %q", buf.String())
-	}
-}
-
 func TestCheckFilterExplicitlyEnabled(t *testing.T) {
 	home := t.TempDir()
 	filterDir := filepath.Join(home, ".config", "snip", "filters")
@@ -946,34 +677,45 @@ git-log = false
 
 func TestCheckAndRunUnproxyableFormatConsistent(t *testing.T) {
 	tests := []struct {
-		name    string
-		args    []string
-		wantSub string
+		name string
+		args []string
 	}{
-		{"check cd", []string{"snip", "check", "--", "cd", "/tmp"}, "is a shell builtin"},
-		{"run cd", []string{"snip", "run", "--", "cd", "/tmp"}, "cannot be proxied"},
-		{"global cd", []string{"snip", "cd", "/tmp"}, "cannot be proxied"},
+		{"check cd", []string{"snip", "check", "--", "cd", "/tmp"}},
+		{"run cd", []string{"snip", "run", "--", "cd", "/tmp"}},
+		{"global cd", []string{"snip", "cd", "/tmp"}},
+		{"check source", []string{"snip", "check", "--", "source", "script.sh"}},
+		{"run source", []string{"snip", "run", "--", "source", "script.sh"}},
+		{"global source", []string{"snip", "source", "script.sh"}},
+		{"check dot", []string{"snip", "check", "--", ".", "script.sh"}},
+		{"run dot", []string{"snip", "run", "--", ".", "script.sh"}},
+		{"global dot", []string{"snip", ".", "script.sh"}},
+		{"check export", []string{"snip", "check", "--", "export", "FOO=bar"}},
+		{"run export", []string{"snip", "run", "--", "export", "FOO=bar"}},
+		{"global export", []string{"snip", "export", "FOO=bar"}},
+		{"check eval", []string{"snip", "check", "--", "eval", "echo hi"}},
+		{"run eval", []string{"snip", "run", "--", "eval", "echo hi"}},
+		{"global eval", []string{"snip", "eval", "echo hi"}},
+		{"check set", []string{"snip", "check", "--", "set", "-e"}},
+		{"run set", []string{"snip", "run", "--", "set", "-e"}},
+		{"global set", []string{"snip", "set", "-e"}},
+		{"check exit", []string{"snip", "check", "--", "exit"}},
+		{"run exit", []string{"snip", "run", "--", "exit"}},
+		{"global exit", []string{"snip", "exit"}},
+		{"check exec", []string{"snip", "check", "--", "exec", "ls"}},
+		{"run exec", []string{"snip", "run", "--", "exec", "ls"}},
+		{"global exec", []string{"snip", "exec", "ls"}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			old := os.Stderr
-			r, w, _ := os.Pipe()
-			os.Stderr = w
-			code := Run(tt.args)
-			_ = w.Close()
-			os.Stderr = old
-			var buf bytes.Buffer
-			if _, err := buf.ReadFrom(r); err != nil {
-		t.Fatalf("ReadFrom: %v", err)
-	}
-
-			if code != 1 {
-				t.Errorf("expected exit code 1, got %d", code)
-			}
-			output := buf.String()
-			if !strings.Contains(output, tt.wantSub) {
-				t.Errorf("expected stderr to contain %q, got %q", tt.wantSub, output)
+			output := captureStderr(func() {
+				code := Run(tt.args)
+				if code != 1 {
+					t.Errorf("expected exit code 1, got %d", code)
+				}
+			})
+			if !strings.Contains(output, "cannot be proxied") {
+				t.Errorf("expected stderr to contain 'cannot be proxied', got %q", output)
 			}
 		})
 	}
@@ -1136,119 +878,9 @@ func TestCheckSubcommandPreservesDoubleDash(t *testing.T) {
 	}
 }
 
-func TestRunSubcommandUnproxyableErrorMessageFormat(t *testing.T) {
-	tests := []struct {
-		name    string
-		args    []string
-		wantMsg string
-	}{
-		{"source", []string{"snip", "run", "--", "source"}, "cannot be proxied"},
-		{"dot", []string{"snip", "run", "--", "."}, "cannot be proxied"},
-		{"export", []string{"snip", "run", "--", "export"}, "cannot be proxied"},
-		{"eval", []string{"snip", "run", "--", "eval"}, "cannot be proxied"},
-		{"set", []string{"snip", "run", "--", "set"}, "cannot be proxied"},
-		{"exit", []string{"snip", "run", "--", "exit"}, "cannot be proxied"},
-		{"exec", []string{"snip", "run", "--", "exec"}, "cannot be proxied"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			old := os.Stderr
-			r, w, _ := os.Pipe()
-			os.Stderr = w
-			code := Run(tt.args)
-			_ = w.Close()
-			os.Stderr = old
-			var buf bytes.Buffer
-			if _, err := buf.ReadFrom(r); err != nil {
-		t.Fatalf("ReadFrom: %v", err)
-	}
-
-			if code != 1 {
-				t.Errorf("expected exit code 1, got %d", code)
-			}
-			output := buf.String()
-			if !strings.Contains(output, tt.wantMsg) {
-				t.Errorf("expected stderr to contain %q, got %q", tt.wantMsg, output)
-			}
-		})
+func TestRunCommandHelpAfterSeparator(t *testing.T) {
+	code := Run([]string{"snip", "run", "--", "git", "--help"})
+	if code != 0 {
+		t.Errorf("Run(run -- git --help) = %d, want 0", code)
 	}
 }
-
-func TestCheckSubcommandUnproxyableErrorMessageFormat(t *testing.T) {
-	tests := []struct {
-		name    string
-		args    []string
-		wantMsg string
-	}{
-		{"source", []string{"snip", "check", "--", "source"}, "is a shell builtin"},
-		{"dot", []string{"snip", "check", "--", "."}, "is a shell builtin"},
-		{"export", []string{"snip", "check", "--", "export"}, "is a shell builtin"},
-		{"eval", []string{"snip", "check", "--", "eval"}, "is a shell builtin"},
-		{"set", []string{"snip", "check", "--", "set"}, "is a shell builtin"},
-		{"exit", []string{"snip", "check", "--", "exit"}, "is a shell builtin"},
-		{"exec", []string{"snip", "check", "--", "exec"}, "is a shell builtin"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			old := os.Stderr
-			r, w, _ := os.Pipe()
-			os.Stderr = w
-			code := Run(tt.args)
-			_ = w.Close()
-			os.Stderr = old
-			var buf bytes.Buffer
-			if _, err := buf.ReadFrom(r); err != nil {
-		t.Fatalf("ReadFrom: %v", err)
-	}
-
-			if code != 1 {
-				t.Errorf("expected exit code 1, got %d", code)
-			}
-			output := buf.String()
-			if !strings.Contains(output, tt.wantMsg) {
-				t.Errorf("expected stderr to contain %q, got %q", tt.wantMsg, output)
-			}
-		})
-	}
-}
-
-func TestGlobalUnproxyableErrorMessageFormat(t *testing.T) {
-	tests := []struct {
-		name    string
-		args    []string
-		wantMsg string
-	}{
-		{"cd", []string{"snip", "cd"}, "cannot be proxied"},
-		{"source", []string{"snip", "source"}, "cannot be proxied"},
-		{"eval", []string{"snip", "eval"}, "cannot be proxied"},
-		{"exec", []string{"snip", "exec"}, "cannot be proxied"},
-		{"set", []string{"snip", "set"}, "cannot be proxied"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			old := os.Stderr
-			r, w, _ := os.Pipe()
-			os.Stderr = w
-			code := Run(tt.args)
-			_ = w.Close()
-			os.Stderr = old
-			var buf bytes.Buffer
-			if _, err := buf.ReadFrom(r); err != nil {
-		t.Fatalf("ReadFrom: %v", err)
-	}
-
-			if code != 1 {
-				t.Errorf("expected exit code 1, got %d", code)
-			}
-			output := buf.String()
-			if !strings.Contains(output, tt.wantMsg) {
-				t.Errorf("expected stderr to contain %q, got %q", tt.wantMsg, output)
-			}
-		})
-	}
-}
-
-

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,9 +1,11 @@
 package cli
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -86,9 +88,23 @@ func TestUnproxyableCommands(t *testing.T) {
 }
 
 func TestRunRejectsCd(t *testing.T) {
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
 	code := Run([]string{"snip", "cd", "/tmp"})
+	_ = w.Close()
+	os.Stderr = old
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+
 	if code != 1 {
 		t.Errorf("Run(cd) = %d, want 1", code)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "cd") {
+		t.Errorf("expected stderr to contain 'cd', got %q", output)
 	}
 }
 
@@ -124,13 +140,6 @@ func TestRunGlobalHelpBeforeSeparator(t *testing.T) {
 	code := Run([]string{"snip", "run", "--help", "--", "foo", "bar"})
 	if code != 0 {
 		t.Errorf("Run(run --help -- foo bar) = %d, want 0", code)
-	}
-}
-
-func TestRunCommandHelpAfterSeparator(t *testing.T) {
-	code := Run([]string{"snip", "run", "--", "git", "--help"})
-	if code != 0 {
-		t.Errorf("Run(run -- git --help) = %d, want 0", code)
 	}
 }
 
@@ -187,7 +196,151 @@ func TestCheckShellBuiltinExit(t *testing.T) {
 	}
 }
 
-func TestCheckFilterFound(t *testing.T) {
+func TestRunRejectsSource(t *testing.T) {
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	code := Run([]string{"snip", "source", "script.sh"})
+	_ = w.Close()
+	os.Stderr = old
+var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+	if code != 1 {
+		t.Errorf("Run(source) = %d, want 1", code)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "source") {
+		t.Errorf("expected stderr to contain 'source', got %q", output)
+	}
+	if !strings.Contains(output, "cannot be proxied") {
+		t.Errorf("expected stderr to contain 'cannot be proxied', got %q", output)
+	}
+}
+
+func TestRunRejectsDot(t *testing.T) {
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	code := Run([]string{"snip", ".", "script.sh"})
+	_ = w.Close()
+	os.Stderr = old
+var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+	if code != 1 {
+		t.Errorf("Run(.) = %d, want 1", code)
+	}
+	output := buf.String()
+	if !strings.Contains(output, ".") {
+		t.Errorf("expected stderr to contain '.', got %q", output)
+	}
+	if !strings.Contains(output, "cannot be proxied") {
+		t.Errorf("expected stderr to contain 'cannot be proxied', got %q", output)
+	}
+}
+
+func TestRunSubcommandRejectsUnproxyableErrorMessage(t *testing.T) {
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	code := Run([]string{"snip", "run", "--", "cd", "/tmp"})
+	_ = w.Close()
+	os.Stderr = old
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+
+	if code != 1 {
+		t.Errorf("Run(run -- cd) = %d, want 1", code)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "cd") {
+		t.Errorf("expected stderr to contain 'cd', got %q", output)
+	}
+	if !strings.Contains(output, "cannot be proxied") {
+		t.Errorf("expected stderr to contain 'cannot be proxied', got %q", output)
+	}
+}
+
+func TestRunGlobalUnproxyableErrorMessage(t *testing.T) {
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	code := Run([]string{"snip", "cd", "/tmp"})
+	_ = w.Close()
+	os.Stderr = old
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+
+	if code != 1 {
+		t.Errorf("Run(cd) = %d, want 1", code)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "cd") {
+		t.Errorf("expected stderr to contain 'cd', got %q", output)
+	}
+	if !strings.Contains(output, "cannot be proxied") {
+		t.Errorf("expected stderr to contain 'cannot be proxied', got %q", output)
+	}
+}
+
+func TestCheckRejectsSource(t *testing.T) {
+	code := Run([]string{"snip", "check", "--", "source", "script.sh"})
+	if code != 1 {
+		t.Errorf("Run(check -- source) = %d, want 1", code)
+	}
+}
+
+func TestCheckRejectsDot(t *testing.T) {
+	code := Run([]string{"snip", "check", "--", ".", "script.sh"})
+	if code != 1 {
+		t.Errorf("Run(check -- .) = %d, want 1", code)
+	}
+}
+
+func TestCheckRejectsArgsBeforeSeparator(t *testing.T) {
+	code := Run([]string{"snip", "check", "foo", "--", "bar"})
+	if code != 1 {
+		t.Errorf("expected exit code 1, got %d", code)
+	}
+}
+
+func TestCheckNoFilter(t *testing.T) {
+	home := t.TempDir()
+	filterDir := filepath.Join(home, ".config", "snip", "filters")
+	if err := os.MkdirAll(filterDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", filepath.Join(home, ".config", "snip", "config.toml"))
+
+	var buf bytes.Buffer
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	code := Run([]string{"snip", "check", "--", "ls", "-la"})
+	_ = w.Close()
+	os.Stdout = old
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+
+	if code != 1 {
+		t.Errorf("expected exit code 1, got %d", code)
+	}
+	if !strings.Contains(buf.String(), "no filter") {
+		t.Errorf("expected output to contain 'no filter', got %q", buf.String())
+	}
+}
+
+func TestCheckExcludedByFlags(t *testing.T) {
 	home := t.TempDir()
 	filterDir := filepath.Join(home, ".config", "snip", "filters")
 	if err := os.MkdirAll(filterDir, 0o755); err != nil {
@@ -218,8 +371,884 @@ on_error: "passthrough"
 	t.Setenv("HOME", home)
 	t.Setenv("SNIP_CONFIG", filepath.Join(home, ".config", "snip", "config.toml"))
 
+	var buf bytes.Buffer
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	code := Run([]string{"snip", "check", "--", "git", "log", "--pretty"})
+	_ = w.Close()
+	os.Stdout = old
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+
+	if code != 1 {
+		t.Errorf("expected exit code 1, got %d", code)
+	}
+	if !strings.Contains(buf.String(), "excluded by flags") {
+		t.Errorf("expected output to contain 'excluded by flags', got %q", buf.String())
+	}
+}
+
+func TestCheckShellBuiltinOutputIncludesCommand(t *testing.T) {
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	code := Run([]string{"snip", "check", "--", "cd", "/tmp"})
+	_ = w.Close()
+	os.Stderr = old
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+
+	if code != 1 {
+		t.Errorf("expected exit code 1, got %d", code)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "cd") {
+		t.Errorf("expected output to contain 'cd', got %q", output)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(output), "snip: cd is") {
+		t.Errorf("expected output to start with 'snip: cd is', got %q", output)
+	}
+}
+
+func TestCheckShellBuiltinSourceOutput(t *testing.T) {
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	code := Run([]string{"snip", "check", "--", "source", "script.sh"})
+	_ = w.Close()
+	os.Stderr = old
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+
+	if code != 1 {
+		t.Errorf("expected exit code 1, got %d", code)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "source") {
+		t.Errorf("expected output to contain 'source', got %q", output)
+	}
+	if !strings.Contains(output, "shell builtin") {
+		t.Errorf("expected output to contain 'shell builtin', got %q", output)
+	}
+}
+
+func TestCheckShellBuiltinDotOutput(t *testing.T) {
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	code := Run([]string{"snip", "check", "--", ".", "script.sh"})
+	_ = w.Close()
+	os.Stderr = old
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+
+	if code != 1 {
+		t.Errorf("expected exit code 1, got %d", code)
+	}
+	output := buf.String()
+	if !strings.Contains(output, ".") {
+		t.Errorf("expected output to contain '.', got %q", output)
+	}
+	if !strings.Contains(output, "shell builtin") {
+		t.Errorf("expected output to contain 'shell builtin', got %q", output)
+	}
+}
+
+func TestCheckFilterFoundOutput(t *testing.T) {
+	home := t.TempDir()
+	filterDir := filepath.Join(home, ".config", "snip", "filters")
+	if err := os.MkdirAll(filterDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	filterYAML := `name: "git-log"
+version: 1
+description: "Test filter"
+match:
+  command: "git"
+  subcommand: "log"
+  exclude_flags: ["--format", "--pretty", "--graph", "--oneline"]
+inject:
+  args: ["--pretty=format:%h %s", "--no-merges"]
+  defaults:
+    "-n": "10"
+  skip_if_present: ["--merges", "--format", "--pretty", "--oneline"]
+pipeline:
+  - action: "keep_lines"
+    pattern: "\\S"
+on_error: "passthrough"
+`
+	if err := os.WriteFile(filepath.Join(filterDir, "git-log.yaml"), []byte(filterYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", filepath.Join(home, ".config", "snip", "config.toml"))
+
+	var buf bytes.Buffer
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
 	code := Run([]string{"snip", "check", "--", "git", "log"})
+	_ = w.Close()
+	os.Stdout = old
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+
 	if code != 0 {
 		t.Errorf("expected exit code 0, got %d", code)
 	}
+	if !strings.Contains(buf.String(), "filter: git-log") {
+		t.Errorf("expected output to contain 'filter: git-log', got %q", buf.String())
+	}
 }
+
+func TestParseSeparatorArgs(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		cmdName   string
+		wantCmd   string
+		wantArgs  []string
+		wantErr   string
+	}{
+		{
+			name:     "normal case",
+			args:     []string{"--", "git", "log", "-10"},
+			cmdName:  "run",
+			wantCmd:  "git",
+			wantArgs: []string{"log", "-10"},
+			wantErr:  "",
+		},
+		{
+			name:     "single command after separator",
+			args:     []string{"--", "docker"},
+			cmdName:  "run",
+			wantCmd:  "docker",
+			wantArgs: []string{},
+			wantErr:  "",
+		},
+		{
+			name:     "no separator",
+			args:     []string{"git", "log"},
+			cmdName:  "run",
+			wantCmd:  "",
+			wantArgs: nil,
+			wantErr:  "run requires -- separator: snip run -- <command> [args...]",
+		},
+		{
+			name:     "empty after separator",
+			args:     []string{"--"},
+			cmdName:  "run",
+			wantCmd:  "",
+			wantArgs: nil,
+			wantErr:  "run requires a command after --",
+		},
+		{
+			name:     "args before separator",
+			args:     []string{"foo", "--", "bar"},
+			cmdName:  "run",
+			wantCmd:  "",
+			wantArgs: nil,
+			wantErr:  "run: unexpected arguments before -- (foo)",
+		},
+		{
+			name:     "command with embedded double dash",
+			args:     []string{"--", "git", "--", "log"},
+			cmdName:  "run",
+			wantCmd:  "git",
+			wantArgs: []string{"--", "log"},
+			wantErr:  "",
+		},
+		{
+			name:     "check command name in error",
+			args:     []string{"git"},
+			cmdName:  "check",
+			wantCmd:  "",
+			wantArgs: nil,
+			wantErr:  "check requires -- separator: snip check -- <command> [args...]",
+		},
+		{
+			name:     "check empty after separator",
+			args:     []string{"--"},
+			cmdName:  "check",
+			wantCmd:  "",
+			wantArgs: nil,
+			wantErr:  "check requires a command after --",
+		},
+		{
+			name:     "multiple args before separator",
+			args:     []string{"-v", "extra", "--", "git", "log"},
+			cmdName:  "run",
+			wantCmd:  "",
+			wantArgs: nil,
+			wantErr:  "run: unexpected arguments before -- (-v extra)",
+		},
+		{
+			name:     "separator is second arg",
+			args:     []string{"-v", "--", "git", "log"},
+			cmdName:  "run",
+			wantCmd:  "",
+			wantArgs: nil,
+			wantErr:  "run: unexpected arguments before -- (-v)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, args, errMsg := parseSeparatorArgs(tt.args, tt.cmdName)
+			if cmd != tt.wantCmd {
+				t.Errorf("cmd = %q, want %q", cmd, tt.wantCmd)
+			}
+			if !reflect.DeepEqual(args, tt.wantArgs) {
+				t.Errorf("args = %v, want %v", args, tt.wantArgs)
+			}
+			if errMsg != tt.wantErr {
+				t.Errorf("errMsg = %q, want %q", errMsg, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckWithCommandOnlyFilter(t *testing.T) {
+	home := t.TempDir()
+	filterDir := filepath.Join(home, ".config", "snip", "filters")
+	if err := os.MkdirAll(filterDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	filterYAML := `name: "docker-all"
+version: 1
+description: "Docker filter"
+match:
+  command: "docker"
+pipeline:
+  - action: "keep_lines"
+    pattern: "\\S"
+on_error: "passthrough"
+`
+	if err := os.WriteFile(filepath.Join(filterDir, "docker-all.yaml"), []byte(filterYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", filepath.Join(home, ".config", "snip", "config.toml"))
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	code := Run([]string{"snip", "check", "--", "docker", "build", "-t", "app", "."})
+	_ = w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+
+	if code != 0 {
+		t.Errorf("expected exit code 0, got %d", code)
+	}
+	if !strings.Contains(buf.String(), "filter: docker-all") {
+		t.Errorf("expected output to contain 'filter: docker-all', got %q", buf.String())
+	}
+}
+
+func TestCheckWithRequireFlagsMatches(t *testing.T) {
+	home := t.TempDir()
+	filterDir := filepath.Join(home, ".config", "snip", "filters")
+	if err := os.MkdirAll(filterDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	filterYAML := `name: "go-test-json"
+version: 1
+description: "Go test JSON filter"
+match:
+  command: "go"
+  subcommand: "test"
+  require_flags: ["-json"]
+pipeline:
+  - action: "keep_lines"
+    pattern: "\\S"
+on_error: "passthrough"
+`
+	if err := os.WriteFile(filepath.Join(filterDir, "go-test-json.yaml"), []byte(filterYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", filepath.Join(home, ".config", "snip", "config.toml"))
+
+	var buf bytes.Buffer
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	code := Run([]string{"snip", "check", "--", "go", "test", "-json"})
+	_ = w.Close()
+	os.Stdout = old
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+
+	if code != 0 {
+		t.Errorf("expected exit code 0, got %d", code)
+	}
+	if !strings.Contains(buf.String(), "filter: go-test-json") {
+		t.Errorf("expected output to contain 'filter: go-test-json', got %q", buf.String())
+	}
+}
+
+func TestCheckWithRequireFlagsExcluded(t *testing.T) {
+	home := t.TempDir()
+	filterDir := filepath.Join(home, ".config", "snip", "filters")
+	if err := os.MkdirAll(filterDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	filterYAML := `name: "go-test-json"
+version: 1
+description: "Go test JSON filter"
+match:
+  command: "go"
+  subcommand: "test"
+  require_flags: ["-json"]
+pipeline:
+  - action: "keep_lines"
+    pattern: "\\S"
+on_error: "passthrough"
+`
+	if err := os.WriteFile(filepath.Join(filterDir, "go-test-json.yaml"), []byte(filterYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", filepath.Join(home, ".config", "snip", "config.toml"))
+
+	var buf bytes.Buffer
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	code := Run([]string{"snip", "check", "--", "go", "test", "-v"})
+	_ = w.Close()
+	os.Stdout = old
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+
+	if code != 1 {
+		t.Errorf("expected exit code 1, got %d", code)
+	}
+	if !strings.Contains(buf.String(), "no filter: excluded by flags") {
+		t.Errorf("expected output to contain 'no filter: excluded by flags', got %q", buf.String())
+	}
+}
+
+func TestCheckBareCommandNoFilter(t *testing.T) {
+	home := t.TempDir()
+	filterDir := filepath.Join(home, ".config", "snip", "filters")
+	if err := os.MkdirAll(filterDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", filepath.Join(home, ".config", "snip", "config.toml"))
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	code := Run([]string{"snip", "check", "--", "git"})
+	_ = w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+
+	if code != 1 {
+		t.Errorf("expected exit code 1, got %d", code)
+	}
+	if !strings.Contains(buf.String(), "no filter") {
+		t.Errorf("expected output to contain 'no filter', got %q", buf.String())
+	}
+}
+
+func TestCheckUnproxyableEval(t *testing.T) {
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	code := Run([]string{"snip", "check", "--", "eval", "echo", "hi"})
+	_ = w.Close()
+	os.Stderr = old
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+
+	if code != 1 {
+		t.Errorf("expected exit code 1, got %d", code)
+	}
+	if !strings.Contains(buf.String(), "eval") {
+		t.Errorf("expected stderr to contain 'eval', got %q", buf.String())
+	}
+	if !strings.Contains(buf.String(), "shell builtin") {
+		t.Errorf("expected stderr to contain 'shell builtin', got %q", buf.String())
+	}
+}
+
+func TestCheckUnproxyableWait(t *testing.T) {
+	code := Run([]string{"snip", "check", "--", "wait"})
+	if code != 1 {
+		t.Errorf("expected exit code 1, got %d", code)
+	}
+}
+
+func TestRunUnproxyableExec(t *testing.T) {
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	code := Run([]string{"snip", "run", "--", "exec", "ls"})
+	_ = w.Close()
+	os.Stderr = old
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+
+	if code != 1 {
+		t.Errorf("expected exit code 1, got %d", code)
+	}
+	if !strings.Contains(buf.String(), "exec") {
+		t.Errorf("expected stderr to contain 'exec', got %q", buf.String())
+	}
+	if !strings.Contains(buf.String(), "cannot be proxied") {
+		t.Errorf("expected stderr to contain 'cannot be proxied', got %q", buf.String())
+	}
+}
+
+func TestCheckFilterExplicitlyEnabled(t *testing.T) {
+	home := t.TempDir()
+	filterDir := filepath.Join(home, ".config", "snip", "filters")
+	if err := os.MkdirAll(filterDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	filterYAML := `name: "git-log"
+version: 1
+description: "Test filter"
+match:
+  command: "git"
+  subcommand: "log"
+pipeline:
+  - action: "keep_lines"
+    pattern: "\\S"
+on_error: "passthrough"
+`
+	if err := os.WriteFile(filepath.Join(filterDir, "git-log.yaml"), []byte(filterYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	configContent := `[filters]
+[filters.enable]
+git-log = true
+`
+	if err := os.WriteFile(filepath.Join(home, ".config", "snip", "config.toml"), []byte(configContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", filepath.Join(home, ".config", "snip", "config.toml"))
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	code := Run([]string{"snip", "check", "--", "git", "log"})
+	_ = w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+
+	if code != 0 {
+		t.Errorf("expected exit code 0, got %d", code)
+	}
+	if !strings.Contains(buf.String(), "filter: git-log") {
+		t.Errorf("expected output to contain 'filter: git-log', got %q", buf.String())
+	}
+}
+
+func TestCheckFilterDisabled(t *testing.T) {
+	home := t.TempDir()
+	filterDir := filepath.Join(home, ".config", "snip", "filters")
+	if err := os.MkdirAll(filterDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	filterYAML := `name: "git-log"
+version: 1
+description: "Test filter"
+match:
+  command: "git"
+  subcommand: "log"
+  exclude_flags: ["--format", "--pretty", "--graph", "--oneline"]
+inject:
+  args: ["--pretty=format:%h %s", "--no-merges"]
+  defaults:
+    "-n": "10"
+  skip_if_present: ["--merges", "--format", "--pretty", "--oneline"]
+pipeline:
+  - action: "keep_lines"
+    pattern: "\\S"
+on_error: "passthrough"
+`
+	if err := os.WriteFile(filepath.Join(filterDir, "git-log.yaml"), []byte(filterYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	configContent := `[filters]
+[filters.enable]
+git-log = false
+`
+	if err := os.WriteFile(filepath.Join(home, ".config", "snip", "config.toml"), []byte(configContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", filepath.Join(home, ".config", "snip", "config.toml"))
+
+	var buf bytes.Buffer
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	code := Run([]string{"snip", "check", "--", "git", "log"})
+	_ = w.Close()
+	os.Stdout = old
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+
+	if code != 1 {
+		t.Errorf("expected exit code 1, got %d", code)
+	}
+	if !strings.Contains(buf.String(), "filter disabled: git-log") {
+		t.Errorf("expected output to contain 'filter disabled: git-log', got %q", buf.String())
+	}
+}
+
+func TestCheckAndRunUnproxyableFormatConsistent(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantSub string
+	}{
+		{"check cd", []string{"snip", "check", "--", "cd", "/tmp"}, "is a shell builtin"},
+		{"run cd", []string{"snip", "run", "--", "cd", "/tmp"}, "cannot be proxied"},
+		{"global cd", []string{"snip", "cd", "/tmp"}, "cannot be proxied"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			old := os.Stderr
+			r, w, _ := os.Pipe()
+			os.Stderr = w
+			code := Run(tt.args)
+			_ = w.Close()
+			os.Stderr = old
+			var buf bytes.Buffer
+			if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+
+			if code != 1 {
+				t.Errorf("expected exit code 1, got %d", code)
+			}
+			output := buf.String()
+			if !strings.Contains(output, tt.wantSub) {
+				t.Errorf("expected stderr to contain %q, got %q", tt.wantSub, output)
+			}
+		})
+	}
+}
+
+func TestRunSubcommandRejectsArgsBeforeSeparatorErrorMessage(t *testing.T) {
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	code := Run([]string{"snip", "run", "-v", "--", "git", "log"})
+	_ = w.Close()
+	os.Stderr = old
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+
+	if code != 1 {
+		t.Errorf("expected exit code 1, got %d", code)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "unexpected arguments before --") {
+		t.Errorf("expected stderr to contain 'unexpected arguments before --', got %q", output)
+	}
+}
+
+func TestCheckSubcommandRejectsArgsBeforeSeparatorErrorMessage(t *testing.T) {
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	code := Run([]string{"snip", "check", "-v", "--", "git", "log"})
+	_ = w.Close()
+	os.Stderr = old
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+
+	if code != 1 {
+		t.Errorf("expected exit code 1, got %d", code)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "unexpected arguments before --") {
+		t.Errorf("expected stderr to contain 'unexpected arguments before --', got %q", output)
+	}
+}
+
+func TestRunSubcommandNoArgs(t *testing.T) {
+	code := Run([]string{"snip", "run"})
+	if code != 1 {
+		t.Errorf("Run(run with no args) = %d, want 1", code)
+	}
+}
+
+func TestCheckSubcommandNoArgs(t *testing.T) {
+	code := Run([]string{"snip", "check"})
+	if code != 1 {
+		t.Errorf("Run(check with no args) = %d, want 1", code)
+	}
+}
+
+func TestParseFlagsHelpNotConsumedAfterSeparator(t *testing.T) {
+	flags, remaining := ParseFlags([]string{"run", "--", "git", "--help"})
+	if flags.Help {
+		t.Errorf("flags.Help = true, want false (--help after -- should be a command arg)")
+	}
+	wantRemaining := []string{"run", "--", "git", "--help"}
+	if !reflect.DeepEqual(remaining, wantRemaining) {
+		t.Errorf("remaining = %v, want %v", remaining, wantRemaining)
+	}
+}
+
+func TestParseFlagsVersionNotConsumedAfterSeparator(t *testing.T) {
+	flags, remaining := ParseFlags([]string{"run", "--", "git", "--version"})
+	if flags.Version {
+		t.Errorf("flags.Version = true, want false (--version after -- should be a command arg)")
+	}
+	wantRemaining := []string{"run", "--", "git", "--version"}
+	if !reflect.DeepEqual(remaining, wantRemaining) {
+		t.Errorf("remaining = %v, want %v", remaining, wantRemaining)
+	}
+}
+
+func TestParseFlagsHelpConsumedBeforeSeparatorForRun(t *testing.T) {
+	flags, remaining := ParseFlags([]string{"run", "--help", "--", "git", "log"})
+	if !flags.Help {
+		t.Errorf("flags.Help = false, want true (--help before -- should be snip flag)")
+	}
+	wantRemaining := []string{"run", "git", "log"}
+	if !reflect.DeepEqual(remaining, wantRemaining) {
+		t.Errorf("remaining = %v, want %v", remaining, wantRemaining)
+	}
+}
+
+func TestParseFlagsVersionConsumedBeforeSeparatorForRun(t *testing.T) {
+	flags, remaining := ParseFlags([]string{"run", "--version", "--", "git", "log"})
+	if !flags.Version {
+		t.Errorf("flags.Version = false, want true (--version before -- should be snip flag)")
+	}
+	wantRemaining := []string{"run", "git", "log"}
+	if !reflect.DeepEqual(remaining, wantRemaining) {
+		t.Errorf("remaining = %v, want %v", remaining, wantRemaining)
+	}
+}
+
+func TestParseFlagsHelpConsumedBeforeSeparatorForCheck(t *testing.T) {
+	flags, remaining := ParseFlags([]string{"check", "--help", "--", "git", "log"})
+	if !flags.Help {
+		t.Errorf("flags.Help = false, want true")
+	}
+	wantRemaining := []string{"check", "git", "log"}
+	if !reflect.DeepEqual(remaining, wantRemaining) {
+		t.Errorf("remaining = %v, want %v", remaining, wantRemaining)
+	}
+}
+
+func TestParseFlagsHelpNotConsumedAfterSeparatorForCheck(t *testing.T) {
+	flags, remaining := ParseFlags([]string{"check", "--", "git", "--help"})
+	if flags.Help {
+		t.Errorf("flags.Help = true, want false (--help after -- should be a command arg)")
+	}
+	wantRemaining := []string{"check", "--", "git", "--help"}
+	if !reflect.DeepEqual(remaining, wantRemaining) {
+		t.Errorf("remaining = %v, want %v", remaining, wantRemaining)
+	}
+}
+
+func TestParseSeparatorArgsFindsFirstSeparator(t *testing.T) {
+	cmd, args, errMsg := parseSeparatorArgs([]string{"--", "git", "--", "log"}, "run")
+	if errMsg != "" {
+		t.Errorf("unexpected error: %q", errMsg)
+	}
+	if cmd != "git" {
+		t.Errorf("cmd = %q, want %q", cmd, "git")
+	}
+	if !reflect.DeepEqual(args, []string{"--", "log"}) {
+		t.Errorf("args = %v, want [--, log]", args)
+	}
+}
+
+func TestRunSubcommandPreservesDoubleDash(t *testing.T) {
+	flags, remaining := ParseFlags([]string{"run", "--", "git", "--", "log"})
+	if flags.Help {
+		t.Errorf("flags.Help = true, want false")
+	}
+	wantRemaining := []string{"run", "--", "git", "--", "log"}
+	if !reflect.DeepEqual(remaining, wantRemaining) {
+		t.Errorf("remaining = %v, want %v", remaining, wantRemaining)
+	}
+}
+
+func TestCheckSubcommandPreservesDoubleDash(t *testing.T) {
+	flags, remaining := ParseFlags([]string{"check", "--", "git", "--", "log"})
+	if flags.Help {
+		t.Errorf("flags.Help = true, want false")
+	}
+	wantRemaining := []string{"check", "--", "git", "--", "log"}
+	if !reflect.DeepEqual(remaining, wantRemaining) {
+		t.Errorf("remaining = %v, want %v", remaining, wantRemaining)
+	}
+}
+
+func TestRunSubcommandUnproxyableErrorMessageFormat(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantMsg string
+	}{
+		{"source", []string{"snip", "run", "--", "source"}, "cannot be proxied"},
+		{"dot", []string{"snip", "run", "--", "."}, "cannot be proxied"},
+		{"export", []string{"snip", "run", "--", "export"}, "cannot be proxied"},
+		{"eval", []string{"snip", "run", "--", "eval"}, "cannot be proxied"},
+		{"set", []string{"snip", "run", "--", "set"}, "cannot be proxied"},
+		{"exit", []string{"snip", "run", "--", "exit"}, "cannot be proxied"},
+		{"exec", []string{"snip", "run", "--", "exec"}, "cannot be proxied"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			old := os.Stderr
+			r, w, _ := os.Pipe()
+			os.Stderr = w
+			code := Run(tt.args)
+			_ = w.Close()
+			os.Stderr = old
+			var buf bytes.Buffer
+			if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+
+			if code != 1 {
+				t.Errorf("expected exit code 1, got %d", code)
+			}
+			output := buf.String()
+			if !strings.Contains(output, tt.wantMsg) {
+				t.Errorf("expected stderr to contain %q, got %q", tt.wantMsg, output)
+			}
+		})
+	}
+}
+
+func TestCheckSubcommandUnproxyableErrorMessageFormat(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantMsg string
+	}{
+		{"source", []string{"snip", "check", "--", "source"}, "is a shell builtin"},
+		{"dot", []string{"snip", "check", "--", "."}, "is a shell builtin"},
+		{"export", []string{"snip", "check", "--", "export"}, "is a shell builtin"},
+		{"eval", []string{"snip", "check", "--", "eval"}, "is a shell builtin"},
+		{"set", []string{"snip", "check", "--", "set"}, "is a shell builtin"},
+		{"exit", []string{"snip", "check", "--", "exit"}, "is a shell builtin"},
+		{"exec", []string{"snip", "check", "--", "exec"}, "is a shell builtin"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			old := os.Stderr
+			r, w, _ := os.Pipe()
+			os.Stderr = w
+			code := Run(tt.args)
+			_ = w.Close()
+			os.Stderr = old
+			var buf bytes.Buffer
+			if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+
+			if code != 1 {
+				t.Errorf("expected exit code 1, got %d", code)
+			}
+			output := buf.String()
+			if !strings.Contains(output, tt.wantMsg) {
+				t.Errorf("expected stderr to contain %q, got %q", tt.wantMsg, output)
+			}
+		})
+	}
+}
+
+func TestGlobalUnproxyableErrorMessageFormat(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantMsg string
+	}{
+		{"cd", []string{"snip", "cd"}, "cannot be proxied"},
+		{"source", []string{"snip", "source"}, "cannot be proxied"},
+		{"eval", []string{"snip", "eval"}, "cannot be proxied"},
+		{"exec", []string{"snip", "exec"}, "cannot be proxied"},
+		{"set", []string{"snip", "set"}, "cannot be proxied"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			old := os.Stderr
+			r, w, _ := os.Pipe()
+			os.Stderr = w
+			code := Run(tt.args)
+			_ = w.Close()
+			os.Stderr = old
+			var buf bytes.Buffer
+			if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+
+			if code != 1 {
+				t.Errorf("expected exit code 1, got %d", code)
+			}
+			output := buf.String()
+			if !strings.Contains(output, tt.wantMsg) {
+				t.Errorf("expected stderr to contain %q, got %q", tt.wantMsg, output)
+			}
+		})
+	}
+}
+
+

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -11,11 +11,66 @@ func TestUnproxyableCommands(t *testing.T) {
 		want    bool
 	}{
 		{"cd", true},
+		{"chdir", true},
+		{"pushd", true},
+		{"popd", true},
 		{"source", true},
 		{".", true},
+		{"export", true},
+		{"unset", true},
+		{"alias", true},
+		{"unalias", true},
+		{"readonly", true},
+		{"declare", true},
+		{"typeset", true},
+		{"local", true},
+		{"shift", true},
+		{"read", true},
+		{"mapfile", true},
+		{"readarray", true},
+		{"let", true},
+		{"getopts", true},
+		{"set", true},
+		{"shopt", true},
+		{"setopt", true},
+		{"unsetopt", true},
+		{"emulate", true},
+		{"eval", true},
+		{"exec", true},
+		{"exit", true},
+		{"logout", true},
+		{"return", true},
+		{"break", true},
+		{"continue", true},
+		{"wait", true},
+		{"bg", true},
+		{"fg", true},
+		{"disown", true},
+		{"jobs", true},
+		{"suspend", true},
+		{"bindkey", true},
+		{"bind", true},
+		{"complete", true},
+		{"compopt", true},
+		{"compinit", true},
+		{"zstyle", true},
+		{"autoload", true},
+		{"zmodload", true},
+		{"enable", true},
+		{"disable", true},
+		{"abbr", true},
+		{"functions", true},
+		{"hash", true},
+		{"trap", true},
+		{"umask", true},
+		{"ulimit", true},
 		{"git", false},
 		{"go", false},
-		{"export", false},
+		{"docker", false},
+		{"echo", false},
+		{"printf", false},
+		{"pwd", false},
+		{"test", false},
 	}
 
 	for _, tt := range tests {
@@ -85,5 +140,47 @@ func TestRunSubcommandWithFlags(t *testing.T) {
 	wantRemaining := []string{"run", "--", "git", "log", "-10"}
 	if !reflect.DeepEqual(remaining, wantRemaining) {
 		t.Errorf("remaining = %v, want %v", remaining, wantRemaining)
+	}
+}
+
+func TestCheckMissingSeparator(t *testing.T) {
+	code := Run([]string{"snip", "check", "git", "log"})
+	if code != 1 {
+		t.Errorf("Run(check without --) = %d, want 1", code)
+	}
+}
+
+func TestCheckEmptyAfterSeparator(t *testing.T) {
+	code := Run([]string{"snip", "check", "--"})
+	if code != 1 {
+		t.Errorf("Run(check --) = %d, want 1", code)
+	}
+}
+
+func TestCheckShellBuiltin(t *testing.T) {
+	code := Run([]string{"snip", "check", "--", "cd", "/tmp"})
+	if code != 1 {
+		t.Errorf("Run(check -- cd) = %d, want 1", code)
+	}
+}
+
+func TestCheckShellBuiltinExport(t *testing.T) {
+	code := Run([]string{"snip", "check", "--", "export", "FOO=bar"})
+	if code != 1 {
+		t.Errorf("Run(check -- export) = %d, want 1", code)
+	}
+}
+
+func TestCheckShellBuiltinSet(t *testing.T) {
+	code := Run([]string{"snip", "check", "--", "set", "-e"})
+	if code != 1 {
+		t.Errorf("Run(check -- set) = %d, want 1", code)
+	}
+}
+
+func TestCheckShellBuiltinExit(t *testing.T) {
+	code := Run([]string{"snip", "check", "--", "exit"})
+	if code != 1 {
+		t.Errorf("Run(check -- exit) = %d, want 1", code)
 	}
 }

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -64,7 +64,7 @@ func isStackedVerboseFlag(arg string) bool {
 
 func isBuiltInCommand(arg string) bool {
 	switch arg {
-	case "run", "init", "gain", "cc-economics", "config", "proxy", "hook", "hook-audit", "discover", "learn", "verify", "trust", "untrust":
+	case "run", "check", "init", "gain", "cc-economics", "config", "proxy", "hook", "hook-audit", "discover", "learn", "verify", "trust", "untrust":
 		return true
 	default:
 		return false

--- a/internal/cli/flags_test.go
+++ b/internal/cli/flags_test.go
@@ -139,6 +139,18 @@ func TestParseFlags(t *testing.T) {
 			wantFlags: Flags{Verbose: 1},
 			wantArgs:  []string{"run", "--", "git", "log"},
 		},
+		{
+			name:      "check is a built-in command",
+			args:      []string{"check", "--", "git", "log"},
+			wantFlags: Flags{},
+			wantArgs:  []string{"check", "--", "git", "log"},
+		},
+		{
+			name:      "check with snip flags before it",
+			args:      []string{"-v", "check", "--", "git", "log"},
+			wantFlags: Flags{Verbose: 1},
+			wantArgs:  []string{"check", "--", "git", "log"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
My suggestion/attempt to allow things like [opencode-snip to work better](https://github.com/edouard-claude/snip/issues/18).

The idea is that the harness can check whether a command would benefit from being wrapped by snip. This way the harness can skip snip if the command would not have a filter associated or would be 'unproxyable'.

If this gets merged, I'll open a PR [for this branch](https://github.com/JoaoCostaIFG/opencode-snip/tree/main) for opencode-snip.

- Adds a `snip check -- <command> [args...]` subcommand that checks whether a command would be filtered without running it:
  - Exits with 0 and `filter: <name> when matched`
  - Exits with 1 and a reason otherwise (no filter, no filter: excluded by flags, filter disabled: <name>, shell builtin: <reason>).
- Expands `unproxyableReason` to cover bash, zsh, and fish builtins:
  - Directory navigation (cd, pushd, popd, chdir)
  - Environment vars (export, unset, alias, …)
  - Shell options (set, shopt, setopt, …)
  - Flow control (exit, break, continue, …)
  - Job control (wait, bg, fg, …)
  - Shell configuration (bindkey, complete, umask, …).

**Important:** Expanding `unproxyableReason` to catch shell builtins, commands that manipulate shell state, etc. makes it so more commands start being rejected by snip. This affects the top-level path: commands like `snip alias`, `snip umask`, `snip exec`, `snip export`, etc. now error out with "cannot be proxied" instead of attempting to run them. This change was intentional.

This shares a bit of code with the `run` command (added by #45).

**Note:** the diff looks quite large for a PR because I used AI to add a test for each 'unproxyable' command. If you find this unnecessary, I can get rid of it.