### PR TITLE
fix(tracking): prevent SQLite BUSY errors on concurrent snip runs

### DIFF
--- a/internal/tracking/tracker.go
+++ b/internal/tracking/tracker.go
@@ -3,9 +3,12 @@ package tracking
 import (
 	"database/sql"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
+	"time"
 )
 
 // Tracker manages token savings tracking in SQLite.
@@ -44,13 +47,17 @@ func (t *Tracker) ensureOpen() error {
 			return
 		}
 
-		db, err := sql.Open("sqlite", t.dbPath)
+		db, err := sql.Open("sqlite", buildDSN(t.dbPath))
 		if err != nil {
 			t.initErr = fmt.Errorf("open db: %w", err)
 			return
 		}
+		// SQLite tolerates one writer at a time; pinning the pool to a single
+		// connection avoids in-process contention while busy_timeout handles
+		// cross-process contention.
+		db.SetMaxOpenConns(1)
 
-		if _, err := db.Exec(createTableSQL); err != nil {
+		if err := execWithBusyRetry(db, createTableSQL); err != nil {
 			_ = db.Close()
 			t.initErr = fmt.Errorf("create table: %w", err)
 			return
@@ -59,6 +66,39 @@ func (t *Tracker) ensureOpen() error {
 		t.db = db
 	})
 	return t.initErr
+}
+
+// buildDSN constructs a modernc.org/sqlite DSN with WAL journaling and a 5s
+// busy timeout so concurrent snip processes wait for locks instead of failing.
+func buildDSN(dbPath string) string {
+	q := url.Values{}
+	q.Add("_pragma", "busy_timeout(5000)")
+	q.Add("_pragma", "journal_mode(WAL)")
+	q.Add("_pragma", "synchronous(NORMAL)")
+	return "file:" + dbPath + "?" + q.Encode()
+}
+
+// execWithBusyRetry runs an Exec, retrying on SQLITE_BUSY with exponential
+// backoff. busy_timeout already covers most contention, but WAL setup itself
+// can briefly contend before it takes effect.
+func execWithBusyRetry(db *sql.DB, query string, args ...any) error {
+	var err error
+	for attempt := range 3 {
+		_, err = db.Exec(query, args...)
+		if err == nil || !isBusyErr(err) {
+			return err
+		}
+		time.Sleep(time.Duration(50*(1<<attempt)) * time.Millisecond)
+	}
+	return err
+}
+
+func isBusyErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "SQLITE_BUSY") || strings.Contains(s, "database is locked")
 }
 
 // Track records a filtered command execution.

--- a/internal/tracking/tracker_test.go
+++ b/internal/tracking/tracker_test.go
@@ -4,6 +4,7 @@ package tracking
 
 import (
 	"path/filepath"
+	"sync"
 	"testing"
 )
 
@@ -187,6 +188,81 @@ func TestGetMonthly(t *testing.T) {
 		t.Errorf("saved = %d, want 1000", monthly[0].SavedTokens)
 	}
 }
+
+// TestConcurrentTrack simulates two snip processes writing to the same DB
+// (issue #49). With WAL + busy_timeout in place, no SQLITE_BUSY errors should
+// surface and every Track call must persist.
+func TestConcurrentTrack(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "concurrent.db")
+
+	const trackers = 2
+	const goroutines = 25
+	const inserts = 10
+
+	ts := make([]*Tracker, trackers)
+	for i := range trackers {
+		tr, err := NewTracker(dbPath)
+		if err != nil {
+			t.Fatalf("new tracker %d: %v", i, err)
+		}
+		ts[i] = tr
+		t.Cleanup(func() { _ = tr.Close() })
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, trackers*goroutines*inserts)
+
+	for _, tr := range ts {
+		for g := range goroutines {
+			wg.Add(1)
+			go func(tr *Tracker, g int) {
+				defer wg.Done()
+				for i := range inserts {
+					if err := tr.Track("cmd", "snip cmd", 100, 30, int64(g*inserts+i)); err != nil {
+						errs <- err
+						return
+					}
+				}
+			}(tr, g)
+		}
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Errorf("track: %v", err)
+	}
+
+	summary, err := ts[0].GetSummary()
+	if err != nil {
+		t.Fatalf("summary: %v", err)
+	}
+	want := trackers * goroutines * inserts
+	if summary.TotalCommands != want {
+		t.Errorf("total commands = %d, want %d", summary.TotalCommands, want)
+	}
+}
+
+func TestIsBusyErr(t *testing.T) {
+	tests := []struct {
+		err  error
+		want bool
+	}{
+		{nil, false},
+		{errString("some other error"), false},
+		{errString("database is locked (5) (SQLITE_BUSY)"), true},
+		{errString("database is locked"), true},
+	}
+	for _, tt := range tests {
+		if got := isBusyErr(tt.err); got != tt.want {
+			t.Errorf("isBusyErr(%v) = %v, want %v", tt.err, got, tt.want)
+		}
+	}
+}
+
+type errString string
+
+func (e errString) Error() string { return string(e) }
 
 func TestDBPath(t *testing.T) {
 	t.Setenv("SNIP_DB_PATH", "/custom/path.db")


### PR DESCRIPTION
## Summary

Fixes #49.

When two snip processes (e.g. parallel opencode sessions) tracked tokens against the same SQLite DB, they raced on `CREATE TABLE` and subsequent inserts, surfacing:

```
snip: tracking error: track: create table: database is locked (5) (SQLITE_BUSY)
```

The DB was opened with default SQLite settings: no `busy_timeout`, default `DELETE` journal mode, and no connection pool tuning, so any contention failed immediately instead of waiting.

## Changes

- DSN now sets `busy_timeout(5000)`, `journal_mode(WAL)`, and `synchronous(NORMAL)` via `_pragma=...` (the format supported by `modernc.org/sqlite`).
- Pin the connection pool to a single connection (`SetMaxOpenConns(1)`): SQLite only accepts one writer at a time, this avoids in-process contention while `busy_timeout` covers cross-process contention.
- Wrap `CREATE TABLE` in a small busy-aware retry loop (3 attempts, 50/100/200ms backoff) for the brief window before WAL mode takes effect.

## Test plan

- [x] `go test -race ./internal/tracking/` passes (14 tests)
- [x] New `TestConcurrentTrack`: 2 trackers × 25 goroutines × 10 inserts = 500 concurrent writes, asserts no errors and all 500 rows persisted
- [x] `golangci-lint run ./...` clean
- [x] `make test-race` green across the whole repo
- [x] Manual repro from the issue: `for i in 1 2; do (while true; do ./snip run -- git status > /dev/null; done) & done` runs cleanly with no `tracking error` lines on stderr