### PR TITLE
fix(git-status): preserve filenames using append:true on group_by

### DIFF
--- a/filters/git-status.yaml
+++ b/filters/git-status.yaml
@@ -1,6 +1,6 @@
 name: "git-status"
-version: 1
-description: "Categorized git status with file counts"
+version: 2
+description: "Compact git status: porcelain lines plus status code summary"
 
 match:
   command: "git"
@@ -16,8 +16,25 @@ pipeline:
     pattern: "\\S"
   - action: "group_by"
     pattern: "^(.{2})"
-    format: "{{.Key}} ({{.Count}} files)"
-  - action: "format_template"
-    template: "{{.count}} changes:\n{{.lines}}"
+    format: "{{.Key}}: {{.Count}}"
+    append: true
 
 on_error: "passthrough"
+
+tests:
+  - name: "porcelain output preserves filenames and appends status summary"
+    input: |
+      M  internal/cli/cli.go
+      M  internal/engine/pipeline.go
+      A  internal/filter/kubectl.go
+      ?? filters/kubectl-get-pods.yaml
+      ?? docs/kubectl-filters.md
+    expected: |
+      M  internal/cli/cli.go
+      M  internal/engine/pipeline.go
+      A  internal/filter/kubectl.go
+      ?? filters/kubectl-get-pods.yaml
+      ?? docs/kubectl-filters.md
+      M : 2
+      ??: 2
+      A : 1

--- a/internal/filter/actions_integration_test.go
+++ b/internal/filter/actions_integration_test.go
@@ -124,28 +124,35 @@ func TestGitLogFilterIntegration(t *testing.T) {
 }
 
 func TestGitStatusFilterIntegration(t *testing.T) {
+	// The git-status filter works by INJECTING --porcelain BEFORE execution.
+	// The pipeline then runs on porcelain output, not the verbose fixture.
+	// We test the full savings: raw verbose input vs pipeline-filtered porcelain output.
 	fixture := loadFixture(t, "git_status_raw.txt")
 	f := loadFilter(t, "git-status.yaml")
 
-	filtered, err := applyPipeline(f, fixture)
-	if err != nil {
-		t.Fatalf("apply pipeline: %v", err)
-	}
+	// Simulated post-injection output (what git status --porcelain produces).
+	// Mirrors the file set of the verbose fixture for an apples-to-apples comparison.
+	injectedOutput := "A  internal/filter/kubectl.go\nA  internal/filter/kubectl_test.go\nM  internal/filter/registry.go\n M CHANGELOG.md\n M README.md\n M internal/cli/cli.go\n M internal/engine/pipeline.go\n M internal/filter/actions.go\n M internal/filter/loader.go\n M internal/tracking/tracker.go\n?? filters/kubectl-get-pods.yaml\n?? filters/kubectl-logs.yaml\n?? filters/kubectl-describe.yaml\n?? internal/filter/npm.go\n?? internal/filter/npm_test.go\n?? tests/fixtures/kubectl_pods_raw.txt\n?? tests/fixtures/kubectl_logs_raw.txt\n?? tests/fixtures/npm_install_raw.txt\n?? docs/kubectl-filters.md\n?? docs/npm-filters.md\n"
 
-	if len(filtered) >= len(fixture) {
-		t.Errorf("filtered (%d) not shorter than input (%d)", len(filtered), len(fixture))
+	filtered, err := applyPipeline(f, injectedOutput)
+	if err != nil {
+		t.Fatalf("apply pipeline on injected: %v", err)
 	}
 
 	if strings.TrimSpace(filtered) == "" {
 		t.Error("filtered output is empty")
 	}
 
+	// Full savings: raw verbose input tokens vs final filtered output tokens.
 	inputTokens := utils.EstimateTokens(fixture)
 	outputTokens := utils.EstimateTokens(filtered)
 	savings := float64(inputTokens-outputTokens) / float64(inputTokens) * 100
-	t.Logf("git-status: %d -> %d tokens (%.1f%% savings)", inputTokens, outputTokens, savings)
-	if savings < 60 {
-		t.Errorf("git-status savings %.1f%% < 60%% minimum", savings)
+	t.Logf("git-status full (inject+pipeline): %d -> %d tokens (%.1f%% savings)", inputTokens, outputTokens, savings)
+	// Threshold lower than other filters: git-status preserves filenames (issue #48),
+	// trading some compression for usable output. Savings come from --porcelain injection
+	// stripping verbose section headers, not from aggregating filenames away.
+	if savings < 40 {
+		t.Errorf("git-status savings %.1f%% < 40%% minimum", savings)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixes #48. The previous filter aggregated lines by 2-char porcelain status code, collapsing every file into counters like `M: 8, ??: 10`. Agents could not see which files had changed and ended up bypassing snip via `snip proxy git status`.
- Apply `group_by` with `append: true` — the idiom already used by `filters/ls.yaml` (commit c855138). Porcelain lines are preserved; the status code summary is appended at the end.
- Realign `TestGitStatusFilterIntegration` on the pattern of `TestGitLogFilterIntegration`: run the pipeline on simulated post-injection porcelain rather than on the verbose fixture the pipeline never sees in production. Lower the savings threshold to 40% to reflect the trade-off — the filter is now a selector, not an aggressive compressor.

## Output before / after (10 modified/untracked files)

Before:
```
3 changes:
M  (8 files)
?? (10 files)
```

After:
```
M  internal/cli/cli.go
M  internal/engine/pipeline.go
A  internal/filter/kubectl.go
?? filters/kubectl-get-pods.yaml
?? docs/kubectl-filters.md
M : 2
??: 2
A : 1
```

## Test plan
- [x] \`go run ./cmd/snip verify\` — git-status inline tests pass (1/1, 26/26 overall)
- [x] \`go test ./internal/filter -run TestGitStatusFilterIntegration -v\` — 43.4% savings, above the 40% threshold
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`make test\` — all packages green
- [x] \`make test-race\` — all packages green
- [x] Smoke test on this repo: filenames visible, summary trailing