### PR TITLE
fix(release): bypass macOS quarantine in Homebrew cask (#71)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,6 +34,12 @@ homebrew_casks:
       name: homebrew-tap
     homepage: "https://github.com/edouard-claude/snip"
     description: "CLI proxy that reduces LLM token consumption by 60-90% by filtering shell output"
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/snip"]
+          end
 
 changelog:
   sort: asc


### PR DESCRIPTION
## Summary
- Adds a `postflight` to the Homebrew cask that strips the `com.apple.quarantine` xattr from the installed binary, preventing the "Apple cannot verify developer" Gatekeeper popup on macOS.
- Official GoReleaser recommendation for unsigned binaries (https://goreleaser.com/customization/homebrew_casks/#signing-and-notarizing).
- No code change, no behavior change for Linux/Windows users.

## Why
Users installing via `brew install edouard-claude/tap/snip` on macOS were hit by Gatekeeper because the binary is not Apple-notarized, and Homebrew casks always inherit the quarantine attribute.

Notarization would require an Apple Developer account (\$99/year). The `xattr` postflight is the standard workaround used by most open-source CLI casks.

## Test plan
- [x] `goreleaser check` passes (no deprecation warning)
- [x] `goreleaser release --snapshot --clean` generates the `postflight` block in `dist/homebrew/Casks/snip.rb`
- [x] `golangci-lint run ./...` clean
- [x] `make test-race` green
- [ ] Verify on a real Mac after next release tag (no Gatekeeper popup after `brew install`)

Closes #71