### PR TITLE
fix(engine): strip CR from CRLF line endings before filtering

### DIFF
--- a/filters/ls.yaml
+++ b/filters/ls.yaml
@@ -66,3 +66,18 @@ tests:
       Apr 28 10:00  README.md  1234
       json: 1
       md: 1
+  - name: "cygwin actual user output with ACL+ marker and year column"
+    input: |
+      total 104617
+      drwxrwx---+  1 jspelletier     Domain Users        0 Apr 28 09:19 .
+      drwxrwx---+  1 jspelletier     Domain Users        0 Dec 11 10:20 ..
+      -r-xr-x---+  2 jspelletier     Domain Users     8429 Jan 30  2024 .clang-format
+      drwxrwx---+  1 jspelletier     Domain Users        0 Apr 23 14:13 .claude
+      -r-xr-x---+  1 jspelletier     Domain Users     9020 Jul 22  2025 .editorconfig
+      -rwxrwx---+  1 jspelletier     Domain Users      171 Apr 23 13:47 .mcp.json
+    expected: |
+      Jan 30  2024  .clang-format  8429
+      Apr 23 14:13  .claude  0
+      Jul 22  2025  .editorconfig  9020
+      Apr 23 13:47  .mcp.json  171
+      json: 1

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -153,6 +153,14 @@ func ApplyPipeline(f *filter.Filter, input string) (string, error) {
 	if len(lines) > 0 && lines[len(lines)-1] == "" {
 		lines = lines[:len(lines)-1]
 	}
+	// Strip CR from CRLF line endings so anchors like $ and patterns like \.\.?$
+	// behave correctly when the wrapped tool emits Windows-style line endings
+	// (e.g. cygwin's ls.exe under cmd.exe).
+	for i, l := range lines {
+		if len(l) > 0 && l[len(l)-1] == '\r' {
+			lines[i] = l[:len(l)-1]
+		}
+	}
 
 	result := filter.ActionResult{
 		Lines:    lines,

--- a/internal/engine/pipeline_test.go
+++ b/internal/engine/pipeline_test.go
@@ -30,6 +30,38 @@ func TestApplyPipelineKeepLines(t *testing.T) {
 	}
 }
 
+func TestApplyPipelineStripsCRFromCRLFLineEndings(t *testing.T) {
+	// Regression: cygwin's ls.exe under cmd.exe emits CRLF line endings.
+	// Without CR stripping, "$" anchors do not match (line ends with \r),
+	// so dot-entry removal fails, and reformatted lines carry a trailing CR
+	// into captured filenames — which corrupts the rendered output. (#44)
+	f := &filter.Filter{
+		Name: "test",
+		Pipeline: filter.Pipeline{
+			{ActionName: "remove_lines", Params: map[string]any{"pattern": `\.$`}},
+			{ActionName: "replace", Params: map[string]any{
+				"pattern":     `^name\s+(\S+)$`,
+				"replacement": "[$1]",
+			}},
+		},
+	}
+
+	input := "skip me .\r\nname .mcp.json\r\nname README.md\r\n"
+	out, err := ApplyPipeline(f, input)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if strings.Contains(out, "\r") {
+		t.Errorf("output still contains CR: %q", out)
+	}
+	if strings.Contains(out, "skip me") {
+		t.Errorf("dot-entry not removed (anchors broken by CR): %q", out)
+	}
+	if !strings.Contains(out, "[.mcp.json]") {
+		t.Errorf("expected reformatted .mcp.json, got: %q", out)
+	}
+}
+
 func TestApplyPipelineChained(t *testing.T) {
 	f := &filter.Filter{
 		Name: "test",

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -134,6 +134,12 @@ func ApplyTestPipeline(f *filter.Filter, input string) (string, error) {
 	if len(lines) > 0 && lines[len(lines)-1] == "" {
 		lines = lines[:len(lines)-1]
 	}
+	// Strip CR from CRLF line endings (matches engine.ApplyPipeline behavior).
+	for i, l := range lines {
+		if len(l) > 0 && l[len(l)-1] == '\r' {
+			lines[i] = l[:len(l)-1]
+		}
+	}
 
 	ar := filter.ActionResult{
 		Lines:    lines,


### PR DESCRIPTION
## Summary

Fixes #44.

Cygwin's `ls.exe` under cmd.exe (and other Windows tools snip wraps) emits CRLF line endings. `engine.ApplyPipeline` split on `\n` and left a trailing `\r` on every line, which broke filters in two ways:

1. `$` anchors and patterns like `\.\.?$` stopped matching, so the `ls` filter no longer removed `.` and `..` entries.
2. Capture groups like `(.+)$` pulled the CR into the captured filename. The reformatted output became `name\r  size` — terminals interpret `\r` as carriage return and redraw the size on top of the date, so files like `.mcp.json` appeared "skipped" even though they were in the output.

Demonstrated locally by feeding the issue's exact cygwin output (with ACL `+` marker) into the pipeline:

```
"Apr 28 09:19  .\r  0"             ← dot entry not removed (anchor broken)
"Jul 22  2025  .editorconfig\r  9020"  ← CR injected into filename
"Apr 23 13:47  .mcp.json\r  171"
```

## Changes

- `internal/engine/pipeline.go`: strip a trailing `\r` from each line right after the `\n` split in `ApplyPipeline`.
- `internal/verify/verify.go`: same fix in the mirrored `ApplyTestPipeline` so embedded YAML tests behave the same way.
- `internal/engine/pipeline_test.go`: new `TestApplyPipelineStripsCRFromCRLFLineEndings` regression test.
- `filters/ls.yaml`: extra inline test for the issue reporter's exact `ls -la` output (LF case) — ACL `+`, multi-space columns, year column.

## Test plan

- [x] `go test -race ./internal/engine/` passes (new CRLF regression test included)
- [x] `./snip verify ls` — 3/3 tests passed (including new ACL+ regression)
- [x] `golangci-lint run ./...` clean
- [x] `make test-race` green across the whole repo
- [x] Manual: pipe CRLF cygwin-style ls output through the filter, confirm `.` / `..` entries removed and filenames rendered without CR