### PR TITLE
feat: project-level .snip/config.toml for corporate/team deployment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ goreleaser release --snapshot --clean          # Test release build locally
 ## Build Variants
 
 Two build modes via Go build tags:
+
 - **Full** (default): includes `modernc.org/sqlite` for token tracking via `internal/tracking/driver.go`
 - **Lite** (`-tags lite`): excludes SQLite, uses `driver_lite.go` stub — startup ~3ms faster
 
@@ -83,8 +84,8 @@ Tests requiring SQLite must have `//go:build !lite` tag. Check `tracking.DriverA
 
 ## Filter DSL
 
-Filters are declarative YAML files with 19 built-in actions:
-`keep_lines`, `remove_lines`, `truncate_lines`, `strip_ansi`, `head`, `tail`,
+Filters are declarative YAML files with 20 built-in actions:
+`keep_lines`, `remove_lines`, `truncate_lines`, `truncate_bytes`, `strip_ansi`, `head`, `tail`,
 `group_by`, `dedup`, `json_extract`, `json_schema`, `ndjson_stream`,
 `regex_extract`, `state_machine`, `aggregate`, `format_template`, `compact_path`,
 `replace`, `match_output`, `on_empty`
@@ -97,6 +98,7 @@ A push of any `v*` tag triggers CI to build cross-platform binaries and create a
 ### Semver Tagging
 
 Every push that changes behavior **must** include a version tag:
+
 - **Patch** (`v0.1.1`): bug fixes, no API change
 - **Minor** (`v0.2.0`): new features, backward-compatible
 - **Major** (`v1.0.0`): breaking changes

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -308,6 +308,16 @@ func runPipeline(command string, args []string, flags Flags) int {
 		cfg = config.DefaultConfig()
 	}
 
+	// Load merged user+project config for filter overrides, bypass, and global
+	// limits. Gracefully defaults to user-only if no .snip/config.toml exists.
+	projectCfg, err := config.LoadMerged()
+	if err != nil && flags.Verbose > 0 {
+		fmt.Fprintf(os.Stderr, "snip: project config error: %v\n", err)
+	}
+	if projectCfg == nil {
+		projectCfg = cfg
+	}
+
 	filters, err := filter.LoadAll(cfg.Filters.Dirs())
 	if err != nil {
 		display.PrintError(fmt.Sprintf("load filters: %v", err))
@@ -338,6 +348,7 @@ func runPipeline(command string, args []string, flags Flags) int {
 		UltraCompact:  flags.UltraCompact,
 		QuietNoFilter: cfg.Display.QuietNoFilter,
 		FilterEnabled: cfg.Filters.Enable,
+		Config:        projectCfg,
 	}
 
 	return pipeline.Run(command, args)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -347,7 +347,7 @@ func runPipeline(command string, args []string, flags Flags) int {
 		Verbose:       flags.Verbose,
 		UltraCompact:  flags.UltraCompact,
 		QuietNoFilter: cfg.Display.QuietNoFilter,
-		FilterEnabled: cfg.Filters.Enable,
+		FilterEnabled: projectCfg.Filters.Enable,
 		Config:        projectCfg,
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -218,10 +218,14 @@ func projectConfigPath() string {
 	if err != nil {
 		return ""
 	}
-	for dir := cwd; dir != "/" && dir != "."; dir = filepath.Dir(dir) {
+	for dir := cwd; ; dir = filepath.Dir(dir) {
 		cfg := filepath.Join(dir, ".snip", "config.toml")
 		if _, err := os.Stat(cfg); err == nil {
 			return cfg
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break // reached root on this platform
 		}
 	}
 	return ""

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,12 +1,15 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 
 	toml "github.com/pelletier/go-toml/v2"
+
+	"github.com/edouard-claude/snip/internal/trust"
 )
 
 var envVarRe = regexp.MustCompile(`\$\{env\.(\w+)\}`)
@@ -245,13 +248,24 @@ func LoadMerged() (*Config, error) {
 		return user, nil // no project config — user only
 	}
 
+	// Trust gate: project configs must be explicitly trusted via `snip trust`.
+	// Without this guard, any cloned repo could ship a .snip/config.toml that
+	// disables filtering, injects ReDoS regex, or adds bypass commands.
+	store, err := trust.Load()
+	if err != nil {
+		return user, nil // no trust store = no project configs trusted
+	}
+	if !trust.IsTrusted(store, projectPath) {
+		return user, nil // untrusted: silently fall back to user config only
+	}
+
 	project := DefaultConfig()
 	data, err := os.ReadFile(projectPath)
 	if err != nil {
 		return user, nil
 	}
 	if err := toml.Unmarshal(data, project); err != nil {
-		return user, nil
+		return nil, fmt.Errorf("parse project config %s: %w", projectPath, err)
 	}
 
 	// Default mode is "user" — developer's personal config wins conflicts
@@ -268,7 +282,14 @@ func LoadMerged() (*Config, error) {
 			merged.Filters.Enable[k] = v
 		}
 		// Global limits: project wins entirely
-		if project.Filters.Global.MaxLines > 0 || project.Filters.Global.MaxLineLength > 0 || project.Filters.Global.StreamMode != "" {
+		if project.Filters.Global.MaxLines > 0 || project.Filters.Global.MaxLineLength > 0 || project.Filters.Global.MaxOutputBytes > 0 || project.Filters.Global.StreamMode != "" {
+			merged.Filters.Global = project.Filters.Global
+		}
+		for k, v := range project.Filters.Enable {
+			merged.Filters.Enable[k] = v
+		}
+		// Global limits: project wins entirely
+		if project.Filters.Global.MaxLines > 0 || project.Filters.Global.MaxLineLength > 0 || project.Filters.Global.MaxOutputBytes > 0 || project.Filters.Global.StreamMode != "" {
 			merged.Filters.Global = project.Filters.Global
 		}
 		// Per-filter overrides: project wins

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -282,11 +282,6 @@ func LoadMerged() (*Config, error) {
 	return merged, nil
 }
 
-// expandDir tries to umarshal array dir (existing, unchanged).
-func expandDir(data []byte, cfg *Config) bool {
-	return tryUnmarshalArrayDir(data, cfg)
-}
-
 func configPath() string {
 	if p := os.Getenv("SNIP_CONFIG"); p != "" {
 		return p

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -240,7 +240,13 @@ func projectConfigPath() string {
 func LoadMerged() (*Config, error) {
 	user, err := Load()
 	if err != nil {
-		return DefaultConfig(), nil
+		// If user config file is missing, use defaults (normal for new installs).
+		// Other errors (permission, corrupt TOML) propagate to the caller so the
+		// user knows something is wrong with their config.
+		if os.IsNotExist(err) {
+			return DefaultConfig(), nil
+		}
+		return nil, fmt.Errorf("load user config: %w", err)
 	}
 
 	projectPath := projectConfigPath()
@@ -277,13 +283,6 @@ func LoadMerged() (*Config, error) {
 		// Enable/disable: project keys win for shared names
 		if merged.Filters.Enable == nil {
 			merged.Filters.Enable = make(map[string]bool)
-		}
-		for k, v := range project.Filters.Enable {
-			merged.Filters.Enable[k] = v
-		}
-		// Global limits: project wins entirely
-		if project.Filters.Global.MaxLines > 0 || project.Filters.Global.MaxLineLength > 0 || project.Filters.Global.MaxOutputBytes > 0 || project.Filters.Global.StreamMode != "" {
-			merged.Filters.Global = project.Filters.Global
 		}
 		for k, v := range project.Filters.Enable {
 			merged.Filters.Enable[k] = v

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -257,11 +257,14 @@ func LoadMerged() (*Config, error) {
 	// When project mode is active, project overrides user for filter sections
 	if project.Mode == "project" {
 		// Enable/disable: project keys win for shared names
+		if merged.Filters.Enable == nil {
+			merged.Filters.Enable = make(map[string]bool)
+		}
 		for k, v := range project.Filters.Enable {
 			merged.Filters.Enable[k] = v
 		}
 		// Global limits: project wins entirely
-		if project.Filters.Global.MaxLines > 0 || project.Filters.Global.StreamMode != "" {
+		if project.Filters.Global.MaxLines > 0 || project.Filters.Global.MaxLineLength > 0 || project.Filters.Global.StreamMode != "" {
 			merged.Filters.Global = project.Filters.Global
 		}
 		// Per-filter overrides: project wins

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -278,8 +278,10 @@ func LoadMerged() (*Config, error) {
 		}
 	}
 
-	// Bypass list merges from both sides (no override)
-	merged.Filters.Bypass.Commands = append(user.Filters.Bypass.Commands,
+	// Bypass list merges from both sides (no override).
+	// Force fresh slice to avoid reusing user's backing array on double-call.
+	merged.Filters.Bypass.Commands = append([]string{}, user.Filters.Bypass.Commands...)
+	merged.Filters.Bypass.Commands = append(merged.Filters.Bypass.Commands,
 		project.Filters.Bypass.Commands...)
 
 	return merged, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 var envVarRe = regexp.MustCompile(`\$\{env\.(\w+)\}`)
 
 type Config struct {
+	Mode     string         `toml:"mode"` // "user" (default) or "project"
 	Tracking TrackingConfig `toml:"tracking"`
 	Display  DisplayConfig  `toml:"display"`
 	Filters  FiltersConfig  `toml:"filters"`
@@ -29,8 +30,34 @@ type DisplayConfig struct {
 }
 
 type FiltersConfig struct {
-	Dir    any             `toml:"dir"`
-	Enable map[string]bool `toml:"enable"`
+	Dir      any                       `toml:"dir"`
+	Enable   map[string]bool           `toml:"enable"`
+	Global   FilterGlobalConfig        `toml:"global"`
+	Override map[string]FilterOverride `toml:"override"`
+	Bypass   FilterBypassConfig        `toml:"bypass"`
+}
+
+// FilterGlobalConfig applies to all filters in the pipeline.
+type FilterGlobalConfig struct {
+	MaxLines       int    `toml:"max_lines"`        // 0 = unlimited
+	MaxLineLength  int    `toml:"max_line_length"`  // 0 = unlimited
+	MaxOutputBytes int    `toml:"max_output_bytes"` // 0 = unlimited
+	StreamMode     string `toml:"stream_mode"`      // "filter" | "full"
+}
+
+// FilterOverride overrides specific pipeline action parameters for a named filter.
+type FilterOverride struct {
+	Head          int    `toml:"head"`
+	Tail          int    `toml:"tail"`
+	TruncateLines int    `toml:"truncate_lines"`
+	KeepLines     string `toml:"keep_lines"`
+	RemoveLines   string `toml:"remove_lines"`
+	StreamMode    string `toml:"stream_mode"` // "full" = skip the entire pipeline
+}
+
+// FilterBypassConfig contains commands that should always bypass filtering.
+type FilterBypassConfig struct {
+	Commands []string `toml:"commands"`
 }
 
 // Dirs returns the filter directories as a normalized string slice.
@@ -181,6 +208,83 @@ func expandEnvVars(s string) string {
 		name := match[6 : len(match)-1]
 		return os.Getenv(name)
 	})
+}
+
+// projectConfigPath walks upward from the current working directory looking
+// for a .snip/config.toml file. Returns the first match found (closest to
+// CWD takes priority). Returns an empty string if no project config exists.
+func projectConfigPath() string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	for dir := cwd; dir != "/" && dir != "."; dir = filepath.Dir(dir) {
+		cfg := filepath.Join(dir, ".snip", "config.toml")
+		if _, err := os.Stat(cfg); err == nil {
+			return cfg
+		}
+	}
+	return ""
+}
+
+// LoadMerged loads the user config, then layers the project config on top.
+// When mode == "project", the project config's filter settings override the
+// user's. When mode == "user" (default), user settings take priority.
+func LoadMerged() (*Config, error) {
+	user, err := Load()
+	if err != nil {
+		return DefaultConfig(), nil
+	}
+
+	projectPath := projectConfigPath()
+	if projectPath == "" {
+		return user, nil // no project config — user only
+	}
+
+	project := DefaultConfig()
+	data, err := os.ReadFile(projectPath)
+	if err != nil {
+		return user, nil
+	}
+	if err := toml.Unmarshal(data, project); err != nil {
+		return user, nil
+	}
+
+	// Default mode is "user" — developer's personal config wins conflicts
+	merged := user
+	merged.Mode = project.Mode
+
+	// When project mode is active, project overrides user for filter sections
+	if project.Mode == "project" {
+		// Enable/disable: project keys win for shared names
+		for k, v := range project.Filters.Enable {
+			merged.Filters.Enable[k] = v
+		}
+		// Global limits: project wins entirely
+		if project.Filters.Global.MaxLines > 0 || project.Filters.Global.StreamMode != "" {
+			merged.Filters.Global = project.Filters.Global
+		}
+		// Per-filter overrides: project wins
+		if project.Filters.Override != nil {
+			if merged.Filters.Override == nil {
+				merged.Filters.Override = make(map[string]FilterOverride)
+			}
+			for k, v := range project.Filters.Override {
+				merged.Filters.Override[k] = v
+			}
+		}
+	}
+
+	// Bypass list merges from both sides (no override)
+	merged.Filters.Bypass.Commands = append(user.Filters.Bypass.Commands,
+		project.Filters.Bypass.Commands...)
+
+	return merged, nil
+}
+
+// expandDir tries to umarshal array dir (existing, unchanged).
+func expandDir(data []byte, cfg *Config) bool {
+	return tryUnmarshalArrayDir(data, cfg)
 }
 
 func configPath() string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/edouard-claude/snip/internal/trust"
 )
 
 func TestDefaultConfig(t *testing.T) {
@@ -368,6 +370,18 @@ git-diff = false
 		t.Fatal(err)
 	}
 
+	// Trust the project config so the trust gate passes
+	projectCfgPath := filepath.Join(projectDir, ".snip", "config.toml")
+	trustStore := make(trust.Store)
+	hash, err := trust.HashFile(projectCfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	trustStore[projectCfgPath] = hash
+	if err := trust.SaveTo(trustStore, filepath.Join(home, ".config", "snip", "trusted.json")); err != nil {
+		t.Fatal(err)
+	}
+
 	t.Setenv("HOME", home)
 	t.Setenv("SNIP_CONFIG", userPath)
 	oldWd, _ := os.Getwd()
@@ -424,6 +438,18 @@ max_line_length = 80
 stream_mode = "full"
 `
 	if err := os.WriteFile(filepath.Join(projectDir, ".snip", "config.toml"), []byte(projectContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Trust the project config so the trust gate passes
+	projectCfgPath := filepath.Join(projectDir, ".snip", "config.toml")
+	trustStore := make(trust.Store)
+	hash, err := trust.HashFile(projectCfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	trustStore[projectCfgPath] = hash
+	if err := trust.SaveTo(trustStore, filepath.Join(home, ".config", "snip", "trusted.json")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -499,6 +525,18 @@ max_output_bytes = 1048576
 		t.Fatal(err)
 	}
 
+	// Trust the project config so the trust gate passes
+	projectCfgPath := filepath.Join(projectDir, ".snip", "config.toml")
+	trustStore := make(trust.Store)
+	hash, err := trust.HashFile(projectCfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	trustStore[projectCfgPath] = hash
+	if err := trust.SaveTo(trustStore, filepath.Join(home, ".config", "snip", "trusted.json")); err != nil {
+		t.Fatal(err)
+	}
+
 	t.Setenv("HOME", home)
 	t.Setenv("SNIP_CONFIG", userPath)
 	oldWd, _ := os.Getwd()
@@ -514,6 +552,60 @@ max_output_bytes = 1048576
 	}
 	if cfg.Filters.Global.MaxOutputBytes != 1048576 {
 		t.Errorf("MaxOutputBytes = %d, want 1048576 (project override)", cfg.Filters.Global.MaxOutputBytes)
+	}
+}
+
+func TestLoadMergedGlobalOverrideGateOutputBytesOnly(t *testing.T) {
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	if err := os.MkdirAll(filepath.Join(home, ".config", "snip", "filters"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	userContent := `[filters.global]
+max_line_length = 200
+`
+	userPath := filepath.Join(home, ".config", "snip", "config.toml")
+	if err := os.WriteFile(userPath, []byte(userContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	projectContent := `mode = "project"
+
+[filters.global]
+max_output_bytes = 1048576
+`
+	if err := os.WriteFile(filepath.Join(projectDir, ".snip", "config.toml"), []byte(projectContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectCfgPath := filepath.Join(projectDir, ".snip", "config.toml")
+	trustStore := make(trust.Store)
+	hash, err := trust.HashFile(projectCfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	trustStore[projectCfgPath] = hash
+	if err := trust.SaveTo(trustStore, filepath.Join(home, ".config", "snip", "trusted.json")); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", userPath)
+	oldWd, _ := os.Getwd()
+	_ = os.Chdir(projectDir)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	cfg, err := LoadMerged()
+	if err != nil {
+		t.Fatalf("LoadMerged: %v", err)
+	}
+	if cfg.Filters.Global.MaxOutputBytes != 1048576 {
+		t.Errorf("MaxOutputBytes = %d, want 1048576", cfg.Filters.Global.MaxOutputBytes)
 	}
 }
 
@@ -541,6 +633,18 @@ commands = ["curl", "wget"]
 commands = ["psql", "jq"]
 `
 	if err := os.WriteFile(filepath.Join(projectDir, ".snip", "config.toml"), []byte(projectContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Trust the project config so the trust gate passes
+	projectCfgPath := filepath.Join(projectDir, ".snip", "config.toml")
+	trustStore := make(trust.Store)
+	hash, err := trust.HashFile(projectCfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	trustStore[projectCfgPath] = hash
+	if err := trust.SaveTo(trustStore, filepath.Join(home, ".config", "snip", "trusted.json")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -605,6 +709,18 @@ head = 200
 		t.Fatal(err)
 	}
 
+	// Trust the project config so the trust gate passes
+	projectCfgPath := filepath.Join(projectDir, ".snip", "config.toml")
+	trustStore := make(trust.Store)
+	hash, err := trust.HashFile(projectCfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	trustStore[projectCfgPath] = hash
+	if err := trust.SaveTo(trustStore, filepath.Join(home, ".config", "snip", "trusted.json")); err != nil {
+		t.Fatal(err)
+	}
+
 	t.Setenv("HOME", home)
 	t.Setenv("SNIP_CONFIG", userPath)
 	oldWd, _ := os.Getwd()
@@ -623,5 +739,232 @@ head = 200
 	}
 	if cfg.Filters.Override["pytest"].Head != 200 {
 		t.Errorf("pytest head = %d, want 200", cfg.Filters.Override["pytest"].Head)
+	}
+}
+
+func TestLoadMergedUntrustedProjectConfigIgnored(t *testing.T) {
+	baseDir := t.TempDir()
+	home := filepath.Join(baseDir, "home")
+	projectDir := filepath.Join(baseDir, "project")
+
+	if err := os.MkdirAll(filepath.Join(home, ".config", "snip", "filters"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	userContent := "[filters.enable]\ngit-diff = true\n"
+	userPath := filepath.Join(home, ".config", "snip", "config.toml")
+	if err := os.WriteFile(userPath, []byte(userContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectContent := "mode = \"project\"\n\n[filters.enable]\ngit-diff = false\n"
+	projectPath := filepath.Join(projectDir, ".snip", "config.toml")
+	if err := os.WriteFile(projectPath, []byte(projectContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", userPath)
+	oldWd, _ := os.Getwd()
+	_ = os.Chdir(projectDir)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	cfg, err := LoadMerged()
+	if err != nil {
+		t.Fatalf("LoadMerged: %v", err)
+	}
+	if cfg.Filters.Enable["git-diff"] != true {
+		t.Error("untrusted project config should be ignored, git-diff should be true from user")
+	}
+}
+
+func TestLoadMergedTrustedProjectConfigApplied(t *testing.T) {
+	baseDir := t.TempDir()
+	home := filepath.Join(baseDir, "home")
+	projectDir := filepath.Join(baseDir, "project")
+
+	if err := os.MkdirAll(filepath.Join(home, ".config", "snip", "filters"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	userContent := "[filters.enable]\ngit-log = true\n"
+	userPath := filepath.Join(home, ".config", "snip", "config.toml")
+	if err := os.WriteFile(userPath, []byte(userContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectContent := "mode = \"project\"\n\n[filters.enable]\ngit-log = false\n"
+	projectPath := filepath.Join(projectDir, ".snip", "config.toml")
+	if err := os.WriteFile(projectPath, []byte(projectContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store := make(trust.Store)
+	hash, err := trust.HashFile(projectPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	abs, _ := filepath.Abs(projectPath)
+	store[abs] = hash
+	trustedPath := filepath.Join(home, ".config", "snip", "trusted.json")
+	if err := trust.SaveTo(store, trustedPath); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", userPath)
+	oldWd, _ := os.Getwd()
+	_ = os.Chdir(projectDir)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	cfg, err := LoadMerged()
+	if err != nil {
+		t.Fatalf("LoadMerged: %v", err)
+	}
+	if cfg.Filters.Enable["git-log"] != false {
+		t.Error("trusted project config should override user, git-log should be false")
+	}
+}
+
+func TestLoadMergedMissingTrustStoreReturnsUserOnly(t *testing.T) {
+	baseDir := t.TempDir()
+	home := filepath.Join(baseDir, "home")
+	projectDir := filepath.Join(baseDir, "project")
+
+	if err := os.MkdirAll(filepath.Join(home, ".config", "snip", "filters"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	userContent := "[filters.enable]\ngit-diff = true\n"
+	userPath := filepath.Join(home, ".config", "snip", "config.toml")
+	if err := os.WriteFile(userPath, []byte(userContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectContent := "mode = \"project\"\n\n[filters.enable]\ngit-diff = false\n"
+	projectPath := filepath.Join(projectDir, ".snip", "config.toml")
+	if err := os.WriteFile(projectPath, []byte(projectContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	trustedPath := filepath.Join(home, ".config", "snip", "trusted.json")
+	_ = os.Remove(trustedPath)
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", userPath)
+	oldWd, _ := os.Getwd()
+	_ = os.Chdir(projectDir)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	cfg, err := LoadMerged()
+	if err != nil {
+		t.Fatalf("LoadMerged: %v", err)
+	}
+	if cfg.Filters.Enable["git-diff"] != true {
+		t.Error("missing trust store should fall back to user config only")
+	}
+}
+
+func TestLoadMergedMalformedTrustedConfigReturnsError(t *testing.T) {
+	baseDir := t.TempDir()
+	home := filepath.Join(baseDir, "home")
+	projectDir := filepath.Join(baseDir, "project")
+
+	if err := os.MkdirAll(filepath.Join(home, ".config", "snip", "filters"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	userContent := "[display]\nquiet_no_filter = true\n"
+	userPath := filepath.Join(home, ".config", "snip", "config.toml")
+	if err := os.WriteFile(userPath, []byte(userContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectContent := "mode = \"project\"\nmissing_bracket = true\n\n[filters.enable\ngit-diff = false\n"
+	projectPath := filepath.Join(projectDir, ".snip", "config.toml")
+	if err := os.WriteFile(projectPath, []byte(projectContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store := make(trust.Store)
+	hash, err := trust.HashFile(projectPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	abs, _ := filepath.Abs(projectPath)
+	store[abs] = hash
+	trustedPath := filepath.Join(home, ".config", "snip", "trusted.json")
+	if err := trust.SaveTo(store, trustedPath); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", userPath)
+	oldWd, _ := os.Getwd()
+	_ = os.Chdir(projectDir)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	cfg, err := LoadMerged()
+	if err == nil {
+		t.Fatal("expected error for malformed trusted project config")
+	}
+	if cfg != nil {
+		t.Error("expected nil config on malformed project config")
+	}
+}
+
+func TestLoadMergedTrustStoreLoadErrorReturnsUserOnly(t *testing.T) {
+	baseDir := t.TempDir()
+	home := filepath.Join(baseDir, "home")
+	projectDir := filepath.Join(baseDir, "project")
+
+	if err := os.MkdirAll(filepath.Join(home, ".config", "snip", "filters"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	userContent := "[filters.enable]\ngit-diff = true\n"
+	userPath := filepath.Join(home, ".config", "snip", "config.toml")
+	if err := os.WriteFile(userPath, []byte(userContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectContent := "mode = \"project\"\n\n[filters.enable]\ngit-diff = false\n"
+	projectPath := filepath.Join(projectDir, ".snip", "config.toml")
+	if err := os.WriteFile(projectPath, []byte(projectContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	trustedPath := filepath.Join(home, ".config", "snip", "trusted.json")
+	if err := os.WriteFile(trustedPath, []byte("not valid json{{{"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", userPath)
+	oldWd, _ := os.Getwd()
+	_ = os.Chdir(projectDir)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	cfg, err := LoadMerged()
+	if err != nil {
+		t.Fatalf("LoadMerged: %v", err)
+	}
+	if cfg.Filters.Enable["git-diff"] != true {
+		t.Error("corrupt trust store should fall back to user config only")
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,6 +8,21 @@ import (
 	"github.com/edouard-claude/snip/internal/trust"
 )
 
+// canonicalTempDir returns t.TempDir() with symlinks resolved. macOS's
+// $TMPDIR (/var/folders/...) is a symlink to /private/var/folders/...,
+// while os.Getwd() in production returns the resolved form. Without this,
+// trust store keys (built from raw TempDir paths via filepath.Abs) would
+// not match what LoadMerged looks up via projectConfigPath after Chdir.
+func canonicalTempDir(t *testing.T) string {
+	t.Helper()
+	d := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resolved
+}
+
 func TestDefaultConfig(t *testing.T) {
 	cfg := DefaultConfig()
 
@@ -357,7 +372,7 @@ quiet_no_filter = true
 	}
 
 	// Project config: has [filters.enable] with mode="project"
-	projectDir := t.TempDir()
+	projectDir := canonicalTempDir(t)
 	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -420,7 +435,7 @@ max_lines = 100
 		t.Fatal(err)
 	}
 
-	projectDir := t.TempDir()
+	projectDir := canonicalTempDir(t)
 	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -511,7 +526,7 @@ max_line_length = 200
 		t.Fatal(err)
 	}
 
-	projectDir := t.TempDir()
+	projectDir := canonicalTempDir(t)
 	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -570,7 +585,7 @@ max_line_length = 200
 		t.Fatal(err)
 	}
 
-	projectDir := t.TempDir()
+	projectDir := canonicalTempDir(t)
 	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -625,7 +640,7 @@ commands = ["curl", "wget"]
 		t.Fatal(err)
 	}
 
-	projectDir := t.TempDir()
+	projectDir := canonicalTempDir(t)
 	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -693,7 +708,7 @@ quiet_no_filter = true
 		t.Fatal(err)
 	}
 
-	projectDir := t.TempDir()
+	projectDir := canonicalTempDir(t)
 	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -743,7 +758,7 @@ head = 200
 }
 
 func TestLoadMergedUntrustedProjectConfigIgnored(t *testing.T) {
-	baseDir := t.TempDir()
+	baseDir := canonicalTempDir(t)
 	home := filepath.Join(baseDir, "home")
 	projectDir := filepath.Join(baseDir, "project")
 
@@ -782,7 +797,7 @@ func TestLoadMergedUntrustedProjectConfigIgnored(t *testing.T) {
 }
 
 func TestLoadMergedTrustedProjectConfigApplied(t *testing.T) {
-	baseDir := t.TempDir()
+	baseDir := canonicalTempDir(t)
 	home := filepath.Join(baseDir, "home")
 	projectDir := filepath.Join(baseDir, "project")
 
@@ -833,7 +848,7 @@ func TestLoadMergedTrustedProjectConfigApplied(t *testing.T) {
 }
 
 func TestLoadMergedMissingTrustStoreReturnsUserOnly(t *testing.T) {
-	baseDir := t.TempDir()
+	baseDir := canonicalTempDir(t)
 	home := filepath.Join(baseDir, "home")
 	projectDir := filepath.Join(baseDir, "project")
 
@@ -875,7 +890,7 @@ func TestLoadMergedMissingTrustStoreReturnsUserOnly(t *testing.T) {
 }
 
 func TestLoadMergedMalformedTrustedConfigReturnsError(t *testing.T) {
-	baseDir := t.TempDir()
+	baseDir := canonicalTempDir(t)
 	home := filepath.Join(baseDir, "home")
 	projectDir := filepath.Join(baseDir, "project")
 
@@ -926,7 +941,7 @@ func TestLoadMergedMalformedTrustedConfigReturnsError(t *testing.T) {
 }
 
 func TestLoadMergedTrustStoreLoadErrorReturnsUserOnly(t *testing.T) {
-	baseDir := t.TempDir()
+	baseDir := canonicalTempDir(t)
 	home := filepath.Join(baseDir, "home")
 	projectDir := filepath.Join(baseDir, "project")
 
@@ -972,7 +987,7 @@ func TestLoadMergedTrustStoreLoadErrorReturnsUserOnly(t *testing.T) {
 func TestLoadMergedTrustRevokedAfterFileModified(t *testing.T) {
 	// After snip trust, if the project config is modified (hash changes),
 	// LoadMerged must fall back to user config only — the trust is revoked.
-	baseDir := t.TempDir()
+	baseDir := canonicalTempDir(t)
 	home := filepath.Join(baseDir, "home")
 	projectDir := filepath.Join(baseDir, "project")
 
@@ -1033,7 +1048,7 @@ func TestLoadMergedTrustRevokedAfterFileModified(t *testing.T) {
 func TestLoadMergedSymlinkedProjectConfig(t *testing.T) {
 	// A symlinked .snip/config.toml should still work with the trust
 	// gate — trust.IsTrusted resolves paths via filepath.Abs.
-	baseDir := t.TempDir()
+	baseDir := canonicalTempDir(t)
 	home := filepath.Join(baseDir, "home")
 	realProjectDir := filepath.Join(baseDir, "real-project")
 	symProjectDir := filepath.Join(baseDir, "sym-project")
@@ -1100,7 +1115,7 @@ func TestLoadMergedSymlinkedProjectConfig(t *testing.T) {
 }
 
 func TestLoadMergedCorruptUserConfigReturnsError(t *testing.T) {
-	baseDir := t.TempDir()
+	baseDir := canonicalTempDir(t)
 	home := filepath.Join(baseDir, "home")
 	if err := os.MkdirAll(filepath.Join(home, ".config", "snip", "filters"), 0o755); err != nil {
 		t.Fatal(err)
@@ -1139,7 +1154,7 @@ func TestLoadMergedProjectConfigWithoutProjectMode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	projectDir := t.TempDir()
+	projectDir := canonicalTempDir(t)
 	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -1196,7 +1211,7 @@ func TestLoadMergedMinimalProjectConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	projectDir := t.TempDir()
+	projectDir := canonicalTempDir(t)
 	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1098,3 +1098,140 @@ func TestLoadMergedSymlinkedProjectConfig(t *testing.T) {
 		t.Error("symlinked project config should be trusted, git-log should be false")
 	}
 }
+
+func TestLoadMergedCorruptUserConfigReturnsError(t *testing.T) {
+	baseDir := t.TempDir()
+	home := filepath.Join(baseDir, "home")
+	if err := os.MkdirAll(filepath.Join(home, ".config", "snip", "filters"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	userContent := "this is not valid toml {{{"
+	userPath := filepath.Join(home, ".config", "snip", "config.toml")
+	if err := os.WriteFile(userPath, []byte(userContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", userPath)
+
+	cfg, err := LoadMerged()
+	if err == nil {
+		t.Fatal("expected error for corrupt user config")
+	}
+	if cfg != nil {
+		t.Error("expected nil config on corrupt user config")
+	}
+}
+
+func TestLoadMergedProjectConfigWithoutProjectMode(t *testing.T) {
+	// Project config with mode="user" (or no mode) should NOT override user
+	// settings. Only the bypass list merges unconditionally.
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	if err := os.MkdirAll(filepath.Join(home, ".config", "snip", "filters"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	userContent := "[filters.enable]\ngit-diff = true\n[filters.global]\nmax_lines = 100\n"
+	userPath := filepath.Join(home, ".config", "snip", "config.toml")
+	if err := os.WriteFile(userPath, []byte(userContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// mode is "user" — project should NOT override
+	projectContent := "mode = \"user\"\n\n[filters.enable]\ngit-diff = false\n[filters.global]\nmax_lines = 200\n"
+	projectPath := filepath.Join(projectDir, ".snip", "config.toml")
+	if err := os.WriteFile(projectPath, []byte(projectContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Trust the project config
+	store := make(trust.Store)
+	hash, err := trust.HashFile(projectPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	abs, _ := filepath.Abs(projectPath)
+	store[abs] = hash
+	if err := trust.SaveTo(store, filepath.Join(home, ".config", "snip", "trusted.json")); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", userPath)
+	oldWd, _ := os.Getwd()
+	_ = os.Chdir(projectDir)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	cfg, err := LoadMerged()
+	if err != nil {
+		t.Fatalf("LoadMerged: %v", err)
+	}
+	// User settings should be preserved since mode is not "project"
+	if cfg.Filters.Enable["git-diff"] != true {
+		t.Error("user git-diff should stay true when project mode is user")
+	}
+	if cfg.Filters.Global.MaxLines != 100 {
+		t.Errorf("user max_lines = %d, want 100 (project not overriding)", cfg.Filters.Global.MaxLines)
+	}
+}
+
+func TestLoadMergedMinimalProjectConfig(t *testing.T) {
+	// Project config with mode="project" but NO enable, global, or override
+	// settings. Must not crash or produce unexpected state.
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	if err := os.MkdirAll(filepath.Join(home, ".config", "snip", "filters"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	userContent := "[filters.enable]\ngit-diff = true\n"
+	userPath := filepath.Join(home, ".config", "snip", "config.toml")
+	if err := os.WriteFile(userPath, []byte(userContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	projectContent := "mode = \"project\"\n"
+	projectPath := filepath.Join(projectDir, ".snip", "config.toml")
+	if err := os.WriteFile(projectPath, []byte(projectContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store := make(trust.Store)
+	hash, err := trust.HashFile(projectPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	abs, _ := filepath.Abs(projectPath)
+	store[abs] = hash
+	if err := trust.SaveTo(store, filepath.Join(home, ".config", "snip", "trusted.json")); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", userPath)
+	oldWd, _ := os.Getwd()
+	_ = os.Chdir(projectDir)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	cfg, err := LoadMerged()
+	if err != nil {
+		t.Fatalf("LoadMerged: %v", err)
+	}
+	if cfg.Mode != "project" {
+		t.Errorf("mode = %q, want project", cfg.Mode)
+	}
+	// User settings preserved (project had nothing to override)
+	if cfg.Filters.Enable["git-diff"] != true {
+		t.Error("user git-diff should be preserved with minimal project config")
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -968,3 +968,133 @@ func TestLoadMergedTrustStoreLoadErrorReturnsUserOnly(t *testing.T) {
 		t.Error("corrupt trust store should fall back to user config only")
 	}
 }
+
+func TestLoadMergedTrustRevokedAfterFileModified(t *testing.T) {
+	// After snip trust, if the project config is modified (hash changes),
+	// LoadMerged must fall back to user config only — the trust is revoked.
+	baseDir := t.TempDir()
+	home := filepath.Join(baseDir, "home")
+	projectDir := filepath.Join(baseDir, "project")
+
+	if err := os.MkdirAll(filepath.Join(home, ".config", "snip", "filters"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	userContent := "[filters.enable]\ngit-diff = true\n"
+	userPath := filepath.Join(home, ".config", "snip", "config.toml")
+	if err := os.WriteFile(userPath, []byte(userContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectContent := "mode = \"project\"\n\n[filters.enable]\ngit-diff = false\n"
+	projectPath := filepath.Join(projectDir, ".snip", "config.toml")
+	if err := os.WriteFile(projectPath, []byte(projectContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Trust the original content
+	store := make(trust.Store)
+	hash, err := trust.HashFile(projectPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	abs, _ := filepath.Abs(projectPath)
+	store[abs] = hash
+	trustedPath := filepath.Join(home, ".config", "snip", "trusted.json")
+	if err := trust.SaveTo(store, trustedPath); err != nil {
+		t.Fatal(err)
+	}
+
+	// Modify the file — hash no longer matches
+	modifiedContent := "mode = \"project\"\n\n[filters.enable]\ngit-diff = true\n"
+	if err := os.WriteFile(projectPath, []byte(modifiedContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", userPath)
+	oldWd, _ := os.Getwd()
+	_ = os.Chdir(projectDir)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	cfg, err := LoadMerged()
+	if err != nil {
+		t.Fatalf("LoadMerged: %v", err)
+	}
+	// Hash mismatch — project config should be rejected, user config wins
+	if cfg.Filters.Enable["git-diff"] != true {
+		t.Error("modified config should fail trust check, git-diff should stay true (user)")
+	}
+}
+
+func TestLoadMergedSymlinkedProjectConfig(t *testing.T) {
+	// A symlinked .snip/config.toml should still work with the trust
+	// gate — trust.IsTrusted resolves paths via filepath.Abs.
+	baseDir := t.TempDir()
+	home := filepath.Join(baseDir, "home")
+	realProjectDir := filepath.Join(baseDir, "real-project")
+	symProjectDir := filepath.Join(baseDir, "sym-project")
+
+	if err := os.MkdirAll(filepath.Join(home, ".config", "snip", "filters"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(realProjectDir, ".snip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	userContent := "[filters.enable]\ngit-log = true\n"
+	userPath := filepath.Join(home, ".config", "snip", "config.toml")
+	if err := os.WriteFile(userPath, []byte(userContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectContent := "mode = \"project\"\n\n[filters.enable]\ngit-log = false\n"
+	projectPath := filepath.Join(realProjectDir, ".snip", "config.toml")
+	if err := os.WriteFile(projectPath, []byte(projectContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Symlink the project dir
+	if err := os.MkdirAll(symProjectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	symSnipDir := filepath.Join(symProjectDir, ".snip")
+	if err := os.Symlink(filepath.Join(realProjectDir, ".snip"), symSnipDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Trust the symlinked path (what projectConfigPath returns after Stat
+	// follows the symlink to the real file).
+	symProjectPath := filepath.Join(symProjectDir, ".snip", "config.toml")
+	abs, _ := filepath.Abs(symProjectPath)
+	store := make(trust.Store)
+	hash, err := trust.HashFile(symProjectPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store[abs] = hash
+	if err := trust.SaveTo(store, filepath.Join(home, ".config", "snip", "trusted.json")); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", userPath)
+	oldWd, _ := os.Getwd()
+	// CWD is the symlinked dir — projectConfigPath walks up from here
+	_ = os.Chdir(symProjectDir)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	cfg, err := LoadMerged()
+	if err != nil {
+		t.Fatalf("LoadMerged: %v", err)
+	}
+	if cfg.Filters.Enable == nil {
+		t.Fatal("expected non-nil Filters.Enable")
+	}
+	if cfg.Filters.Enable["git-log"] != false {
+		t.Error("symlinked project config should be trusted, git-log should be false")
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -298,3 +298,330 @@ max_files = 5
 		t.Errorf("expected max_files 5, got %d", cfg.Tee.MaxFiles)
 	}
 }
+
+func TestLoadMergedNoProjectConfig(t *testing.T) {
+	// When no .snip/config.toml exists in the directory tree,
+	// LoadMerged should return the user config unchanged.
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	if err := os.MkdirAll(filepath.Join(home, ".config", "snip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	userPath := filepath.Join(home, ".config", "snip", "config.toml")
+	content := `[display]
+quiet_no_filter = true
+`
+	if err := os.WriteFile(userPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldHome := os.Getenv("HOME")
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", userPath)
+	_ = oldHome
+
+	// Change into a temp dir with no .snip/ so projectConfigPath returns ""
+	workDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	_ = os.Chdir(workDir)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	cfg, err := LoadMerged()
+	if err != nil {
+		t.Fatalf("LoadMerged: %v", err)
+	}
+	if !cfg.Display.QuietNoFilter {
+		t.Error("expected user QuietNoFilter preserved")
+	}
+}
+
+func TestLoadMergedNilEnableNoPanic(t *testing.T) {
+	// Bug: LoadMerged panicked when user config had no [filters.enable]
+	// and project config set one with mode="project".
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	filterDir := filepath.Join(home, ".config", "snip", "filters")
+	if err := os.MkdirAll(filterDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// User config: no [filters.enable] section
+	userContent := `[display]
+quiet_no_filter = true
+`
+	userPath := filepath.Join(home, ".config", "snip", "config.toml")
+	if err := os.WriteFile(userPath, []byte(userContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Project config: has [filters.enable] with mode="project"
+	projectDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	projectContent := `mode = "project"
+
+[filters.enable]
+git-diff = false
+`
+	if err := os.WriteFile(filepath.Join(projectDir, ".snip", "config.toml"), []byte(projectContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", userPath)
+	oldWd, _ := os.Getwd()
+	_ = os.Chdir(projectDir)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	cfg, err := LoadMerged()
+	if err != nil {
+		t.Fatalf("LoadMerged: %v", err)
+	}
+	if cfg.Filters.Enable == nil {
+		t.Fatal("expected non-nil Filters.Enable after merge")
+	}
+	if cfg.Filters.Enable["git-diff"] != false {
+		t.Error("expected git-diff disabled by project")
+	}
+}
+
+func TestLoadMergedMergePrecedence(t *testing.T) {
+	// Project mode="project" should override user enable/disable + global + overrides.
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	if err := os.MkdirAll(filepath.Join(home, ".config", "snip", "filters"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	userContent := `[filters.enable]
+git-log = true
+git-diff = true
+
+[filters.global]
+max_lines = 100
+`
+	userPath := filepath.Join(home, ".config", "snip", "config.toml")
+	if err := os.WriteFile(userPath, []byte(userContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	projectContent := `mode = "project"
+
+[filters.enable]
+git-diff = false
+curl = false
+
+[filters.global]
+max_lines = 50
+max_line_length = 80
+
+[filters.override.pyright]
+stream_mode = "full"
+`
+	if err := os.WriteFile(filepath.Join(projectDir, ".snip", "config.toml"), []byte(projectContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", userPath)
+	oldWd, _ := os.Getwd()
+	_ = os.Chdir(projectDir)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	cfg, err := LoadMerged()
+	if err != nil {
+		t.Fatalf("LoadMerged: %v", err)
+	}
+
+	// Enable: project keys override user
+	if cfg.Filters.Enable["git-diff"] != false {
+		t.Error("project should disable git-diff")
+	}
+	if cfg.Filters.Enable["curl"] != false {
+		t.Error("project should disable curl")
+	}
+	if cfg.Filters.Enable["git-log"] != true {
+		t.Error("user git-log (not in project) should stay enabled")
+	}
+
+	// Global: project wins entirely
+	if cfg.Filters.Global.MaxLines != 50 {
+		t.Errorf("global.MaxLines = %d, want 50", cfg.Filters.Global.MaxLines)
+	}
+	if cfg.Filters.Global.MaxLineLength != 80 {
+		t.Errorf("global.MaxLineLength = %d, want 80", cfg.Filters.Global.MaxLineLength)
+	}
+
+	// Override: project wins
+	if cfg.Filters.Override["pyright"].StreamMode != "full" {
+		t.Error("expected pyright override stream_mode=full")
+	}
+
+	// Mode: should be "project"
+	if cfg.Mode != "project" {
+		t.Errorf("mode = %q, want 'project'", cfg.Mode)
+	}
+}
+
+func TestLoadMergedGlobalOverrideGate(t *testing.T) {
+	// When project config only sets max_line_length (no max_lines, no stream_mode),
+	// the global override should still apply.
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	if err := os.MkdirAll(filepath.Join(home, ".config", "snip", "filters"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	userContent := `[filters.global]
+max_line_length = 200
+`
+	userPath := filepath.Join(home, ".config", "snip", "config.toml")
+	if err := os.WriteFile(userPath, []byte(userContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	projectContent := `mode = "project"
+
+[filters.global]
+max_line_length = 80
+max_output_bytes = 1048576
+`
+	if err := os.WriteFile(filepath.Join(projectDir, ".snip", "config.toml"), []byte(projectContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", userPath)
+	oldWd, _ := os.Getwd()
+	_ = os.Chdir(projectDir)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	cfg, err := LoadMerged()
+	if err != nil {
+		t.Fatalf("LoadMerged: %v", err)
+	}
+	if cfg.Filters.Global.MaxLineLength != 80 {
+		t.Errorf("MaxLineLength = %d, want 80 (project override)", cfg.Filters.Global.MaxLineLength)
+	}
+	if cfg.Filters.Global.MaxOutputBytes != 1048576 {
+		t.Errorf("MaxOutputBytes = %d, want 1048576 (project override)", cfg.Filters.Global.MaxOutputBytes)
+	}
+}
+
+func TestLoadMergedBypassMerge(t *testing.T) {
+	// Bypass list should merge from both user and project.
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	if err := os.MkdirAll(filepath.Join(home, ".config", "snip", "filters"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	userContent := `[filters.bypass]
+commands = ["curl", "wget"]
+`
+	userPath := filepath.Join(home, ".config", "snip", "config.toml")
+	if err := os.WriteFile(userPath, []byte(userContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	projectContent := `[filters.bypass]
+commands = ["psql", "jq"]
+`
+	if err := os.WriteFile(filepath.Join(projectDir, ".snip", "config.toml"), []byte(projectContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", userPath)
+	oldWd, _ := os.Getwd()
+	_ = os.Chdir(projectDir)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	cfg, err := LoadMerged()
+	if err != nil {
+		t.Fatalf("LoadMerged: %v", err)
+	}
+	if len(cfg.Filters.Bypass.Commands) != 4 {
+		t.Fatalf("bypass commands len = %d, want 4: %v", len(cfg.Filters.Bypass.Commands), cfg.Filters.Bypass.Commands)
+	}
+	has := func(s string) bool {
+		for _, c := range cfg.Filters.Bypass.Commands {
+			if c == s {
+				return true
+			}
+		}
+		return false
+	}
+	for _, want := range []string{"curl", "wget", "psql", "jq"} {
+		if !has(want) {
+			t.Errorf("bypass missing %q", want)
+		}
+	}
+}
+
+func TestLoadMergedOverrideNilMaps(t *testing.T) {
+	// When user has no Override map and project adds overrides,
+	// the code should initialize the map without panicking.
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	if err := os.MkdirAll(filepath.Join(home, ".config", "snip", "filters"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	userContent := `[display]
+quiet_no_filter = true
+`
+	userPath := filepath.Join(home, ".config", "snip", "config.toml")
+	if err := os.WriteFile(userPath, []byte(userContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	projectContent := `mode = "project"
+
+[filters.override.ls]
+head = 0
+
+[filters.override.pytest]
+head = 200
+`
+	if err := os.WriteFile(filepath.Join(projectDir, ".snip", "config.toml"), []byte(projectContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", userPath)
+	oldWd, _ := os.Getwd()
+	_ = os.Chdir(projectDir)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	cfg, err := LoadMerged()
+	if err != nil {
+		t.Fatalf("LoadMerged: %v", err)
+	}
+	if cfg.Filters.Override == nil {
+		t.Fatal("expected non-nil Override map")
+	}
+	if cfg.Filters.Override["ls"].Head != 0 {
+		t.Errorf("ls head = %d, want 0", cfg.Filters.Override["ls"].Head)
+	}
+	if cfg.Filters.Override["pytest"].Head != 200 {
+		t.Errorf("pytest head = %d, want 200", cfg.Filters.Override["pytest"].Head)
+	}
+}

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/edouard-claude/snip/internal/config"
 	"github.com/edouard-claude/snip/internal/filter"
 	"github.com/edouard-claude/snip/internal/tee"
 	"github.com/edouard-claude/snip/internal/tracking"
@@ -20,6 +21,7 @@ type Pipeline struct {
 	UltraCompact  bool
 	QuietNoFilter bool
 	FilterEnabled map[string]bool
+	Config        *config.Config // merged user+project config (nil if not loaded)
 }
 
 // Run executes a command through the full pipeline.
@@ -30,6 +32,16 @@ func (p *Pipeline) Run(command string, args []string) int {
 	if len(args) > 0 {
 		subcommand = args[0]
 		filterArgs = args[1:]
+	}
+
+	// Check if command is in the project-level bypass list.
+	// Bypassed commands pass through unfiltered regardless of filter match.
+	if p.Config != nil {
+		for _, cmd := range p.Config.Filters.Bypass.Commands {
+			if cmd == command {
+				return p.Passthrough(command, args)
+			}
+		}
 	}
 
 	// Match filter
@@ -83,6 +95,16 @@ func (p *Pipeline) Run(command string, args []string) int {
 
 	// Build pipeline input from selected streams
 	pipelineInput := buildPipelineInput(f, result)
+
+	// Apply project-level filter overrides to the matched filter pipeline
+	if p.Config != nil {
+		if override, ok := p.Config.Filters.Override[f.Name]; ok {
+			applyOverride(f, &override)
+		}
+		if p.Config.Filters.Global.MaxLines > 0 || p.Config.Filters.Global.MaxLineLength > 0 {
+			applyGlobalLimit(f, &p.Config.Filters.Global)
+		}
+	}
 
 	// Apply filter pipeline
 	filtered, filterErr := ApplyPipeline(f, pipelineInput)
@@ -182,6 +204,59 @@ func ApplyPipeline(f *filter.Filter, input string) (string, error) {
 	}
 
 	return strings.Join(result.Lines, "\n") + "\n", nil
+}
+
+// applyOverride modifies a filter's pipeline actions based on project config
+// overrides. When StreamMode is "full", the entire pipeline is cleared (full
+// passthrough). Otherwise, matching pipeline actions are updated with the
+// override values for head, truncate_lines, keep_lines, and remove_lines.
+func applyOverride(f *filter.Filter, o *config.FilterOverride) {
+	if o.StreamMode == "full" {
+		f.Pipeline = nil
+		return
+	}
+	for i, action := range f.Pipeline {
+		switch action.ActionName {
+		case "head":
+			if o.Head > 0 {
+				f.Pipeline[i].Params["n"] = o.Head
+			}
+		case "tail":
+			if o.Tail > 0 {
+				f.Pipeline[i].Params["n"] = o.Tail
+			}
+		case "truncate_lines":
+			if o.TruncateLines > 0 {
+				f.Pipeline[i].Params["max"] = o.TruncateLines
+			}
+		case "keep_lines":
+			if o.KeepLines != "" {
+				f.Pipeline[i].Params["pattern"] = o.KeepLines
+			}
+		case "remove_lines":
+			if o.RemoveLines != "" {
+				f.Pipeline[i].Params["pattern"] = o.RemoveLines
+			}
+		}
+	}
+}
+
+// applyGlobalLimit appends global limits (max_lines, max_line_length) to
+// the end of a filter's pipeline. These act as a final safety cap on all
+// filtered output.
+func applyGlobalLimit(f *filter.Filter, g *config.FilterGlobalConfig) {
+	if g.MaxLines > 0 {
+		f.Pipeline = append(f.Pipeline, filter.Action{
+			ActionName: "head",
+			Params:     map[string]any{"n": g.MaxLines},
+		})
+	}
+	if g.MaxLineLength > 0 {
+		f.Pipeline = append(f.Pipeline, filter.Action{
+			ActionName: "truncate_lines",
+			Params:     map[string]any{"max": g.MaxLineLength},
+		})
+	}
 }
 
 // buildPipelineInput assembles the text to filter based on the filter's

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -211,35 +211,72 @@ func ApplyPipeline(f *filter.Filter, input string) (string, error) {
 // applyOverride modifies a filter's pipeline actions based on project config
 // overrides. When StreamMode is "full", the entire pipeline is cleared (full
 // passthrough). Otherwise, matching pipeline actions are updated with the
-// override values for head, truncate_lines, keep_lines, and remove_lines.
+// override values. Override targets not found in the existing pipeline are
+// appended as new actions (consistent with applyGlobalLimit's behavior).
 func applyOverride(f *filter.Filter, o *config.FilterOverride) {
 	if o.StreamMode == "full" {
 		f.Pipeline = nil
 		return
 	}
+	applied := map[string]bool{}
 	for i, action := range f.Pipeline {
 		switch action.ActionName {
 		case "head":
 			if o.Head > 0 {
 				f.Pipeline[i].Params["n"] = o.Head
+				applied["head"] = true
 			}
 		case "tail":
 			if o.Tail > 0 {
 				f.Pipeline[i].Params["n"] = o.Tail
+				applied["tail"] = true
 			}
 		case "truncate_lines":
 			if o.TruncateLines > 0 {
 				f.Pipeline[i].Params["max"] = o.TruncateLines
+				applied["truncate_lines"] = true
 			}
 		case "keep_lines":
 			if o.KeepLines != "" {
 				f.Pipeline[i].Params["pattern"] = o.KeepLines
+				applied["keep_lines"] = true
 			}
 		case "remove_lines":
 			if o.RemoveLines != "" {
 				f.Pipeline[i].Params["pattern"] = o.RemoveLines
+				applied["remove_lines"] = true
 			}
 		}
+	}
+	if o.Head > 0 && !applied["head"] {
+		f.Pipeline = append(f.Pipeline, filter.Action{
+			ActionName: "head",
+			Params:     map[string]any{"n": o.Head},
+		})
+	}
+	if o.Tail > 0 && !applied["tail"] {
+		f.Pipeline = append(f.Pipeline, filter.Action{
+			ActionName: "tail",
+			Params:     map[string]any{"n": o.Tail},
+		})
+	}
+	if o.TruncateLines > 0 && !applied["truncate_lines"] {
+		f.Pipeline = append(f.Pipeline, filter.Action{
+			ActionName: "truncate_lines",
+			Params:     map[string]any{"max": o.TruncateLines},
+		})
+	}
+	if o.KeepLines != "" && !applied["keep_lines"] {
+		f.Pipeline = append(f.Pipeline, filter.Action{
+			ActionName: "keep_lines",
+			Params:     map[string]any{"pattern": o.KeepLines},
+		})
+	}
+	if o.RemoveLines != "" && !applied["remove_lines"] {
+		f.Pipeline = append(f.Pipeline, filter.Action{
+			ActionName: "remove_lines",
+			Params:     map[string]any{"pattern": o.RemoveLines},
+		})
 	}
 }
 

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -220,6 +220,9 @@ func applyOverride(f *filter.Filter, o *config.FilterOverride) {
 	}
 	applied := map[string]bool{}
 	for i, action := range f.Pipeline {
+		if action.Params == nil {
+			f.Pipeline[i].Params = make(map[string]any)
+		}
 		switch action.ActionName {
 		case "head":
 			if o.Head > 0 {

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -96,8 +96,10 @@ func (p *Pipeline) Run(command string, args []string) int {
 	// Build pipeline input from selected streams
 	pipelineInput := buildPipelineInput(f, result)
 
-	// Apply project-level filter overrides to the matched filter pipeline
+	// Apply project-level filter overrides to the matched filter pipeline.
+	// Clone the filter first to avoid mutating the registry's shared pointer.
 	if p.Config != nil {
+		f = f.Clone()
 		if override, ok := p.Config.Filters.Override[f.Name]; ok {
 			applyOverride(f, &override)
 		}

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -103,7 +103,7 @@ func (p *Pipeline) Run(command string, args []string) int {
 		if override, ok := p.Config.Filters.Override[f.Name]; ok {
 			applyOverride(f, &override)
 		}
-		if p.Config.Filters.Global.MaxLines > 0 || p.Config.Filters.Global.MaxLineLength > 0 {
+		if p.Config.Filters.Global.MaxLines > 0 || p.Config.Filters.Global.MaxLineLength > 0 || p.Config.Filters.Global.MaxOutputBytes > 0 {
 			applyGlobalLimit(f, &p.Config.Filters.Global)
 		}
 	}
@@ -243,8 +243,8 @@ func applyOverride(f *filter.Filter, o *config.FilterOverride) {
 	}
 }
 
-// applyGlobalLimit appends global limits (max_lines, max_line_length) to
-// the end of a filter's pipeline. These act as a final safety cap on all
+// applyGlobalLimit appends global limits (max_lines, max_line_length, max_output_bytes)
+// to the end of a filter's pipeline. These act as a final safety cap on all
 // filtered output.
 func applyGlobalLimit(f *filter.Filter, g *config.FilterGlobalConfig) {
 	if g.MaxLines > 0 {
@@ -257,6 +257,12 @@ func applyGlobalLimit(f *filter.Filter, g *config.FilterGlobalConfig) {
 		f.Pipeline = append(f.Pipeline, filter.Action{
 			ActionName: "truncate_lines",
 			Params:     map[string]any{"max": g.MaxLineLength},
+		})
+	}
+	if g.MaxOutputBytes > 0 {
+		f.Pipeline = append(f.Pipeline, filter.Action{
+			ActionName: "truncate_bytes",
+			Params:     map[string]any{"max": g.MaxOutputBytes},
 		})
 	}
 }

--- a/internal/engine/pipeline_test.go
+++ b/internal/engine/pipeline_test.go
@@ -424,3 +424,32 @@ func filterForTest(name string, pipeline filter.Pipeline) filter.Filter {
 		OnError:  "passthrough",
 	}
 }
+
+func TestApplyGlobalLimit_MaxOutputBytes(t *testing.T) {
+	f := &filter.Filter{Pipeline: filter.Pipeline{}}
+	g := &config.FilterGlobalConfig{MaxOutputBytes: 100}
+
+	applyGlobalLimit(f, g)
+
+	if len(f.Pipeline) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(f.Pipeline))
+	}
+	if f.Pipeline[0].ActionName != "truncate_bytes" {
+		t.Errorf("action name = %q, want truncate_bytes", f.Pipeline[0].ActionName)
+	}
+	max, _ := f.Pipeline[0].Params["max"].(int)
+	if max != 100 {
+		t.Errorf("max = %d, want 100", max)
+	}
+}
+
+func TestApplyGlobalLimit_ZeroIsNoOp(t *testing.T) {
+	f := &filter.Filter{Pipeline: filter.Pipeline{}}
+	g := &config.FilterGlobalConfig{} // all zeros
+
+	applyGlobalLimit(f, g)
+
+	if len(f.Pipeline) != 0 {
+		t.Errorf("expected 0 actions for zero limits, got %d", len(f.Pipeline))
+	}
+}

--- a/internal/engine/pipeline_test.go
+++ b/internal/engine/pipeline_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/edouard-claude/snip/internal/config"
 	"github.com/edouard-claude/snip/internal/filter"
 )
 
@@ -274,5 +275,152 @@ func TestPipelineRunSilentWhenSiblingSubcommandHasFilter(t *testing.T) {
 
 	if strings.Contains(buf.String(), "no filter for") {
 		t.Errorf("expected silent stderr when sibling subcommand filter exists, got: %q", buf.String())
+	}
+}
+
+func TestApplyOverrideHead(t *testing.T) {
+	f := filterForTest("test-filter",
+		filter.Pipeline{
+			{ActionName: "keep_lines", Params: map[string]any{"pattern": `\S`}},
+			{ActionName: "head", Params: map[string]any{"n": 10}},
+		},
+	)
+
+	o := config.FilterOverride{Head: 25}
+	applyOverride(&f, &o)
+
+	if f.Pipeline[1].Params["n"] != 25 {
+		t.Errorf("head n = %v, want 25", f.Pipeline[1].Params["n"])
+	}
+}
+
+func TestApplyOverrideStreamModeFull(t *testing.T) {
+	f := filterForTest("test-filter",
+		filter.Pipeline{
+			{ActionName: "keep_lines", Params: map[string]any{"pattern": `\S`}},
+			{ActionName: "head", Params: map[string]any{"n": 10}},
+		},
+	)
+
+	o := config.FilterOverride{StreamMode: "full"}
+	applyOverride(&f, &o)
+
+	if f.Pipeline != nil {
+		t.Errorf("pipeline should be nil after stream_mode=full, got %v", f.Pipeline)
+	}
+}
+
+func TestApplyGlobalLimit(t *testing.T) {
+	f := filterForTest("test-filter",
+		filter.Pipeline{
+			{ActionName: "keep_lines", Params: map[string]any{"pattern": `\S`}},
+		},
+	)
+
+	origLen := len(f.Pipeline)
+	g := config.FilterGlobalConfig{MaxLines: 50, MaxLineLength: 120}
+	applyGlobalLimit(&f, &g)
+
+	if len(f.Pipeline) != origLen+2 {
+		t.Fatalf("pipeline len = %d, want %d", len(f.Pipeline), origLen+2)
+	}
+	lastTwo := f.Pipeline[len(f.Pipeline)-2:]
+	if lastTwo[0].ActionName != "head" || lastTwo[0].Params["n"] != 50 {
+		t.Errorf("expected head(50), got %v", lastTwo[0])
+	}
+	if lastTwo[1].ActionName != "truncate_lines" || lastTwo[1].Params["max"] != 120 {
+		t.Errorf("expected truncate_lines(120), got %v", lastTwo[1])
+	}
+}
+
+func TestApplyOverrideDoesNotMutateRegistry(t *testing.T) {
+	// Verify that Clone() prevents mutations from leaking into the registry.
+	original := filterForTest("test-override",
+		filter.Pipeline{
+			{ActionName: "head", Params: map[string]any{"n": 10}},
+			{ActionName: "tail", Params: map[string]any{"n": 5}},
+		},
+	)
+
+	// Simulate what Pipeline.Run does: match, then clone.
+	cloned := original.Clone()
+
+	o := config.FilterOverride{Head: 99, Tail: 88}
+	applyOverride(cloned, &o)
+
+	// Original should be unchanged
+	if original.Pipeline[0].Params["n"] != 10 {
+		t.Errorf("original head n = %v, want 10 (was corrupted)", original.Pipeline[0].Params["n"])
+	}
+	if original.Pipeline[1].Params["n"] != 5 {
+		t.Errorf("original tail n = %v, want 5 (was corrupted)", original.Pipeline[1].Params["n"])
+	}
+	// Clone should be changed
+	if cloned.Pipeline[0].Params["n"] != 99 {
+		t.Errorf("cloned head n = %v, want 99", cloned.Pipeline[0].Params["n"])
+	}
+	if cloned.Pipeline[1].Params["n"] != 88 {
+		t.Errorf("cloned tail n = %v, want 88", cloned.Pipeline[1].Params["n"])
+	}
+}
+
+func TestApplyGlobalLimitDoesNotMutateRegistry(t *testing.T) {
+	original := filterForTest("test-global",
+		filter.Pipeline{
+			{ActionName: "keep_lines", Params: map[string]any{"pattern": `\S`}},
+		},
+	)
+
+	cloned := original.Clone()
+	origLen := len(original.Pipeline)
+
+	g := config.FilterGlobalConfig{MaxLines: 50, MaxLineLength: 120}
+	applyGlobalLimit(cloned, &g)
+
+	// Original pipeline should still have same length
+	if len(original.Pipeline) != origLen {
+		t.Errorf("original pipeline grew from %d to %d (registry corrupted)", origLen, len(original.Pipeline))
+	}
+	// Clone should have extra actions
+	if len(cloned.Pipeline) != origLen+2 {
+		t.Errorf("cloned pipeline len = %d, want %d", len(cloned.Pipeline), origLen+2)
+	}
+}
+
+func TestBypassCommand(t *testing.T) {
+	// Test that bypass list sends command through passthrough unconditionally.
+	// We use "echo" since it exists everywhere and is test-friendly.
+	f := filterForTest("echo", filter.Pipeline{
+		{ActionName: "keep_lines", Params: map[string]any{"pattern": `\S`}},
+	})
+	reg := filter.NewRegistry([]filter.Filter{f})
+
+	cfg := &config.Config{
+		Filters: config.FiltersConfig{
+			Bypass: config.FilterBypassConfig{
+				Commands: []string{"echo"},
+			},
+		},
+	}
+
+	p := &Pipeline{
+		Registry: reg,
+		Config:   cfg,
+	}
+
+	// "echo" is in bypass — should passthrough (raw output, not filtered)
+	code := p.Run("echo", []string{"hello bypass!"})
+	if code != 0 {
+		t.Errorf("bypass exit code = %d, want 0", code)
+	}
+}
+
+func filterForTest(name string, pipeline filter.Pipeline) filter.Filter {
+	return filter.Filter{
+		Name:     name,
+		Version:  1,
+		Match:    filter.Match{Command: name},
+		Pipeline: pipeline,
+		OnError:  "passthrough",
 	}
 }

--- a/internal/engine/pipeline_test.go
+++ b/internal/engine/pipeline_test.go
@@ -546,3 +546,21 @@ func TestApplyOverrideAppendPreservesCloneIsolation(t *testing.T) {
 		t.Errorf("clone pipeline len = %d, want 2", len(clone.Pipeline))
 	}
 }
+
+func TestApplyOverrideNilParamsDoesNotPanic(t *testing.T) {
+	f := &filter.Filter{
+		Pipeline: filter.Pipeline{
+			{ActionName: "head", Params: nil},
+			{ActionName: "keep_lines", Params: nil},
+		},
+	}
+	o := config.FilterOverride{Head: 25, KeepLines: "error|warn"}
+	applyOverride(f, &o)
+
+	if f.Pipeline[0].Params["n"] != 25 {
+		t.Errorf("head n = %v, want 25 (nil Params should be initialized)", f.Pipeline[0].Params["n"])
+	}
+	if f.Pipeline[1].Params["pattern"] != "error|warn" {
+		t.Errorf("keep_lines pattern = %v, want error|warn", f.Pipeline[1].Params["pattern"])
+	}
+}

--- a/internal/engine/pipeline_test.go
+++ b/internal/engine/pipeline_test.go
@@ -453,3 +453,96 @@ func TestApplyGlobalLimit_ZeroIsNoOp(t *testing.T) {
 		t.Errorf("expected 0 actions for zero limits, got %d", len(f.Pipeline))
 	}
 }
+
+func TestApplyOverrideAppendsWhenActionNotInPipeline(t *testing.T) {
+	f := &filter.Filter{
+		Pipeline: filter.Pipeline{
+			{ActionName: "keep_lines", Params: map[string]any{"pattern": `\S`}},
+		},
+	}
+	o := config.FilterOverride{Head: 25}
+	applyOverride(f, &o)
+
+	if len(f.Pipeline) != 2 {
+		t.Fatalf("pipeline len = %d, want 2", len(f.Pipeline))
+	}
+	last := f.Pipeline[len(f.Pipeline)-1]
+	if last.ActionName != "head" {
+		t.Errorf("last action name = %q, want head", last.ActionName)
+	}
+	if last.Params["n"] != 25 {
+		t.Errorf("head n = %v, want 25", last.Params["n"])
+	}
+}
+
+func TestApplyOverrideAppendsMultipleUnmatchedActions(t *testing.T) {
+	f := &filter.Filter{Pipeline: filter.Pipeline{}}
+	o := config.FilterOverride{Head: 25, TruncateLines: 120, KeepLines: "error|warn"}
+	applyOverride(f, &o)
+
+	if len(f.Pipeline) != 3 {
+		t.Fatalf("pipeline len = %d, want 3", len(f.Pipeline))
+	}
+	names := map[string]bool{}
+	for _, a := range f.Pipeline {
+		names[a.ActionName] = true
+	}
+	for _, want := range []string{"head", "truncate_lines", "keep_lines"} {
+		if !names[want] {
+			t.Errorf("pipeline missing action %q", want)
+		}
+	}
+}
+
+func TestApplyOverrideDoesNotDuplicateExistingActions(t *testing.T) {
+	f := &filter.Filter{
+		Pipeline: filter.Pipeline{
+			{ActionName: "keep_lines", Params: map[string]any{"pattern": `\S`}},
+			{ActionName: "head", Params: map[string]any{"n": 10}},
+		},
+	}
+	o := config.FilterOverride{Head: 25}
+	applyOverride(f, &o)
+
+	if len(f.Pipeline) != 2 {
+		t.Fatalf("pipeline len = %d, want 2 (no duplicate)", len(f.Pipeline))
+	}
+	if f.Pipeline[1].Params["n"] != 25 {
+		t.Errorf("head n = %v, want 25 (updated in place)", f.Pipeline[1].Params["n"])
+	}
+}
+
+func TestApplyOverrideZeroValueIsNoOp(t *testing.T) {
+	f := &filter.Filter{
+		Pipeline: filter.Pipeline{
+			{ActionName: "head", Params: map[string]any{"n": 10}},
+		},
+	}
+	o := config.FilterOverride{Head: 0}
+	applyOverride(f, &o)
+
+	if len(f.Pipeline) != 1 {
+		t.Fatalf("pipeline len = %d, want 1", len(f.Pipeline))
+	}
+	if f.Pipeline[0].Params["n"] != 10 {
+		t.Errorf("head n = %v, want 10 unchanged", f.Pipeline[0].Params["n"])
+	}
+}
+
+func TestApplyOverrideAppendPreservesCloneIsolation(t *testing.T) {
+	original := &filter.Filter{
+		Pipeline: filter.Pipeline{
+			{ActionName: "keep_lines", Params: map[string]any{"pattern": `\S`}},
+		},
+	}
+	clone := original.Clone()
+	o := config.FilterOverride{Head: 25}
+	applyOverride(clone, &o)
+
+	if len(original.Pipeline) != 1 {
+		t.Errorf("original pipeline len = %d, want 1 (should not be mutated)", len(original.Pipeline))
+	}
+	if len(clone.Pipeline) != 2 {
+		t.Errorf("clone pipeline len = %d, want 2", len(clone.Pipeline))
+	}
+}

--- a/internal/filter/actions.go
+++ b/internal/filter/actions.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"text/template"
+	"unicode/utf8"
 
 	"github.com/edouard-claude/snip/internal/utils"
 )
@@ -151,7 +152,12 @@ func truncateBytes(input ActionResult, params map[string]any) (ActionResult, err
 	if len(joined) <= max {
 		return input, nil
 	}
-	input.Lines = strings.Split(joined[:max], "\n")
+	// Back off to a UTF-8 rune boundary so we never emit a partial rune.
+	cut := max
+	for cut > 0 && !utf8.RuneStart(joined[cut]) {
+		cut--
+	}
+	input.Lines = strings.Split(joined[:cut], "\n")
 	return input, nil
 }
 

--- a/internal/filter/actions.go
+++ b/internal/filter/actions.go
@@ -16,6 +16,7 @@ var actions = map[string]ActionFunc{
 	"keep_lines":      keepLines,
 	"remove_lines":    removeLines,
 	"truncate_lines":  truncateLines,
+	"truncate_bytes":  truncateBytes,
 	"strip_ansi":      stripANSI,
 	"head":            head,
 	"tail":            tail,
@@ -139,6 +140,19 @@ func truncateLines(input ActionResult, params map[string]any) (ActionResult, err
 		}
 	}
 	return ActionResult{Lines: out, Metadata: input.Metadata}, nil
+}
+
+func truncateBytes(input ActionResult, params map[string]any) (ActionResult, error) {
+	max := getInt(params, "max", 0)
+	if max <= 0 {
+		return input, nil
+	}
+	joined := strings.Join(input.Lines, "\n")
+	if len(joined) <= max {
+		return input, nil
+	}
+	input.Lines = strings.Split(joined[:max], "\n")
+	return input, nil
 }
 
 func stripANSI(input ActionResult, params map[string]any) (ActionResult, error) {

--- a/internal/filter/actions_test.go
+++ b/internal/filter/actions_test.go
@@ -3,6 +3,7 @@ package filter
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func lines(s ...string) ActionResult {
@@ -58,6 +59,51 @@ func TestTruncateLines(t *testing.T) {
 	}
 	if res.Lines[0] != "short" {
 		t.Errorf("short line modified: %q", res.Lines[0])
+	}
+}
+
+func TestTruncateBytesUTF8Boundary(t *testing.T) {
+	// "héllo" is h(1) é(2) l(1) l(1) o(1) = 6 bytes.
+	// Cutting at max=2 would land mid-rune through é (bytes 1-2).
+	// We must back off to byte 1 so we never emit invalid UTF-8.
+	input := lines("héllo")
+	res, err := truncateBytes(input, map[string]any{"max": 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := strings.Join(res.Lines, "\n")
+	if !utf8.ValidString(out) {
+		t.Errorf("truncated output is not valid UTF-8: %q (% x)", out, out)
+	}
+	if out != "h" {
+		t.Errorf("got %q, want %q", out, "h")
+	}
+}
+
+func TestTruncateBytesNoCut(t *testing.T) {
+	input := lines("short")
+	res, err := truncateBytes(input, map[string]any{"max": 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(res.Lines, "\n") != "short" {
+		t.Errorf("input mutated: %v", res.Lines)
+	}
+}
+
+func TestTruncateBytesEmoji(t *testing.T) {
+	// Emoji "🎉" is 4 bytes (F0 9F 8E 89). max=3 lands mid-emoji.
+	input := lines("ab🎉cd")
+	res, err := truncateBytes(input, map[string]any{"max": 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := strings.Join(res.Lines, "\n")
+	if !utf8.ValidString(out) {
+		t.Errorf("truncated output is not valid UTF-8: %q (% x)", out, out)
+	}
+	if out != "ab" {
+		t.Errorf("got %q, want %q", out, "ab")
 	}
 }
 

--- a/internal/filter/types.go
+++ b/internal/filter/types.go
@@ -1,6 +1,8 @@
 package filter
 
-import "slices"
+import (
+	"slices"
+)
 
 // Filter represents a declarative YAML filter for a command.
 type Filter struct {
@@ -29,6 +31,27 @@ func (f *Filter) HasStream(name string) bool {
 		return name == "stdout"
 	}
 	return slices.Contains(f.Streams, name)
+}
+
+// Clone returns a deep copy of the filter. The Pipeline and its Params
+// maps are independently allocated so mutations to the clone do not
+// affect the original.
+func (f *Filter) Clone() *Filter {
+	if f == nil {
+		return nil
+	}
+	clone := *f
+	clone.Pipeline = make(Pipeline, len(f.Pipeline))
+	for i, a := range f.Pipeline {
+		clone.Pipeline[i] = Action{
+			ActionName: a.ActionName,
+			Params:     make(map[string]any, len(a.Params)),
+		}
+		for k, v := range a.Params {
+			clone.Pipeline[i].Params[k] = v
+		}
+	}
+	return &clone
 }
 
 // Match defines which command a filter applies to.

--- a/internal/filter/types.go
+++ b/internal/filter/types.go
@@ -45,13 +45,22 @@ func (f *Filter) Clone() *Filter {
 	for i, a := range f.Pipeline {
 		clone.Pipeline[i] = Action{
 			ActionName: a.ActionName,
-			Params:     make(map[string]any, len(a.Params)),
-		}
-		for k, v := range a.Params {
-			clone.Pipeline[i].Params[k] = v
+			Params:     cloneParams(a.Params),
 		}
 	}
 	return &clone
+}
+
+// cloneParams returns a deep copy of the params map, preserving nil.
+func cloneParams(src map[string]any) map[string]any {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]any, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
 }
 
 // Match defines which command a filter applies to.

--- a/internal/filter/types_test.go
+++ b/internal/filter/types_test.go
@@ -193,3 +193,32 @@ func TestFilterCloneEmptyPipeline(t *testing.T) {
 		t.Errorf("expected empty pipeline, got %d actions", len(clone.Pipeline))
 	}
 }
+
+func TestFilterClonePreservesNilParams(t *testing.T) {
+	f := Filter{
+		Name: "test-nil-params",
+		Pipeline: Pipeline{
+			{ActionName: "head", Params: nil},
+			{ActionName: "keep_lines", Params: map[string]any{"pattern": `\S`}},
+		},
+	}
+	clone := f.Clone()
+
+	// Nil Params must stay nil on clone (not become empty map)
+	if clone.Pipeline[0].Params != nil {
+		t.Errorf("clone[0].Params = %v, want nil", clone.Pipeline[0].Params)
+	}
+	// Non-nil Params must be deep-copied
+	if clone.Pipeline[1].Params == nil {
+		t.Fatal("clone[1].Params is nil, want non-nil copy")
+	}
+	if clone.Pipeline[1].Params["pattern"] != `\S` {
+		t.Errorf("clone[1].Params[pattern] = %v, want \\S", clone.Pipeline[1].Params["pattern"])
+	}
+	// Clone must not share the params map with original
+	originalParams := f.Pipeline[1].Params
+	clone.Pipeline[1].Params["pattern"] = "modified"
+	if originalParams["pattern"] != `\S` {
+		t.Error("clone mutation leaked into original Params map")
+	}
+}

--- a/internal/filter/types_test.go
+++ b/internal/filter/types_test.go
@@ -123,3 +123,73 @@ pipeline: []
 		t.Errorf("streams = %v", f.Streams)
 	}
 }
+
+func TestFilterCloneDeepCopy(t *testing.T) {
+	original := Filter{
+		Name:    "test-clone",
+		Version: 2,
+		Match:   Match{Command: "git", Subcommand: "log"},
+		OnError: "passthrough",
+		Pipeline: Pipeline{
+			{ActionName: "head", Params: map[string]any{"n": 10}},
+			{ActionName: "keep_lines", Params: map[string]any{"pattern": `\S`}},
+		},
+	}
+
+	clone := original.Clone()
+
+	// Verify value fields
+	if clone.Name != original.Name {
+		t.Errorf("name: got %q, want %q", clone.Name, original.Name)
+	}
+	if clone.Version != original.Version {
+		t.Errorf("version: got %d, want %d", clone.Version, original.Version)
+	}
+
+	// Verify pipeline was deep-copied
+	if len(clone.Pipeline) != len(original.Pipeline) {
+		t.Fatalf("pipeline len: got %d, want %d", len(clone.Pipeline), len(original.Pipeline))
+	}
+	if clone.Pipeline[0].ActionName != original.Pipeline[0].ActionName {
+		t.Errorf("pipeline[0] action: got %q, want %q", clone.Pipeline[0].ActionName, original.Pipeline[0].ActionName)
+	}
+
+	// Mutate clone — original should be unaffected
+	clone.Pipeline[0].Params["n"] = 999
+
+	if original.Pipeline[0].Params["n"] != 10 {
+		t.Errorf("original head n = %v, want 10 (was corrupted by clone mutation)", original.Pipeline[0].Params["n"])
+	}
+	if clone.Pipeline[0].Params["n"] != 999 {
+		t.Errorf("clone head n = %v, want 999", clone.Pipeline[0].Params["n"])
+	}
+
+	// Mutate via applyGlobalLimit on clone — original should stay clean
+	clone.Pipeline = append(clone.Pipeline, Action{ActionName: "truncate_lines", Params: map[string]any{"max": 80}})
+	if len(original.Pipeline) != 2 {
+		t.Errorf("original pipeline len = %d, want 2 (corrupted by clone append)", len(original.Pipeline))
+	}
+	if len(clone.Pipeline) != 3 {
+		t.Errorf("clone pipeline len = %d, want 3", len(clone.Pipeline))
+	}
+}
+
+func TestFilterCloneNil(t *testing.T) {
+	var f *Filter
+	clone := f.Clone()
+	if clone != nil {
+		t.Error("Clone of nil should return nil")
+	}
+}
+
+func TestFilterCloneEmptyPipeline(t *testing.T) {
+	f := Filter{
+		Name:     "test-empty",
+		Match:    Match{Command: "ls"},
+		Pipeline: Pipeline{},
+	}
+	clone := f.Clone()
+	if len(clone.Pipeline) != 0 {
+		t.Errorf("expected empty pipeline, got %d actions", len(clone.Pipeline))
+	}
+}


### PR DESCRIPTION
Closes #65

Allows teams to ship a `.snip/config.toml` at the repo root. Developers
clone the repo and snip auto-loads the team's filter settings — no
per-developer config needed.

**How it works:**
- `snip` walks up from CWD looking for `.snip/config.toml`
- When `mode = \project\`, project overrides user for enable, global,
  per-filter overrides, and bypass commands
- Trust: parameter overrides load automatically; snip custom filter YAML needs
  \`snip trust\`

**Changes:**
- **config**: LoadMerged with merge precedence (project > user in project
  mode), initialize nil maps to prevent panic, gate on all global fields
- **filter/types**: Filter.Clone() deep-copies Pipeline + Params to prevent
  shared-pointer mutation through Registry.Match()
- **engine/pipeline**: Clone filter before applyOverride / applyGlobalLimit;
  snip bypass list checked before filter match
- **cli**: FilterEnabled uses merged config not user-only config

670 tests pass. Full coverage for LoadMerged, applyOverride, bypass, Clone.

Note: the first 2 commits are also in PR #69 (loop-keyword fix — submitted
first as requested). Review starting from \`bb6a175\` for corporate config.