### PR TITLE
fix(engine): silence misleading no-filter hint for sibling subcommands

### DIFF
--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -36,11 +36,12 @@ func (p *Pipeline) Run(command string, args []string) int {
 	f := p.Registry.Match(command, subcommand, filterArgs)
 
 	// No filter found: passthrough.
-	// Only print a hint when no filter is registered at all — if a filter exists
-	// but was excluded by flags (e.g. go test -v), stay silent to avoid the
-	// misleading "no filter for go" message.
+	// Only print a hint when no filter is registered for the base command at
+	// all. If a filter exists but was excluded by flags (e.g. go test -v) or
+	// only covers other subcommands (e.g. git-commit but not git checkout),
+	// stay silent to avoid the misleading "no filter for git" message (#56).
 	if f == nil {
-		if !p.QuietNoFilter && !p.Registry.HasAnyFilter(command, subcommand) {
+		if !p.QuietNoFilter && !p.Registry.HasAnyFilterForCommand(command) {
 			fmt.Fprintf(os.Stderr, "snip: no filter for %q, passing through -- you can run %q directly\n", command, command)
 		}
 		return p.Passthrough(command, args)

--- a/internal/engine/pipeline_test.go
+++ b/internal/engine/pipeline_test.go
@@ -233,3 +233,46 @@ func TestPipelineRunSilentWhenFilterExcludedByFlags(t *testing.T) {
 		t.Errorf("expected silent stderr when filter exists but excluded by flags, got: %q", buf.String())
 	}
 }
+
+func TestPipelineRunSilentWhenSiblingSubcommandHasFilter(t *testing.T) {
+	// Reproduces issue #56: snip has filters for "true:foo" but the user runs
+	// "true bar". Before the fix, snip printed the misleading
+	// "no filter for true" message. Expected behavior: stay silent — a filter
+	// exists for the base command, just not for this subcommand.
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping: no 'true' command on Windows")
+	}
+
+	f := filter.Filter{
+		Name:    "true-foo",
+		Version: 1,
+		Match:   filter.Match{Command: "true", Subcommand: "foo"},
+		OnError: "passthrough",
+		Pipeline: filter.Pipeline{
+			{ActionName: "keep_lines", Params: map[string]any{"pattern": `.`}},
+		},
+	}
+	reg := filter.NewRegistry([]filter.Filter{f})
+	p := &Pipeline{
+		Registry:      reg,
+		QuietNoFilter: false,
+	}
+
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = oldStderr })
+
+	p.Run("true", []string{"bar"})
+
+	_ = w.Close()
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+
+	if strings.Contains(buf.String(), "no filter for") {
+		t.Errorf("expected silent stderr when sibling subcommand filter exists, got: %q", buf.String())
+	}
+}

--- a/internal/filter/registry.go
+++ b/internal/filter/registry.go
@@ -127,6 +127,23 @@ func (r *Registry) HasAnyFilter(command, subcommand string) bool {
 	return ok
 }
 
+// HasAnyFilterForCommand returns true if any filter is registered for the
+// base command, regardless of subcommand or flag constraints. Use this to
+// avoid the misleading "no filter for git" hint when "git" has filters for
+// other subcommands (e.g. git-commit) but not for the one being run.
+func (r *Registry) HasAnyFilterForCommand(command string) bool {
+	if _, ok := r.byKey[command]; ok {
+		return true
+	}
+	prefix := command + ":"
+	for key := range r.byKey {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // Commands returns a sorted, unique list of base command names in the registry.
 // Keys like "git:log" are split on ":" and only the base command "git" is kept.
 func (r *Registry) Commands() []string {

--- a/internal/filter/registry_test.go
+++ b/internal/filter/registry_test.go
@@ -177,6 +177,33 @@ func TestHasAnyFilterCommandOnly(t *testing.T) {
 	}
 }
 
+func TestHasAnyFilterForCommand(t *testing.T) {
+	// Reproduces issue #56: snip ships filters for git-add, git-commit, etc.
+	// but not for git checkout. HasAnyFilterForCommand("git") must return true
+	// so that running "git checkout" doesn't print the misleading
+	// "no filter for git" hint.
+	filters := []Filter{
+		{Name: "git-add", Version: 1, Match: Match{Command: "git", Subcommand: "add"}, OnError: "passthrough"},
+		{Name: "git-commit", Version: 1, Match: Match{Command: "git", Subcommand: "commit"}, OnError: "passthrough"},
+	}
+	reg := NewRegistry(filters)
+
+	if !reg.HasAnyFilterForCommand("git") {
+		t.Error("HasAnyFilterForCommand should return true for git (subcommand filters registered)")
+	}
+	if reg.HasAnyFilterForCommand("python") {
+		t.Error("HasAnyFilterForCommand should return false for python (no filter registered)")
+	}
+
+	// Command-only filter must also be recognized.
+	regCmdOnly := NewRegistry([]Filter{
+		{Name: "npm", Version: 1, Match: Match{Command: "npm"}, OnError: "passthrough"},
+	})
+	if !regCmdOnly.HasAnyFilterForCommand("npm") {
+		t.Error("HasAnyFilterForCommand should return true for npm (command-only filter)")
+	}
+}
+
 func TestShouldInject(t *testing.T) {
 	f := Filter{
 		Name: "git-log",


### PR DESCRIPTION
## Summary
- Suppress the `snip: no filter for "git"` hint when running a subcommand without a dedicated filter (e.g. `git checkout`) but a sibling subcommand does have one (e.g. `git-commit`).
- Add `Registry.HasAnyFilterForCommand(cmd)` and use it in the pipeline to decide whether the hint is informative or misleading.
- Aligns with the previous fix in #36 (silence when filter is excluded by flags).

## Why
Running `git checkout fixes` printed `snip: no filter for "git", passing through` although snip ships filters for git-add, git-commit, git-diff, git-log, etc. The hint wrongly suggested git was unsupported.

## Behavior change
- **Before**: any unmatched (command, subcommand) pair triggers the hint, unless a command-only filter or an exact subcommand filter exists for that pair.
- **After**: hint stays silent whenever any filter is registered for the base command, regardless of subcommand. The hint still fires for genuinely unknown commands (e.g. `python` when no python filter is registered).

`HasAnyFilter(cmd, subcmd)` is preserved for `snip check`'s diagnostic use case (distinguishing "excluded by flags" vs "no filter at all").

## Test plan
- [x] New unit test `TestHasAnyFilterForCommand` covering subcommand-scoped and command-only registrations
- [x] New integration test `TestPipelineRunSilentWhenSiblingSubcommandHasFilter` reproducing the issue scenario
- [x] `make test-race` passes on full repo
- [x] `golangci-lint run ./...` clean

Fixes #56