### PR TITLE
feat: add gradlew-bat filter for Windows Gradle wrapper, fix platform bugs

### DIFF
--- a/filters/gradlew-bat.yaml
+++ b/filters/gradlew-bat.yaml
@@ -1,0 +1,67 @@
+name: "gradlew-bat"
+version: 1
+description: "Condensed gradle wrapper output on Windows (.bat): build result and errors"
+
+match:
+  command: "gradlew.bat"
+  exclude_flags: ["--version", "-V"]
+
+streams:
+  - stdout
+  - stderr
+
+pipeline:
+  - action: "strip_ansi"
+  - action: "remove_lines"
+    pattern: "(^> Task |^\\s*$|^Downloading|^\\.\\.\\.|^Starting)"
+  - action: "keep_lines"
+    pattern: "(BUILD|FAILURE|ERROR|error:|warning:|FAILED|UP-TO-DATE|actionable|Test result)"
+  - action: "truncate_lines"
+    max: 120
+  - action: "head"
+    n: 40
+
+on_error: "passthrough"
+
+tests:
+  - name: "build success"
+    input: |
+      > Task :compileJava
+      > Task :processResources
+      > Task :classes
+      > Task :jar
+
+      BUILD SUCCESSFUL in 2s
+      5 actionable tasks: 5 executed
+    expected: |
+      BUILD SUCCESSFUL in 2s
+      5 actionable tasks: 5 executed
+  - name: "build failure with error"
+    input: |
+      > Task :compileJava FAILED
+      > Task :processResources UP-TO-DATE
+
+      FAILURE: Build failed with an exception.
+
+      * What went wrong:
+      Execution failed for task ':compileJava'.
+      > Compilation error: package com.example does not exist
+
+      BUILD FAILED in 1s
+    expected: |
+      FAILURE: Build failed with an exception.
+      > Compilation error: package com.example does not exist
+      BUILD FAILED in 1s
+  - name: "download and start noise removed"
+    input: |
+      Downloading https://services.gradle.org/distributions/gradle-8.5-bin.zip
+      .......................................................
+      Starting a Gradle Daemon (subsequent builds will be faster)
+
+      > Task :test
+      Test result: FAILURE
+
+      BUILD FAILED in 5s
+    expected: |
+      Test result: FAILURE
+      BUILD FAILED in 5s


### PR DESCRIPTION
## What

Adds `gradlew-bat.yaml` filter for Windows Gradle wrapper (`gradlew.bat`), identical pipeline to the existing `gradlew.yaml`. 

Also fixes two platform bugs discovered during Windows testing.

## Changes

### New filter
- `filters/gradlew-bat.yaml` — matches `gradlew.bat` command
- 3 inline tests: build success, build failure with error, download/start noise removal
- Verified on Windows 10 (SSH): `snip gradlew.bat test` produces correct filtered output

### Bug fixes
1. **Infinite loop in `projectConfigPath` on Windows** — `dir != "/"` never terminates on Windows where roots are `C:\`. Fixed with platform-independent `parent == dir` guard.
2. **Goroutine order in `Execute`** — `wg.Wait()` before `cmd.Wait()` can deadlock on slow command output. Reordered: `cmd.Wait()` first, then `wg.Wait()`.

## Verification

| Test | Linux | Windows |
|------|:---:|:---:|
| `go vet ./...` | ✅ | — |
| `go test ./...` | ✅ all pass | — |
| `snip verify gradlew-bat` | ✅ 3/3 | ✅ 3/3 |
| `snip gradlew.bat test` | — | ✅ filtered output |

## Note on `.\gradlew.bat` path prefix

This PR handles `gradlew.bat` without a path prefix. The `.\gradlew.bat` path-prefixed invocation (common on Windows) is a separate issue — snip currently treats `.\gradlew.bat` as a single command name, which won't match any filter. This is a systemic issue affecting all path-prefixed commands on Windows, not specific to Gradle.

Closes #74