### PR TITLE
Fix a few opencode issues

### DIFF
--- a/filters/ansible-playbook.yaml
+++ b/filters/ansible-playbook.yaml
@@ -4,6 +4,7 @@ description: "Condensed ansible-playbook: task results and recap"
 
 match:
   command: "ansible-playbook"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/basedpyright.yaml
+++ b/filters/basedpyright.yaml
@@ -4,6 +4,7 @@ description: "Condensed basedpyright output: type errors"
 
 match:
   command: "basedpyright"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/docker-build.yaml
+++ b/filters/docker-build.yaml
@@ -4,6 +4,7 @@ description: "Condensed docker build: step names, final result, and errors"
 
 match:
   command: "docker"
+  exclude_flags: ["--version", "-v"]
 
 streams:
   - stdout

--- a/filters/eslint.yaml
+++ b/filters/eslint.yaml
@@ -4,7 +4,7 @@ description: "Condensed eslint output: file errors and summary"
 
 match:
   command: "eslint"
-  exclude_flags: ["-f", "--format"]
+  exclude_flags: ["-f", "--format", "--version"]
 
 streams:
   - stdout

--- a/filters/g++.yaml
+++ b/filters/g++.yaml
@@ -4,6 +4,7 @@ description: "Condensed g++ output: errors and warnings"
 
 match:
   command: "g++"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/gcc.yaml
+++ b/filters/gcc.yaml
@@ -4,6 +4,7 @@ description: "Condensed gcc/g++ output: errors and warnings"
 
 match:
   command: "gcc"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/gradle.yaml
+++ b/filters/gradle.yaml
@@ -4,6 +4,7 @@ description: "Condensed gradle output: build result and errors"
 
 match:
   command: "gradle"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/jest.yaml
+++ b/filters/jest.yaml
@@ -4,7 +4,7 @@ description: "Condensed jest output: suite results, assertion details, and summa
 
 match:
   command: "jest"
-  exclude_flags: ["--json", "--verbose"]
+  exclude_flags: ["--json", "--verbose", "--version"]
 
 streams:
   - stdout

--- a/filters/mvn.yaml
+++ b/filters/mvn.yaml
@@ -4,6 +4,7 @@ description: "Condensed maven output: build result and errors"
 
 match:
   command: "mvn"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/npm-install.yaml
+++ b/filters/npm-install.yaml
@@ -4,6 +4,7 @@ description: "Condensed npm output: install summary and errors only"
 
 match:
   command: "npm"
+  exclude_flags: ["--version", "-v"]
 
 streams:
   - stdout

--- a/filters/nx.yaml
+++ b/filters/nx.yaml
@@ -4,6 +4,7 @@ description: "Condensed nx output: task results summary"
 
 match:
   command: "nx"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/pip-install.yaml
+++ b/filters/pip-install.yaml
@@ -4,6 +4,7 @@ description: "Condensed pip output: install result and errors only"
 
 match:
   command: "pip"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/pre-commit.yaml
+++ b/filters/pre-commit.yaml
@@ -4,6 +4,7 @@ description: "Condensed pre-commit output: hook results"
 
 match:
   command: "pre-commit"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/prisma.yaml
+++ b/filters/prisma.yaml
@@ -4,6 +4,7 @@ description: "Condensed prisma output: migration and generation status"
 
 match:
   command: "prisma"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/quarto.yaml
+++ b/filters/quarto.yaml
@@ -4,6 +4,7 @@ description: "Condensed quarto output: render status"
 
 match:
   command: "quarto"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/rake.yaml
+++ b/filters/rake.yaml
@@ -4,6 +4,7 @@ description: "Condensed rake output: task results and errors"
 
 match:
   command: "rake"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/rubocop.yaml
+++ b/filters/rubocop.yaml
@@ -4,6 +4,7 @@ description: "Condensed rubocop output: offenses by file"
 
 match:
   command: "rubocop"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/rustc.yaml
+++ b/filters/rustc.yaml
@@ -4,6 +4,7 @@ description: "Condensed rustc output: errors and warnings with locations"
 
 match:
   command: "rustc"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/shellcheck.yaml
+++ b/filters/shellcheck.yaml
@@ -4,6 +4,7 @@ description: "Condensed shellcheck output: warnings by file"
 
 match:
   command: "shellcheck"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/terraform.yaml
+++ b/filters/terraform.yaml
@@ -4,6 +4,7 @@ description: "Condensed terraform output: plan changes and errors"
 
 match:
   command: "terraform"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/tofu.yaml
+++ b/filters/tofu.yaml
@@ -4,6 +4,7 @@ description: "Condensed OpenTofu output: plan changes and errors"
 
 match:
   command: "tofu"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/tsc.yaml
+++ b/filters/tsc.yaml
@@ -4,6 +4,7 @@ description: "Condensed tsc output: type errors and summary"
 
 match:
   command: "tsc"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/internal/filter/registry.go
+++ b/internal/filter/registry.go
@@ -29,12 +29,22 @@ func NewRegistry(filters []Filter) *Registry {
 
 // Match finds the first filter matching the given command, subcommand, and args.
 func (r *Registry) Match(command, subcommand string, args []string) *Filter {
+	// Include subcommand in flag matching so that exclude_flags like
+	// "--version" are detected even when they appear as the first arg
+	// (which pipeline.go extracts as subcommand).
+	allArgs := args
+	if subcommand != "" {
+		allArgs = make([]string, 0, len(args)+1)
+		allArgs = append(allArgs, subcommand)
+		allArgs = append(allArgs, args...)
+	}
+
 	// Try exact match first (command:subcommand)
 	if subcommand != "" {
 		key := command + ":" + subcommand
 		if candidates, ok := r.byKey[key]; ok {
 			for i := range candidates {
-				if matchesFlags(&candidates[i], args) {
+				if matchesFlags(&candidates[i], allArgs) {
 					return &candidates[i]
 				}
 			}
@@ -44,7 +54,7 @@ func (r *Registry) Match(command, subcommand string, args []string) *Filter {
 	// Try command-only match
 	if candidates, ok := r.byKey[command]; ok {
 		for i := range candidates {
-			if matchesFlags(&candidates[i], args) {
+			if matchesFlags(&candidates[i], allArgs) {
 				return &candidates[i]
 			}
 		}

--- a/internal/filter/registry.go
+++ b/internal/filter/registry.go
@@ -82,8 +82,9 @@ func (r *Registry) ShouldInject(f *Filter, args []string) ([]string, bool) {
 		result = append(result, f.Inject.Args...)
 		result = append(result, args[dashDashIdx:]...)
 	} else {
-		result = append(result, args...)
+		result = append(result, args[0])
 		result = append(result, f.Inject.Args...)
+		result = append(result, args[1:]...)
 	}
 
 	// Apply defaults (only if flag not already present)

--- a/internal/tracking/tracker.go
+++ b/internal/tracking/tracker.go
@@ -50,8 +50,8 @@ func (t *Tracker) ensureOpen() error {
 			return
 		}
 
-		db.Exec("PRAGMA journal_mode=WAL")
-		db.Exec("PRAGMA busy_timeout=5000")
+		_, _ = db.Exec("PRAGMA journal_mode=WAL")
+		_, _ = db.Exec("PRAGMA busy_timeout=5000")
 
 		if _, err := db.Exec(createTableSQL); err != nil {
 			_ = db.Close()

--- a/internal/tracking/tracker.go
+++ b/internal/tracking/tracker.go
@@ -50,6 +50,9 @@ func (t *Tracker) ensureOpen() error {
 			return
 		}
 
+		db.Exec("PRAGMA journal_mode=WAL")
+		db.Exec("PRAGMA busy_timeout=5000")
+
 		if _, err := db.Exec(createTableSQL); err != nil {
 			_ = db.Close()
 			t.initErr = fmt.Errorf("create table: %w", err)


### PR DESCRIPTION
This PR addresses a few issues that I opened in the repo. They are all fairly small:

- **Fix `--version` being filtered out** (#51):
  - I was intending to fix just `rustc --version`, but then noticied that `gcc --version` had the same problem.
  - I asked an LLM to spin up some ubuntu docker containers, install the tools with filters, test if the `--version` had problems.
  - In the end, added `exclude_flags: ["--version"]` to 22 filters in the repo.
  - Fixed `registry.Match` to include the subcommand in flag checking (since `--version` gets parsed as subcommand, not an arg).
- **Fix SQLite "database is locked" errors** (#49):
  - Enabled WAL journal mode and set a 5-second busy timeout. I think this should be enough to deal with this.
- **Fix `git diff` injected args placement** (#52):
  - `ShouldInject` was appending injected arguments (like `--stat`) at the end of the command line, after file paths, causing git to error.
  - Injected args are now inserted after the subcommand
  - Not too sure about this one

Closes #49, #51, #52 