### PR TITLE
feat(filters): add gradlew filter and ./ prefix normalization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ The binary (snip) is the engine. Filters are data files. The two evolve independ
 ```
 cmd/snip/main.go        # Entry point
 embed.go                # Embedded default filters (go:embed)
-filters/*.yaml          # Declarative filter definitions (126 filters)
+filters/*.yaml          # Declarative filter definitions (127 filters)
 internal/
   cli/                  # CLI routing, flag parsing
   config/               # TOML config loading (~/.config/snip/config.toml)

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ snip init
 
 This installs a `PreToolUse` hook that transparently rewrites supported commands. Claude Code never sees the substitution -- it receives compressed output as if the original command produced it.
 
-Supported commands: 126 filters covering git, go, cargo, npm, yarn, pnpm, docker, kubectl, terraform, aws, gh, and 80+ more tools.
+Supported commands: 127 filters covering git, go, cargo, npm, yarn, pnpm, docker, kubectl, terraform, aws, gh, and 80+ more tools.
 
 ```bash
 snip init --uninstall   # remove the hook
@@ -316,9 +316,9 @@ pipeline:
 on_error: "passthrough"
 ```
 
-### 126 Built-in Filters
+### 127 Built-in Filters
 
-snip ships with **126 declarative YAML filters** covering all major developer tools:
+snip ships with **127 declarative YAML filters** covering all major developer tools:
 
 | Category | Filters |
 |----------|---------|
@@ -332,7 +332,7 @@ snip ships with **126 declarative YAML filters** covering all major developer to
 | **.NET** (3) | dotnet build/test/format |
 | **Docker/K8s** (7) | docker build/ps/images/logs/compose, kubectl get/logs |
 | **Cloud/Infra** (6) | terraform, tofu, helm, ansible-playbook, gcloud, aws |
-| **Build tools** (12) | make, gcc, g++, gradle, mvn, swift, xcodebuild, just, task, pio, trunk, mise |
+| **Build tools** (13) | make, gcc, g++, gradle, gradlew, mvn, swift, xcodebuild, just, task, pio, trunk, mise |
 | **Files/Search** (7) | ls, find, grep, rg, diff, wc, tree |
 | **Linting** (5) | shellcheck, hadolint, markdownlint, yamllint, pre-commit |
 | **Package managers** (4) | brew, composer, poetry, uv |

--- a/filters/gradlew.yaml
+++ b/filters/gradlew.yaml
@@ -1,0 +1,24 @@
+name: "gradlew"
+version: 1
+description: "Condensed gradle wrapper output: build result and errors"
+
+match:
+  command: "gradlew"
+  exclude_flags: ["--version", "-V"]
+
+streams:
+  - stdout
+  - stderr
+
+pipeline:
+  - action: "strip_ansi"
+  - action: "remove_lines"
+    pattern: "(^> Task |^\\s*$|^Downloading|^\\.\\.\\.|^Starting)"
+  - action: "keep_lines"
+    pattern: "(BUILD|FAILURE|ERROR|error:|warning:|FAILED|UP-TO-DATE|actionable|Test result)"
+  - action: "truncate_lines"
+    max: 120
+  - action: "head"
+    n: 40
+
+on_error: "passthrough"

--- a/internal/filter/registry.go
+++ b/internal/filter/registry.go
@@ -29,6 +29,10 @@ func NewRegistry(filters []Filter) *Registry {
 
 // Match finds the first filter matching the given command, subcommand, and args.
 func (r *Registry) Match(command, subcommand string, args []string) *Filter {
+	// Strip a leading "./" so wrapper invocations (e.g. ./gradlew) match
+	// filters keyed on the bare name.
+	command = strings.TrimPrefix(command, "./")
+
 	// Include subcommand in flag matching so that exclude_flags like
 	// "--version" are detected even when they appear as the first arg
 	// (which pipeline.go extracts as subcommand).
@@ -118,6 +122,7 @@ func (r *Registry) ShouldInject(f *Filter, args []string) ([]string, bool) {
 // and subcommand, regardless of flag constraints. Use this to distinguish
 // "no filter at all" from "filter exists but was excluded by flags".
 func (r *Registry) HasAnyFilter(command, subcommand string) bool {
+	command = strings.TrimPrefix(command, "./")
 	if subcommand != "" {
 		if _, ok := r.byKey[command+":"+subcommand]; ok {
 			return true
@@ -132,6 +137,7 @@ func (r *Registry) HasAnyFilter(command, subcommand string) bool {
 // avoid the misleading "no filter for git" hint when "git" has filters for
 // other subcommands (e.g. git-commit) but not for the one being run.
 func (r *Registry) HasAnyFilterForCommand(command string) bool {
+	command = strings.TrimPrefix(command, "./")
 	if _, ok := r.byKey[command]; ok {
 		return true
 	}

--- a/internal/filter/registry_test.go
+++ b/internal/filter/registry_test.go
@@ -33,6 +33,7 @@ func TestRegistryMatch(t *testing.T) {
 		{"go", "test", nil, "go-test", false},
 		{"git", "push", nil, "", true},
 		{"npm", "install", nil, "", true},
+		{"./go", "test", nil, "go-test", false},
 	}
 
 	for _, tt := range tests {
@@ -201,6 +202,25 @@ func TestHasAnyFilterForCommand(t *testing.T) {
 	})
 	if !regCmdOnly.HasAnyFilterForCommand("npm") {
 		t.Error("HasAnyFilterForCommand should return true for npm (command-only filter)")
+	}
+}
+
+func TestRegistryDotSlashWrapper(t *testing.T) {
+	// Wrapper scripts invoked from the project root (./gradlew, ./mvnw) must
+	// match filters keyed on the bare name.
+	filters := []Filter{
+		{Name: "gradlew", Version: 1, Match: Match{Command: "gradlew"}, OnError: "passthrough"},
+	}
+	reg := NewRegistry(filters)
+
+	if f := reg.Match("./gradlew", "", nil); f == nil || f.Name != "gradlew" {
+		t.Errorf("Match(./gradlew) should resolve to gradlew filter, got %v", f)
+	}
+	if !reg.HasAnyFilter("./gradlew", "") {
+		t.Error("HasAnyFilter(./gradlew) should return true")
+	}
+	if !reg.HasAnyFilterForCommand("./gradlew") {
+		t.Error("HasAnyFilterForCommand(./gradlew) should return true")
 	}
 }
 

--- a/internal/hook/parse.go
+++ b/internal/hook/parse.go
@@ -91,15 +91,18 @@ func ParseSegment(segment string) (prefix, envVars, bareCmd string) {
 }
 
 // BaseCommand extracts the first word (executable name) from a command string.
+// Strips a leading "./" so that wrapper scripts invoked from the project root
+// (e.g. ./gradlew, ./mvnw) match filters keyed on the bare name.
 func BaseCommand(cmd string) string {
 	trimmed := strings.TrimLeft(cmd, " \t")
-	// Find first space or tab
+	end := len(trimmed)
 	for i := 0; i < len(trimmed); i++ {
 		if trimmed[i] == ' ' || trimmed[i] == '\t' {
-			return trimmed[:i]
+			end = i
+			break
 		}
 	}
-	return trimmed
+	return strings.TrimPrefix(trimmed[:end], "./")
 }
 
 // isEnvVarName checks if s is a valid environment variable name: [A-Za-z_][A-Za-z0-9_]*

--- a/internal/hook/parse_test.go
+++ b/internal/hook/parse_test.go
@@ -79,6 +79,8 @@ func TestBaseCommand(t *testing.T) {
 		{"empty", "", ""},
 		{"path", "/usr/bin/git status", "/usr/bin/git"},
 		{"quoted path", `"/usr/local/bin/snip" -- git`, `"/usr/local/bin/snip"`},
+		{"dot slash wrapper", "./gradlew build", "gradlew"},
+		{"dot slash with leading space", "  ./mvnw clean", "mvnw"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `filters/gradlew.yaml` mirroring the gradle pipeline, keyed on `command: "gradlew"`
- Normalizes a leading `./` in the command matcher so wrapper scripts invoked from the project root (e.g. `./gradlew build`) resolve to filters keyed on the bare name. Benefits any future wrapper filter (`./mvnw`, etc.)
- Doc bumps: filter count 126 → 127 across `CLAUDE.md`, `README.md`

Closes #63

Thanks @emartynov for the suggestion.

## Test plan

- [x] `make test` — green
- [x] `make test-race` — green
- [x] `make lint` — 0 issues
- [x] Added `TestRegistryDotSlashWrapper` covering `./gradlew` via `Match`, `HasAnyFilter`, `HasAnyFilterForCommand`
- [x] Added `BaseCommand` test cases for `./gradlew build` and `  ./mvnw clean`