### PR TITLE
feat(codex): add native PreToolUse hook integration (closes #60)

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -58,6 +58,9 @@ func Run(args []string) int {
 	// Built-in commands
 	switch command {
 	case "hook":
+		if len(cmdArgs) > 0 && cmdArgs[0] == "codex" {
+			return runHookCodex()
+		}
 		return runHook()
 
 	case "hook-audit":
@@ -230,17 +233,40 @@ func parseSeparatorArgs(args []string, cmdName string) (string, []string, string
 // runHook handles the "snip hook" subcommand for Claude Code PreToolUse.
 // Always returns 0 (graceful degradation).
 func runHook() int {
-	snipBin, err := os.Executable()
-	if err != nil {
+	snipBin, commands, ok := loadHookContext()
+	if !ok {
 		return 0
 	}
-	snipBin, err = filepath.EvalSymlinks(snipBin)
-	if err != nil {
+	_ = hook.Run(os.Stdin, os.Stdout, commands, snipBin)
+	return 0
+}
+
+// runHookCodex handles "snip hook codex" — Codex's PreToolUse hook entry.
+// Codex cannot rewrite the command in place, so the handler responds with
+// a deny + suggested rewrite. Always returns 0 (graceful degradation).
+func runHookCodex() int {
+	snipBin, commands, ok := loadHookContext()
+	if !ok {
 		return 0
 	}
-	snipBin, err = filepath.Abs(snipBin)
+	_ = hook.RunCodex(os.Stdin, os.Stdout, commands, snipBin)
+	return 0
+}
+
+// loadHookContext resolves the snip binary path and loads the filter
+// registry. Returns ok=false on any failure so callers can exit 0 silently.
+func loadHookContext() (snipBin string, commands []string, ok bool) {
+	bin, err := os.Executable()
 	if err != nil {
-		return 0
+		return "", nil, false
+	}
+	bin, err = filepath.EvalSymlinks(bin)
+	if err != nil {
+		return "", nil, false
+	}
+	bin, err = filepath.Abs(bin)
+	if err != nil {
+		return "", nil, false
 	}
 
 	cfg, err := config.Load()
@@ -250,14 +276,11 @@ func runHook() int {
 
 	filters, err := filter.LoadAll(cfg.Filters.Dirs())
 	if err != nil {
-		return 0
+		return "", nil, false
 	}
 
 	registry := filter.NewRegistry(filters)
-	commands := registry.Commands()
-
-	_ = hook.Run(os.Stdin, os.Stdout, commands, snipBin)
-	return 0
+	return bin, registry.Commands(), true
 }
 
 func runPipeline(command string, args []string, flags Flags) int {

--- a/internal/hook/codex.go
+++ b/internal/hook/codex.go
@@ -1,0 +1,110 @@
+package hook
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/edouard-claude/snip/internal/hookaudit"
+)
+
+// codexAgent is the value written to hookaudit.Event.Agent for Codex events.
+const codexAgent = "codex"
+
+// RunCodex reads a Codex PreToolUse JSON payload from r, determines if the
+// command matches a snip filter, and writes a deny-with-suggestion response
+// telling Codex (and the user) to re-run the command through snip.
+//
+// Codex's PreToolUse hook cannot rewrite the command in place — only "deny"
+// with a free-form reason is honored. See openai/codex#18491. When that
+// limitation is lifted, this function can return updatedInput like Run does.
+//
+// Always returns nil; the caller must exit 0 (graceful degradation).
+func RunCodex(r io.Reader, w io.Writer, commands []string, snipBin string) error {
+	audit := hookaudit.Enabled()
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return fmt.Errorf("read stdin: %w", err)
+	}
+
+	var input hookInput
+	if err := json.Unmarshal(data, &input); err != nil {
+		return nil
+	}
+
+	if input.ToolName != "Bash" {
+		return nil
+	}
+
+	var ti toolInput
+	if err := json.Unmarshal(input.ToolInput, &ti); err != nil {
+		return nil
+	}
+	if ti.Command == "" {
+		return nil
+	}
+
+	firstLine := ti.Command
+	if idx := strings.IndexByte(firstLine, '\n'); idx >= 0 {
+		firstLine = firstLine[:idx]
+	}
+	firstSegment := ExtractFirstSegment(firstLine)
+
+	prefix, envVars, bareCmd := ParseSegment(firstSegment)
+	base := BaseCommand(bareCmd)
+
+	quotedBin := fmt.Sprintf("%q", snipBin)
+	trimmed := strings.TrimLeft(bareCmd, " \t")
+	if base == quotedBin || base == snipBin ||
+		strings.HasPrefix(trimmed, quotedBin) || strings.HasPrefix(trimmed, snipBin) {
+		return nil
+	}
+
+	cmdSet := make(map[string]struct{}, len(commands))
+	for _, c := range commands {
+		cmdSet[c] = struct{}{}
+	}
+	if _, ok := cmdSet[base]; !ok {
+		if audit {
+			hookaudit.Append(hookaudit.Event{
+				Timestamp: time.Now().UTC(),
+				Command:   ti.Command,
+				Base:      base,
+				Matched:   false,
+				Rewritten: false,
+				Agent:     codexAgent,
+			})
+		}
+		return nil
+	}
+
+	rest := ti.Command[len(firstSegment):]
+	suggested := prefix + envVars + quotedBin + " run -- " + bareCmd + rest
+
+	reason := fmt.Sprintf("snip can filter this command. Re-run as: %s", suggested)
+
+	output := map[string]any{
+		"hookSpecificOutput": map[string]any{
+			"hookEventName":            "PreToolUse",
+			"permissionDecision":       "deny",
+			"permissionDecisionReason": reason,
+		},
+	}
+
+	if audit {
+		hookaudit.Append(hookaudit.Event{
+			Timestamp: time.Now().UTC(),
+			Command:   ti.Command,
+			Base:      base,
+			Matched:   true,
+			Rewritten: false,
+			Agent:     codexAgent,
+		})
+	}
+
+	enc := json.NewEncoder(w)
+	return enc.Encode(output)
+}

--- a/internal/hook/codex_test.go
+++ b/internal/hook/codex_test.go
@@ -1,0 +1,163 @@
+package hook
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func extractDenyReason(t *testing.T, output string) string {
+	t.Helper()
+	var result map[string]any
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, output)
+	}
+	hookOut, ok := result["hookSpecificOutput"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing hookSpecificOutput: %s", output)
+	}
+	if hookOut["hookEventName"] != "PreToolUse" {
+		t.Errorf("hookEventName = %v, want PreToolUse", hookOut["hookEventName"])
+	}
+	if hookOut["permissionDecision"] != "deny" {
+		t.Errorf("permissionDecision = %v, want deny", hookOut["permissionDecision"])
+	}
+	if _, ok := hookOut["updatedInput"]; ok {
+		t.Errorf("updatedInput must not be set in Codex response (Codex ignores it): %s", output)
+	}
+	reason, _ := hookOut["permissionDecisionReason"].(string)
+	if reason == "" {
+		t.Fatalf("permissionDecisionReason is empty")
+	}
+	return reason
+}
+
+func TestRunCodexDeniesSupportedCommand(t *testing.T) {
+	commands := []string{"git", "go"}
+	snipBin := "/usr/local/bin/snip"
+
+	input := makePayload("Bash", "git log -10")
+	var out bytes.Buffer
+	if err := RunCodex(strings.NewReader(input), &out, commands, snipBin); err != nil {
+		t.Fatalf("RunCodex: %v", err)
+	}
+	if out.Len() == 0 {
+		t.Fatal("expected deny output for supported command, got empty")
+	}
+
+	reason := extractDenyReason(t, out.String())
+	wantSuggestion := `"/usr/local/bin/snip" run -- git log -10`
+	if !strings.Contains(reason, wantSuggestion) {
+		t.Errorf("reason = %q, want it to contain %q", reason, wantSuggestion)
+	}
+}
+
+func TestRunCodexUnsupportedPassthrough(t *testing.T) {
+	commands := []string{"git", "go"}
+	snipBin := "/usr/local/bin/snip"
+
+	input := makePayload("Bash", "ls -la")
+	var out bytes.Buffer
+	if err := RunCodex(strings.NewReader(input), &out, commands, snipBin); err != nil {
+		t.Fatalf("RunCodex: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("expected no output for unsupported command, got: %s", out.String())
+	}
+}
+
+func TestRunCodexAlreadyRewritten(t *testing.T) {
+	commands := []string{"git"}
+	snipBin := "/usr/local/bin/snip"
+
+	already := `"/usr/local/bin/snip" run -- git status`
+	input := makePayload("Bash", already)
+	var out bytes.Buffer
+	if err := RunCodex(strings.NewReader(input), &out, commands, snipBin); err != nil {
+		t.Fatalf("RunCodex: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("expected no output for already-rewritten command, got: %s", out.String())
+	}
+}
+
+func TestRunCodexMultiSegmentSuggestionIncludesTail(t *testing.T) {
+	commands := []string{"git"}
+	snipBin := "/usr/local/bin/snip"
+
+	input := makePayload("Bash", "git add . && git commit -m 'fix'")
+	var out bytes.Buffer
+	if err := RunCodex(strings.NewReader(input), &out, commands, snipBin); err != nil {
+		t.Fatalf("RunCodex: %v", err)
+	}
+
+	reason := extractDenyReason(t, out.String())
+	wantSuggestion := `"/usr/local/bin/snip" run -- git add . && git commit -m 'fix'`
+	if !strings.Contains(reason, wantSuggestion) {
+		t.Errorf("reason = %q, want it to contain %q", reason, wantSuggestion)
+	}
+}
+
+func TestRunCodexEnvVarPrefix(t *testing.T) {
+	commands := []string{"go"}
+	snipBin := "/usr/local/bin/snip"
+
+	input := makePayload("Bash", "CGO_ENABLED=0 go test ./...")
+	var out bytes.Buffer
+	if err := RunCodex(strings.NewReader(input), &out, commands, snipBin); err != nil {
+		t.Fatalf("RunCodex: %v", err)
+	}
+
+	reason := extractDenyReason(t, out.String())
+	wantSuggestion := `CGO_ENABLED=0 "/usr/local/bin/snip" run -- go test ./...`
+	if !strings.Contains(reason, wantSuggestion) {
+		t.Errorf("reason = %q, want it to contain %q", reason, wantSuggestion)
+	}
+}
+
+func TestRunCodexNonBashTool(t *testing.T) {
+	commands := []string{"git"}
+	snipBin := "/usr/local/bin/snip"
+
+	payload := map[string]any{
+		"tool_name":  "Read",
+		"tool_input": map[string]any{"path": "/tmp/foo"},
+	}
+	data, _ := json.Marshal(payload)
+
+	var out bytes.Buffer
+	if err := RunCodex(strings.NewReader(string(data)), &out, commands, snipBin); err != nil {
+		t.Fatalf("RunCodex: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("expected no output for non-Bash tool, got: %s", out.String())
+	}
+}
+
+func TestRunCodexEmptyCommand(t *testing.T) {
+	commands := []string{"git"}
+	snipBin := "/usr/local/bin/snip"
+
+	input := makePayload("Bash", "")
+	var out bytes.Buffer
+	if err := RunCodex(strings.NewReader(input), &out, commands, snipBin); err != nil {
+		t.Fatalf("RunCodex: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("expected no output for empty command, got: %s", out.String())
+	}
+}
+
+func TestRunCodexMalformedJSON(t *testing.T) {
+	commands := []string{"git"}
+	snipBin := "/usr/local/bin/snip"
+
+	var out bytes.Buffer
+	if err := RunCodex(strings.NewReader("{invalid json"), &out, commands, snipBin); err != nil {
+		t.Fatalf("RunCodex must not error on malformed JSON: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("expected no output for malformed JSON, got: %s", out.String())
+	}
+}

--- a/internal/hookaudit/hookaudit.go
+++ b/internal/hookaudit/hookaudit.go
@@ -37,12 +37,17 @@ func LogPath() string {
 }
 
 // Event represents a single hook audit log entry.
+//
+// Agent identifies which integration produced the event ("claude-code",
+// "cursor", "codex", ...). Omitted on disk for legacy log lines and read
+// back as the empty string.
 type Event struct {
 	Timestamp time.Time `json:"timestamp"`
 	Command   string    `json:"command"`
 	Base      string    `json:"base"`
 	Matched   bool      `json:"matched"`
 	Rewritten bool      `json:"rewritten"`
+	Agent     string    `json:"agent,omitempty"`
 }
 
 // Append writes an event to the audit log as a JSONL line.

--- a/internal/initcmd/codex.go
+++ b/internal/initcmd/codex.go
@@ -1,0 +1,364 @@
+package initcmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+// codexHookSubcommand is the snip subsubcommand Codex invokes.
+const codexHookSubcommand = "hook codex"
+
+// codexConfigDir returns the Codex config directory for the given home.
+func codexConfigDir(home string) string {
+	return filepath.Join(home, ".codex")
+}
+
+// codexHooksPath returns the Codex hooks.json path for the given home.
+func codexHooksPath(home string) string {
+	return filepath.Join(codexConfigDir(home), "hooks.json")
+}
+
+// codexConfigPath returns the Codex config.toml path for the given home.
+func codexConfigPath(home string) string {
+	return filepath.Join(codexConfigDir(home), "config.toml")
+}
+
+// initCodex installs the snip Codex hook: writes ~/.codex/hooks.json with a
+// PreToolUse entry and patches ~/.codex/config.toml to set
+// [features].codex_hooks = true.
+func initCodex(snipBin, home, filterDir string) error {
+	if err := os.MkdirAll(codexConfigDir(home), 0o755); err != nil {
+		return fmt.Errorf("create codex config dir: %w", err)
+	}
+
+	hookCommand := snipBin + " " + codexHookSubcommand
+
+	hooksPath := codexHooksPath(home)
+	if err := patchCodexHooks(hooksPath, hookCommand); err != nil {
+		return fmt.Errorf("patch codex hooks: %w", err)
+	}
+
+	configPath := codexConfigPath(home)
+	res, err := patchCodexConfigToml(configPath, true)
+	if err != nil {
+		return fmt.Errorf("patch codex config.toml: %w", err)
+	}
+
+	legacyAgentsMd := detectLegacyAgentsMD(".")
+
+	fmt.Println("snip init complete:")
+	fmt.Printf("  agent: codex\n")
+	fmt.Printf("  hook: %s\n", hookCommand)
+	fmt.Printf("  filters: %s\n", filterDir)
+	fmt.Printf("  hooks: %s\n", hooksPath)
+	fmt.Printf("  config: %s ([features].codex_hooks=true)\n", configPath)
+	fmt.Println()
+	fmt.Println("note: Codex hooks require a recent Codex CLI release that supports")
+	fmt.Println("      the [features].codex_hooks flag. Codex denies matched commands")
+	fmt.Println("      with a re-run suggestion (transparent rewrite is tracked upstream:")
+	fmt.Println("      https://github.com/openai/codex/issues/18491). For older Codex")
+	fmt.Println("      releases use:  snip init --agent codex --mode prompt")
+	if res.backupWritten {
+		fmt.Printf("      original config.toml backed up to %s.bak (comments are not\n", configPath)
+		fmt.Println("      preserved by the TOML round-trip)")
+	}
+	if legacyAgentsMd != "" {
+		fmt.Printf("      legacy %s detected — remove with `snip init --agent codex --uninstall`\n", legacyAgentsMd)
+		fmt.Println("      or delete it manually if it has been edited or committed")
+	}
+
+	return nil
+}
+
+// uninstallCodex removes the snip entry from ~/.codex/hooks.json and flips
+// [features].codex_hooks to false in ~/.codex/config.toml. It also removes a
+// legacy AGENTS.md prompt file if it still matches the snip template.
+func uninstallCodex() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("get home dir: %w", err)
+	}
+
+	hooksPath := codexHooksPath(home)
+	if err := unpatchCodexHooks(hooksPath); err != nil {
+		return fmt.Errorf("unpatch codex hooks: %w", err)
+	}
+
+	configPath := codexConfigPath(home)
+	if _, err := patchCodexConfigToml(configPath, false); err != nil {
+		return fmt.Errorf("unpatch codex config.toml: %w", err)
+	}
+
+	// Best-effort cleanup of a legacy AGENTS.md.
+	if legacy := detectLegacyAgentsMD("."); legacy != "" {
+		_ = os.Remove(legacy)
+	}
+
+	fmt.Println("snip uninstalled (codex)")
+	return nil
+}
+
+// patchCodexHooks adds the snip hook to ~/.codex/hooks.json. Idempotent:
+// existing snip entries are updated in place; foreign entries are preserved.
+func patchCodexHooks(path, hookCommand string) error {
+	config, mode, err := readJSONMap(path)
+	if err != nil {
+		return err
+	}
+
+	snipMatcher := map[string]any{
+		"matcher": "Bash",
+		"hooks": []any{
+			map[string]any{"type": "command", "command": hookCommand},
+		},
+	}
+
+	hooks, _ := config["hooks"].(map[string]any)
+	if hooks == nil {
+		hooks = make(map[string]any)
+	}
+
+	var preToolUse []any
+	if existing, ok := hooks["PreToolUse"]; ok {
+		if arr, ok := existing.([]any); ok {
+			preToolUse = arr
+		}
+	}
+
+	found := false
+	for i, entry := range preToolUse {
+		if isSnipCodexEntry(entry) {
+			preToolUse[i] = snipMatcher
+			found = true
+			break
+		}
+	}
+	if !found {
+		preToolUse = append(preToolUse, snipMatcher)
+	}
+
+	hooks["PreToolUse"] = preToolUse
+	config["hooks"] = hooks
+
+	return writeJSONMap(path, config, mode)
+}
+
+// unpatchCodexHooks removes snip entries from ~/.codex/hooks.json.
+func unpatchCodexHooks(path string) error {
+	config, mode, err := readJSONMap(path)
+	if err != nil {
+		return err
+	}
+	if config == nil {
+		return nil
+	}
+
+	hooks, _ := config["hooks"].(map[string]any)
+	if hooks == nil {
+		return nil
+	}
+
+	existing, ok := hooks["PreToolUse"]
+	if !ok {
+		return nil
+	}
+	arr, ok := existing.([]any)
+	if !ok {
+		return nil
+	}
+
+	var filtered []any
+	for _, entry := range arr {
+		if !isSnipCodexEntry(entry) {
+			filtered = append(filtered, entry)
+		}
+	}
+
+	if len(filtered) == 0 {
+		delete(hooks, "PreToolUse")
+	} else {
+		hooks["PreToolUse"] = filtered
+	}
+	if len(hooks) == 0 {
+		delete(config, "hooks")
+	}
+
+	return writeJSONMap(path, config, mode)
+}
+
+// isSnipCodexEntry reports whether a Codex PreToolUse entry was installed by
+// snip. Detection looks for "snip hook codex" inside any nested hook command.
+func isSnipCodexEntry(entry any) bool {
+	m, ok := entry.(map[string]any)
+	if !ok {
+		return false
+	}
+	hooksRaw, ok := m["hooks"]
+	if !ok {
+		return false
+	}
+	hooksArr, ok := hooksRaw.([]any)
+	if !ok {
+		return false
+	}
+	for _, h := range hooksArr {
+		hm, ok := h.(map[string]any)
+		if !ok {
+			continue
+		}
+		cmd, _ := hm["command"].(string)
+		if strings.Contains(cmd, codexHookSubcommand) {
+			return true
+		}
+	}
+	return false
+}
+
+// errCodexHooksExplicitlyDisabled is returned when the user has set
+// [features].codex_hooks = false in config.toml and tries to install snip.
+// We refuse to silently flip their explicit choice.
+var errCodexHooksExplicitlyDisabled = errors.New(
+	"~/.codex/config.toml has [features].codex_hooks = false; " +
+		"set it to true (or remove the line) and re-run snip init")
+
+// configPatchResult reports the outcome of a config.toml patch so the
+// install summary can decide which warnings to print.
+type configPatchResult struct {
+	// noOp is true when the desired state already matched on disk and no
+	// write happened (comments preserved verbatim).
+	noOp bool
+	// backupWritten is true when an existing file was rewritten and a .bak
+	// was saved alongside. False for fresh installs (no original existed).
+	backupWritten bool
+}
+
+// patchCodexConfigToml sets [features].codex_hooks to enable.
+//
+// When enable is false (uninstall), the key is forced to false rather than
+// deleted so user intent is recorded explicitly.
+//
+// Returns errCodexHooksExplicitlyDisabled when the user has already pinned
+// codex_hooks=false and we'd be installing — we refuse to silently override.
+func patchCodexConfigToml(path string, enable bool) (configPatchResult, error) {
+	mode := os.FileMode(0o600)
+	data, err := os.ReadFile(path)
+	exists := err == nil
+	if err != nil && !os.IsNotExist(err) {
+		return configPatchResult{}, fmt.Errorf("read config.toml: %w", err)
+	}
+	if exists {
+		if info, statErr := os.Stat(path); statErr == nil {
+			mode = info.Mode().Perm()
+		}
+	} else {
+		data = nil
+	}
+
+	cfg := make(map[string]any)
+	if len(data) > 0 {
+		if err := toml.Unmarshal(data, &cfg); err != nil {
+			return configPatchResult{}, fmt.Errorf("parse config.toml: %w", err)
+		}
+	}
+
+	features, _ := cfg["features"].(map[string]any)
+	if features == nil {
+		features = make(map[string]any)
+	}
+
+	current, present := features["codex_hooks"]
+	currentBool, _ := current.(bool)
+
+	if enable {
+		if present && !currentBool {
+			return configPatchResult{}, errCodexHooksExplicitlyDisabled
+		}
+		if present && currentBool {
+			return configPatchResult{noOp: true}, nil
+		}
+		features["codex_hooks"] = true
+	} else {
+		if present && !currentBool {
+			return configPatchResult{noOp: true}, nil
+		}
+		features["codex_hooks"] = false
+	}
+	cfg["features"] = features
+
+	if exists {
+		_ = os.WriteFile(path+".bak", data, mode)
+	}
+
+	out, err := toml.Marshal(cfg)
+	if err != nil {
+		return configPatchResult{}, fmt.Errorf("marshal config.toml: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return configPatchResult{}, fmt.Errorf("create config dir: %w", err)
+	}
+	if err := os.WriteFile(path, out, mode); err != nil {
+		return configPatchResult{}, fmt.Errorf("write config.toml: %w", err)
+	}
+	return configPatchResult{backupWritten: exists}, nil
+}
+
+// detectLegacyAgentsMD returns the path to AGENTS.md in dir if its content
+// matches the snip prompt-injection template, or "" otherwise. Used to print
+// a migration hint without touching files the user may have edited.
+func detectLegacyAgentsMD(dir string) string {
+	path := filepath.Join(dir, "AGENTS.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	if !strings.Contains(string(data), "# Snip - CLI Token Optimizer") {
+		return ""
+	}
+	return path
+}
+
+// readJSONMap reads a JSON file as map[string]any, returning the discovered
+// file mode. A missing file yields an empty map and the default mode.
+// Writes a .bak alongside if the file is non-empty.
+func readJSONMap(path string) (map[string]any, os.FileMode, error) {
+	mode := os.FileMode(0o644)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return make(map[string]any), mode, nil
+		}
+		return nil, mode, fmt.Errorf("read %s: %w", filepath.Base(path), err)
+	}
+	if info, statErr := os.Stat(path); statErr == nil {
+		mode = info.Mode().Perm()
+	}
+	_ = os.WriteFile(path+".bak", data, mode)
+
+	m := make(map[string]any)
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &m); err != nil {
+			return nil, mode, fmt.Errorf("parse %s: %w", filepath.Base(path), err)
+		}
+	}
+	return m, mode, nil
+}
+
+// writeJSONMap writes the given map to path with indented JSON, creating the
+// parent directory if needed.
+func writeJSONMap(path string, m map[string]any, mode os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create dir: %w", err)
+	}
+	out, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	return os.WriteFile(path, out, mode)
+}

--- a/internal/initcmd/codex_test.go
+++ b/internal/initcmd/codex_test.go
@@ -1,0 +1,423 @@
+package initcmd
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+func TestPatchCodexHooksNew(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.json")
+	hookCommand := "/usr/local/bin/snip hook codex"
+
+	if err := patchCodexHooks(path, hookCommand); err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+
+	cfg := readSettings(t, path)
+	hooks, ok := cfg["hooks"].(map[string]any)
+	if !ok {
+		t.Fatal("hooks not found")
+	}
+	preToolUse, ok := hooks["PreToolUse"].([]any)
+	if !ok {
+		t.Fatal("PreToolUse not found or not array")
+	}
+	if len(preToolUse) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(preToolUse))
+	}
+	entry := preToolUse[0].(map[string]any)
+	if entry["matcher"] != "Bash" {
+		t.Errorf("matcher = %v, want Bash", entry["matcher"])
+	}
+	entryHooks := entry["hooks"].([]any)
+	hook := entryHooks[0].(map[string]any)
+	if hook["command"] != hookCommand {
+		t.Errorf("command = %v, want %s", hook["command"], hookCommand)
+	}
+}
+
+func TestPatchCodexHooksIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.json")
+	hookCommand := "/usr/local/bin/snip hook codex"
+
+	_ = patchCodexHooks(path, hookCommand)
+	_ = patchCodexHooks(path, hookCommand)
+
+	cfg := readSettings(t, path)
+	hooks := cfg["hooks"].(map[string]any)
+	preToolUse := hooks["PreToolUse"].([]any)
+	if len(preToolUse) != 1 {
+		t.Errorf("expected 1 entry after double patch, got %d", len(preToolUse))
+	}
+}
+
+func TestPatchCodexHooksPreservesForeignEntries(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.json")
+
+	existing := map[string]any{
+		"hooks": map[string]any{
+			"PreToolUse": []any{
+				map[string]any{
+					"matcher": "Bash",
+					"hooks": []any{
+						map[string]any{"type": "command", "command": "/opt/other/guard"},
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(existing, "", "  ")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := patchCodexHooks(path, "/usr/local/bin/snip hook codex"); err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+
+	cfg := readSettings(t, path)
+	preToolUse := cfg["hooks"].(map[string]any)["PreToolUse"].([]any)
+	if len(preToolUse) != 2 {
+		t.Fatalf("expected 2 entries (foreign + snip), got %d", len(preToolUse))
+	}
+	first := preToolUse[0].(map[string]any)
+	firstHooks := first["hooks"].([]any)
+	firstHook := firstHooks[0].(map[string]any)
+	if firstHook["command"] != "/opt/other/guard" {
+		t.Errorf("foreign entry not preserved: %v", firstHook["command"])
+	}
+}
+
+func TestUnpatchCodexHooksRemovesOnlySnip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.json")
+
+	existing := map[string]any{
+		"hooks": map[string]any{
+			"PreToolUse": []any{
+				map[string]any{
+					"matcher": "Bash",
+					"hooks": []any{
+						map[string]any{"type": "command", "command": "/opt/other/guard"},
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(existing, "", "  ")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_ = patchCodexHooks(path, "/usr/local/bin/snip hook codex")
+	if err := unpatchCodexHooks(path); err != nil {
+		t.Fatalf("unpatch: %v", err)
+	}
+
+	cfg := readSettings(t, path)
+	preToolUse := cfg["hooks"].(map[string]any)["PreToolUse"].([]any)
+	if len(preToolUse) != 1 {
+		t.Fatalf("expected 1 entry after unpatch, got %d", len(preToolUse))
+	}
+	remaining := preToolUse[0].(map[string]any)
+	hookEntry := remaining["hooks"].([]any)[0].(map[string]any)
+	if hookEntry["command"] != "/opt/other/guard" {
+		t.Errorf("foreign entry not preserved: %v", hookEntry["command"])
+	}
+}
+
+func TestPatchCodexConfigTomlNew(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	res, err := patchCodexConfigToml(path, true)
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	if res.noOp {
+		t.Error("noOp should be false for fresh write")
+	}
+	if res.backupWritten {
+		t.Error("backupWritten should be false for fresh install (no original to back up)")
+	}
+	if _, err := os.Stat(path + ".bak"); !os.IsNotExist(err) {
+		t.Error("no backup should be written when there was no original file")
+	}
+
+	got := readToml(t, path)
+	features, ok := got["features"].(map[string]any)
+	if !ok {
+		t.Fatalf("features section missing: %#v", got)
+	}
+	if v, _ := features["codex_hooks"].(bool); !v {
+		t.Errorf("codex_hooks = %v, want true", features["codex_hooks"])
+	}
+}
+
+func TestPatchCodexConfigTomlPreservesOtherKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	original := []byte(`model = "gpt-5"
+
+[features]
+some_other_flag = true
+
+[other]
+key = "value"
+`)
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := patchCodexConfigToml(path, true)
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	if res.noOp {
+		t.Error("noOp should be false when a write happened")
+	}
+	if !res.backupWritten {
+		t.Error("backupWritten should be true when an existing file was rewritten")
+	}
+
+	got := readToml(t, path)
+	if got["model"] != "gpt-5" {
+		t.Errorf("model = %v, want gpt-5", got["model"])
+	}
+	features := got["features"].(map[string]any)
+	if v, _ := features["some_other_flag"].(bool); !v {
+		t.Error("some_other_flag was dropped")
+	}
+	if v, _ := features["codex_hooks"].(bool); !v {
+		t.Error("codex_hooks not set")
+	}
+	other := got["other"].(map[string]any)
+	if other["key"] != "value" {
+		t.Errorf("other.key = %v, want value", other["key"])
+	}
+	bak, err := os.ReadFile(path + ".bak")
+	if err != nil {
+		t.Fatalf("backup not written: %v", err)
+	}
+	if string(bak) != string(original) {
+		t.Error("backup does not match original")
+	}
+}
+
+func TestPatchCodexConfigTomlAlreadyEnabledIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	original := []byte(`# user comment preserved
+[features]
+codex_hooks = true
+`)
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	infoBefore, _ := os.Stat(path)
+
+	res, err := patchCodexConfigToml(path, true)
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	if !res.noOp {
+		t.Error("noOp should be true for already-enabled state")
+	}
+	if res.backupWritten {
+		t.Error("backupWritten should be false for no-op")
+	}
+	infoAfter, _ := os.Stat(path)
+	if infoBefore.ModTime() != infoAfter.ModTime() {
+		t.Error("file should not have been rewritten")
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(original) {
+		t.Errorf("file was rewritten; comments lost. got:\n%s", got)
+	}
+	if _, err := os.Stat(path + ".bak"); !os.IsNotExist(err) {
+		t.Error("no backup should be written for no-op")
+	}
+}
+
+func TestPatchCodexConfigTomlExplicitOptOutRefused(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	if err := os.WriteFile(path, []byte("[features]\ncodex_hooks = false\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := patchCodexConfigToml(path, true)
+	if err == nil {
+		t.Fatal("expected error when codex_hooks is explicitly false")
+	}
+	if !errors.Is(err, errCodexHooksExplicitlyDisabled) {
+		t.Errorf("err = %v, want errCodexHooksExplicitlyDisabled", err)
+	}
+}
+
+func TestUnpatchCodexConfigTomlSetsFalse(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	if _, err := patchCodexConfigToml(path, true); err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	if _, err := patchCodexConfigToml(path, false); err != nil {
+		t.Fatalf("unpatch: %v", err)
+	}
+
+	got := readToml(t, path)
+	features, ok := got["features"].(map[string]any)
+	if !ok {
+		t.Fatalf("features missing")
+	}
+	if v, _ := features["codex_hooks"].(bool); v {
+		t.Errorf("codex_hooks = true after unpatch; want false")
+	}
+}
+
+func TestInitCodexEndToEnd(t *testing.T) {
+	home := t.TempDir()
+	filterDir := filepath.Join(home, ".config", "snip", "filters")
+	if err := os.MkdirAll(filterDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := initCodex("/usr/local/bin/snip", home, filterDir); err != nil {
+		t.Fatalf("initCodex: %v", err)
+	}
+
+	hooks := readSettings(t, codexHooksPath(home))
+	preToolUse := hooks["hooks"].(map[string]any)["PreToolUse"].([]any)
+	if len(preToolUse) != 1 {
+		t.Fatalf("expected 1 PreToolUse entry, got %d", len(preToolUse))
+	}
+	entryHooks := preToolUse[0].(map[string]any)["hooks"].([]any)
+	cmd := entryHooks[0].(map[string]any)["command"].(string)
+	if !strings.HasSuffix(cmd, " hook codex") {
+		t.Errorf("hook command = %q, want suffix ' hook codex'", cmd)
+	}
+
+	conf := readToml(t, codexConfigPath(home))
+	features := conf["features"].(map[string]any)
+	if v, _ := features["codex_hooks"].(bool); !v {
+		t.Errorf("codex_hooks = %v, want true", features["codex_hooks"])
+	}
+}
+
+func TestInitCodexThenUninstallSymmetric(t *testing.T) {
+	home := t.TempDir()
+	filterDir := filepath.Join(home, ".config", "snip", "filters")
+	_ = os.MkdirAll(filterDir, 0o755)
+
+	if err := initCodex("/usr/local/bin/snip", home, filterDir); err != nil {
+		t.Fatalf("initCodex: %v", err)
+	}
+
+	t.Setenv("HOME", home)
+	if err := uninstallCodex(); err != nil {
+		t.Fatalf("uninstallCodex: %v", err)
+	}
+
+	hooks := readSettings(t, codexHooksPath(home))
+	if h, ok := hooks["hooks"].(map[string]any); ok {
+		if _, ok := h["PreToolUse"]; ok {
+			t.Error("PreToolUse should be removed after uninstall")
+		}
+	}
+
+	conf := readToml(t, codexConfigPath(home))
+	features, ok := conf["features"].(map[string]any)
+	if !ok {
+		t.Fatal("features should exist with codex_hooks=false")
+	}
+	if v, _ := features["codex_hooks"].(bool); v {
+		t.Errorf("codex_hooks should be false after uninstall, got %v", v)
+	}
+}
+
+func TestDetectLegacyAgentsMD(t *testing.T) {
+	dir := t.TempDir()
+	if got := detectLegacyAgentsMD(dir); got != "" {
+		t.Errorf("detectLegacyAgentsMD on empty dir = %q, want empty", got)
+	}
+
+	// Foreign AGENTS.md
+	foreign := filepath.Join(dir, "AGENTS.md")
+	if err := os.WriteFile(foreign, []byte("# My project rules"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := detectLegacyAgentsMD(dir); got != "" {
+		t.Errorf("foreign AGENTS.md misdetected as legacy: %q", got)
+	}
+
+	// Snip-template AGENTS.md
+	if err := os.WriteFile(foreign, []byte(promptContent("/usr/local/bin/snip")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := detectLegacyAgentsMD(dir)
+	if got == "" {
+		t.Error("snip AGENTS.md not detected as legacy")
+	}
+}
+
+func TestParseModeFlag(t *testing.T) {
+	mode, remaining := parseMode([]string{"--mode", "prompt", "--uninstall"})
+	if mode != "prompt" {
+		t.Errorf("mode = %q, want prompt", mode)
+	}
+	if len(remaining) != 1 || remaining[0] != "--uninstall" {
+		t.Errorf("remaining = %v, want [--uninstall]", remaining)
+	}
+
+	mode, remaining = parseMode([]string{"--mode=hook"})
+	if mode != "hook" {
+		t.Errorf("mode = %q, want hook", mode)
+	}
+	if len(remaining) != 0 {
+		t.Errorf("remaining = %v, want empty", remaining)
+	}
+
+	mode, _ = parseMode([]string{})
+	if mode != "" {
+		t.Errorf("mode = %q, want empty", mode)
+	}
+}
+
+func TestRunRejectsUnknownMode(t *testing.T) {
+	err := Run([]string{"--agent", "codex", "--mode", "wat"})
+	if err == nil {
+		t.Fatal("expected error for unknown mode")
+	}
+	if !strings.Contains(err.Error(), "unknown mode") {
+		t.Errorf("err = %q, want to contain 'unknown mode'", err.Error())
+	}
+}
+
+func readToml(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read toml: %v", err)
+	}
+	out := make(map[string]any)
+	if err := toml.Unmarshal(data, &out); err != nil {
+		t.Fatalf("parse toml: %v", err)
+	}
+	return out
+}

--- a/internal/initcmd/init.go
+++ b/internal/initcmd/init.go
@@ -53,6 +53,26 @@ func parseAgent(args []string) (string, []string) {
 	return agent, remaining
 }
 
+// parseMode extracts the --mode value from args. Empty string means no
+// --mode flag was provided; the caller decides the per-agent default.
+func parseMode(args []string) (string, []string) {
+	mode := ""
+	var remaining []string
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--mode" && i+1 < len(args) {
+			mode = args[i+1]
+			i++
+		} else if strings.HasPrefix(arg, "--mode=") {
+			mode = strings.TrimPrefix(arg, "--mode=")
+		} else {
+			remaining = append(remaining, arg)
+		}
+	}
+	return mode, remaining
+}
+
 // isValidAgent checks if the given agent name is supported.
 func isValidAgent(name string) bool {
 	for _, a := range validAgents {
@@ -66,9 +86,14 @@ func isValidAgent(name string) bool {
 // Run installs the snip integration for the specified agent.
 func Run(args []string) error {
 	agent, remaining := parseAgent(args)
+	mode, remaining := parseMode(remaining)
 
 	if !isValidAgent(agent) {
 		return fmt.Errorf("unknown agent %q, valid agents: %s", agent, strings.Join(validAgents, ", "))
+	}
+
+	if mode != "" && mode != "hook" && mode != "prompt" {
+		return fmt.Errorf("unknown mode %q, valid modes: hook, prompt", mode)
 	}
 
 	for _, arg := range remaining {
@@ -99,7 +124,14 @@ func Run(args []string) error {
 		return initClaudeCode(snipBin, home, filterDir)
 	case "cursor":
 		return initCursor(snipBin, home, filterDir)
-	case "codex", "windsurf", "cline", "copilot", "gemini", "kilocode", "antigravity":
+	case "codex":
+		// Codex defaults to runtime hooks; --mode prompt selects the legacy
+		// AGENTS.md prompt-injection path for older Codex releases.
+		if mode == "prompt" {
+			return initPromptAgent(agent, snipBin, filterDir)
+		}
+		return initCodex(snipBin, home, filterDir)
+	case "windsurf", "cline", "copilot", "gemini", "kilocode", "antigravity":
 		return initPromptAgent(agent, snipBin, filterDir)
 	}
 	return nil
@@ -221,7 +253,9 @@ func Uninstall(agent string) error {
 		return uninstallClaudeCode()
 	case "cursor":
 		return uninstallCursor()
-	case "codex", "windsurf", "cline", "copilot", "gemini", "kilocode", "antigravity":
+	case "codex":
+		return uninstallCodex()
+	case "windsurf", "cline", "copilot", "gemini", "kilocode", "antigravity":
 		return uninstallPromptAgent(agent)
 	}
 	return nil


### PR DESCRIPTION
`snip init --agent codex` now installs a real runtime hook in
~/.codex/hooks.json and enables [features].codex_hooks in
~/.codex/config.toml, replacing the prompt-injection AGENTS.md as the
default. Codex's PreToolUse cannot rewrite commands in-place
(openai/codex#18491), so the new `snip hook codex` handler responds with
permissionDecision=deny and a re-run suggestion. Use `--mode prompt` to
keep the legacy AGENTS.md flow on older Codex releases.

The install summary calls out the deny-with-suggestion limitation, the
TOML round-trip caveat (a .bak is written when an existing config.toml
is rewritten), and an explicit codex_hooks=false opt-out is refused
rather than silently overridden.

The hookaudit Event gains an optional Agent field so per-agent activity
is distinguishable in the log.