### PR TITLE
fix(filters): bypass --version/-V on filters with keep_lines (#59)

### DIFF
--- a/filters/biome.yaml
+++ b/filters/biome.yaml
@@ -4,6 +4,7 @@ description: "Condensed biome output: lint/format diagnostics"
 
 match:
   command: "biome"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/brew-install.yaml
+++ b/filters/brew-install.yaml
@@ -4,6 +4,7 @@ description: "Condensed brew output: install/update summary"
 
 match:
   command: "brew"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/composer-install.yaml
+++ b/filters/composer-install.yaml
@@ -4,6 +4,7 @@ description: "Condensed composer output: install summary"
 
 match:
   command: "composer"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/liquibase.yaml
+++ b/filters/liquibase.yaml
@@ -4,6 +4,7 @@ description: "Condensed liquibase output: migration status"
 
 match:
   command: "liquibase"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/next-build.yaml
+++ b/filters/next-build.yaml
@@ -4,6 +4,7 @@ description: "Condensed next.js build output: pages and errors"
 
 match:
   command: "next"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/oxlint.yaml
+++ b/filters/oxlint.yaml
@@ -4,6 +4,7 @@ description: "Condensed oxlint output: lint issues"
 
 match:
   command: "oxlint"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/ping.yaml
+++ b/filters/ping.yaml
@@ -4,6 +4,7 @@ description: "Condensed ping output: statistics only"
 
 match:
   command: "ping"
+  exclude_flags: ["--version", "-V"]
 
 pipeline:
   - action: "keep_lines"

--- a/filters/pio.yaml
+++ b/filters/pio.yaml
@@ -4,6 +4,7 @@ description: "Condensed PlatformIO output: build result"
 
 match:
   command: "pio"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/playwright.yaml
+++ b/filters/playwright.yaml
@@ -4,6 +4,7 @@ description: "Condensed playwright output: test results and failures"
 
 match:
   command: "playwright"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/poetry-install.yaml
+++ b/filters/poetry-install.yaml
@@ -4,6 +4,7 @@ description: "Condensed poetry output: install summary"
 
 match:
   command: "poetry"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/pytest.yaml
+++ b/filters/pytest.yaml
@@ -4,7 +4,7 @@ description: "Condensed pytest output: failures with locations and summary line"
 
 match:
   command: "pytest"
-  exclude_flags: ["--tb=no", "--co", "--collect-only"]
+  exclude_flags: ["--tb=no", "--co", "--collect-only", "--version", "-V"]
 
 inject:
   args: ["--tb=line", "-q"]

--- a/filters/rspec.yaml
+++ b/filters/rspec.yaml
@@ -4,7 +4,7 @@ description: "Condensed RSpec output with pass/fail summary"
 
 match:
   command: "rspec"
-  exclude_flags: ["--format", "-f"]
+  exclude_flags: ["--format", "-f", "--version", "-V"]
 
 pipeline:
   - action: "keep_lines"

--- a/filters/rsync.yaml
+++ b/filters/rsync.yaml
@@ -4,6 +4,7 @@ description: "Condensed rsync output: transfer summary"
 
 match:
   command: "rsync"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/spring-boot.yaml
+++ b/filters/spring-boot.yaml
@@ -4,6 +4,7 @@ description: "Condensed spring-boot output: startup and errors"
 
 match:
   command: "spring-boot"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/swift-build.yaml
+++ b/filters/swift-build.yaml
@@ -4,6 +4,7 @@ description: "Condensed swift build output: errors and warnings"
 
 match:
   command: "swift"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/systemctl.yaml
+++ b/filters/systemctl.yaml
@@ -4,6 +4,7 @@ description: "Condensed systemctl output: service status"
 
 match:
   command: "systemctl"
+  exclude_flags: ["--version", "-V"]
 
 pipeline:
   - action: "strip_ansi"

--- a/filters/trunk-build.yaml
+++ b/filters/trunk-build.yaml
@@ -4,6 +4,7 @@ description: "Condensed trunk build output"
 
 match:
   command: "trunk"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/turbo.yaml
+++ b/filters/turbo.yaml
@@ -4,6 +4,7 @@ description: "Condensed turborepo output: task results summary"
 
 match:
   command: "turbo"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/uv-sync.yaml
+++ b/filters/uv-sync.yaml
@@ -4,6 +4,7 @@ description: "Condensed uv output: install summary"
 
 match:
   command: "uv"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/vitest.yaml
+++ b/filters/vitest.yaml
@@ -4,6 +4,7 @@ description: "Condensed vitest output: test results and failures"
 
 match:
   command: "vitest"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/wget.yaml
+++ b/filters/wget.yaml
@@ -4,6 +4,7 @@ description: "Condensed wget output: download summary"
 
 match:
   command: "wget"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout

--- a/filters/xcodebuild.yaml
+++ b/filters/xcodebuild.yaml
@@ -4,6 +4,7 @@ description: "Condensed xcodebuild output: build result and errors"
 
 match:
   command: "xcodebuild"
+  exclude_flags: ["--version", "-V"]
 
 streams:
   - stdout


### PR DESCRIPTION
## Summary

- Adds `exclude_flags: ["--version", "-V"]` to 22 filters whose pipelines use `keep_lines` and were silently swallowing `<cmd> --version` output.
- Merges into existing `exclude_flags` for `pytest.yaml` and `rspec.yaml` (no replacement).
- No Go code changes — fix is data-only.

## Why these 22 specifically

The contributor of #59 listed 66 filters as affected. After investigation, only the 22 whose pipeline contains `keep_lines` actually exhibit the swallow behavior:

`biome, brew-install, composer-install, liquibase, next-build, oxlint, ping, pio, playwright, poetry-install, pytest, rspec, rsync, spring-boot, swift-build, systemctl, trunk-build, turbo, uv-sync, vitest, wget, xcodebuild`

The other ~44 filters do match `<cmd> --version` but their pipelines (`strip_ansi` + `truncate_lines` + `head` + `compact_path`) pass the version line through unchanged. Touching them would be churn without observable benefit.

The pattern follows the 23 reference filters already using `exclude_flags: ["--version", "-V"]` (pip-install, eslint, jest, mvn, npm-install, tsc, ...).

## Out of scope (separate issues)

- Filters like `next-build.yaml`, `swift-build.yaml`, `kubectl-get.yaml`, `xcodebuild.yaml` that are named for a subcommand but lack `match.subcommand` (matches the whole base command). This is a different design issue.
- Phantom `-V` on a few pre-existing filters (e.g., `swift -V` → unknown argument) — cleanup for a separate PR.

## Test plan

- [x] `go test ./internal/filter/...` — 93 passed, 0 failed
- [x] `golangci-lint run` — 0 issues
- [x] `make test-race` — all packages OK
- [x] `snip check` on the 22 `<cmd> --version` invocations → `no filter: excluded by flags`
- [x] `snip check` on 3 `-V` variants (`uv -V`, `pytest -V`, `rspec -V`) → bypass confirmed
- [x] Non-regression: `uv sync`, `pytest tests/`, `next build`, `turbo run build`, `swift build`, `rspec spec/` still match their filter
- [x] Empirical reproduction with a fake `uv` binary: before the fix `snip uv --version` returns empty; after the fix the version line passes through

Fixes #59