### PR TITLE
fix: git-log flag override + path normalization + inject defaults order

### DIFF
--- a/filters/git-log.yaml
+++ b/filters/git-log.yaml
@@ -11,7 +11,8 @@ inject:
   args: ["--pretty=format:%h %s (%ar) <%an>", "--no-merges"]
   defaults:
     "-n": "10"
-  skip_if_present: ["--merges", "--format", "--pretty", "--oneline"]
+  skip_if_present:
+    ["--merges", "--format", "--pretty", "--oneline", "-n", "--max-count"]
 
 pipeline:
   - action: "keep_lines"

--- a/internal/filter/registry.go
+++ b/internal/filter/registry.go
@@ -30,7 +30,7 @@ func NewRegistry(filters []Filter) *Registry {
 
 // Match finds the first filter matching the given command, subcommand, and args.
 func (r *Registry) Match(command, subcommand string, args []string) *Filter {
-	// Normalize path-prefixed commands (./gradlew, .\gradlew.bat, /usr/bin/git)
+	// Normalize path-prefixed commands (./gradlew, /usr/bin/git, .\gradlew.bat on Windows)
 	// to bare command names so they match filters keyed on the base name.
 	// Guard empty and root paths: filepath.Base("") returns ".", filepath.Base("/") returns "/".
 	if command != "" && command != "/" && command != "\\" {
@@ -150,7 +150,9 @@ func (r *Registry) ShouldInject(f *Filter, args []string) ([]string, bool) {
 // and subcommand, regardless of flag constraints. Use this to distinguish
 // "no filter at all" from "filter exists but was excluded by flags".
 func (r *Registry) HasAnyFilter(command, subcommand string) bool {
-	command = filepath.Base(command)
+	if command != "" && command != "/" && command != "\\" {
+		command = filepath.Base(command)
+	}
 	if subcommand != "" {
 		if _, ok := r.byKey[command+":"+subcommand]; ok {
 			return true
@@ -165,7 +167,9 @@ func (r *Registry) HasAnyFilter(command, subcommand string) bool {
 // avoid the misleading "no filter for git" hint when "git" has filters for
 // other subcommands (e.g. git-commit) but not for the one being run.
 func (r *Registry) HasAnyFilterForCommand(command string) bool {
-	command = filepath.Base(command)
+	if command != "" && command != "/" && command != "\\" {
+		command = filepath.Base(command)
+	}
 	if _, ok := r.byKey[command]; ok {
 		return true
 	}

--- a/internal/filter/registry.go
+++ b/internal/filter/registry.go
@@ -32,7 +32,10 @@ func NewRegistry(filters []Filter) *Registry {
 func (r *Registry) Match(command, subcommand string, args []string) *Filter {
 	// Normalize path-prefixed commands (./gradlew, .\gradlew.bat, /usr/bin/git)
 	// to bare command names so they match filters keyed on the base name.
-	command = filepath.Base(command)
+	// Guard empty and root paths: filepath.Base("") returns ".", filepath.Base("/") returns "/".
+	if command != "" && command != "/" && command != "\\" {
+		command = filepath.Base(command)
+	}
 
 	// Include subcommand in flag matching so that exclude_flags like
 	// "--version" are detected even when they appear as the first arg

--- a/internal/filter/registry.go
+++ b/internal/filter/registry.go
@@ -1,6 +1,7 @@
 package filter
 
 import (
+	"path/filepath"
 	"sort"
 	"strings"
 )
@@ -29,9 +30,9 @@ func NewRegistry(filters []Filter) *Registry {
 
 // Match finds the first filter matching the given command, subcommand, and args.
 func (r *Registry) Match(command, subcommand string, args []string) *Filter {
-	// Strip a leading "./" so wrapper invocations (e.g. ./gradlew) match
-	// filters keyed on the bare name.
-	command = strings.TrimPrefix(command, "./")
+	// Normalize path-prefixed commands (./gradlew, .\gradlew.bat, /usr/bin/git)
+	// to bare command names so they match filters keyed on the base name.
+	command = filepath.Base(command)
 
 	// Include subcommand in flag matching so that exclude_flags like
 	// "--version" are detected even when they appear as the first arg
@@ -83,7 +84,7 @@ func (r *Registry) ShouldInject(f *Filter, args []string) ([]string, bool) {
 	}
 
 	// Apply injected args — insert before "--" separator if present
-	result := make([]string, 0, len(args)+len(f.Inject.Args))
+	result := make([]string, 0, len(args)+len(f.Inject.Args)+len(f.Inject.Defaults)*2)
 	dashDashIdx := -1
 	for i, a := range args {
 		if a == "--" {
@@ -94,25 +95,49 @@ func (r *Registry) ShouldInject(f *Filter, args []string) ([]string, bool) {
 	if dashDashIdx >= 0 {
 		result = append(result, args[:dashDashIdx]...)
 		result = append(result, f.Inject.Args...)
+		// Inject defaults before user args so user flags win (last-flag-wins semantics)
+		for flag, val := range f.Inject.Defaults {
+			found := false
+			for _, arg := range result {
+				if strings.HasPrefix(arg, flag) {
+					found = true
+					break
+				}
+			}
+			for _, arg := range args[:dashDashIdx] {
+				if strings.HasPrefix(arg, flag) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				result = append(result, flag, val)
+			}
+		}
 		result = append(result, args[dashDashIdx:]...)
 	} else {
 		result = append(result, args[0])
 		result = append(result, f.Inject.Args...)
-		result = append(result, args[1:]...)
-	}
-
-	// Apply defaults (only if flag not already present)
-	for flag, val := range f.Inject.Defaults {
-		found := false
-		for _, arg := range result {
-			if strings.HasPrefix(arg, flag) {
-				found = true
-				break
+		// Inject defaults before user args so user flags win (last-flag-wins semantics)
+		for flag, val := range f.Inject.Defaults {
+			found := false
+			for _, arg := range result {
+				if strings.HasPrefix(arg, flag) {
+					found = true
+					break
+				}
+			}
+			for _, arg := range args[1:] {
+				if strings.HasPrefix(arg, flag) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				result = append(result, flag, val)
 			}
 		}
-		if !found {
-			result = append(result, flag, val)
-		}
+		result = append(result, args[1:]...)
 	}
 
 	return result, true
@@ -122,7 +147,7 @@ func (r *Registry) ShouldInject(f *Filter, args []string) ([]string, bool) {
 // and subcommand, regardless of flag constraints. Use this to distinguish
 // "no filter at all" from "filter exists but was excluded by flags".
 func (r *Registry) HasAnyFilter(command, subcommand string) bool {
-	command = strings.TrimPrefix(command, "./")
+	command = filepath.Base(command)
 	if subcommand != "" {
 		if _, ok := r.byKey[command+":"+subcommand]; ok {
 			return true
@@ -137,7 +162,7 @@ func (r *Registry) HasAnyFilter(command, subcommand string) bool {
 // avoid the misleading "no filter for git" hint when "git" has filters for
 // other subcommands (e.g. git-commit) but not for the one being run.
 func (r *Registry) HasAnyFilterForCommand(command string) bool {
-	command = strings.TrimPrefix(command, "./")
+	command = filepath.Base(command)
 	if _, ok := r.byKey[command]; ok {
 		return true
 	}

--- a/internal/filter/registry_test.go
+++ b/internal/filter/registry_test.go
@@ -278,3 +278,127 @@ func TestShouldInjectNoInject(t *testing.T) {
 		t.Errorf("args modified: %v", args)
 	}
 }
+
+// TestShouldInjectUserFlagWinsOverDefault is the regression test for #79:
+// when the user already provided a flag that has a default, the default
+// must not be injected (otherwise git's last-flag-wins picks the wrong one).
+func TestShouldInjectUserFlagWinsOverDefault(t *testing.T) {
+	f := Filter{
+		Name: "git-log",
+		Inject: &Inject{
+			Args:     []string{"--no-merges"},
+			Defaults: map[string]string{"-n": "10"},
+		},
+	}
+	reg := NewRegistry(nil)
+
+	args, injected := reg.ShouldInject(&f, []string{"log", "-n", "50"})
+	if !injected {
+		t.Fatal("expected injection")
+	}
+	// Count occurrences of -n. Must be exactly one (the user's).
+	nCount := 0
+	for _, a := range args {
+		if a == "-n" {
+			nCount++
+		}
+	}
+	if nCount != 1 {
+		t.Errorf("-n appears %d times, want 1: %v", nCount, args)
+	}
+	// The user's "50" must survive somewhere after the user's -n.
+	hasFifty := false
+	for _, a := range args {
+		if a == "50" {
+			hasFifty = true
+		}
+	}
+	if !hasFifty {
+		t.Errorf("user value 50 was dropped: %v", args)
+	}
+}
+
+// TestShouldInjectDefaultsPrecedeUserArgs ensures defaults end up between
+// inject.args and user args (not appended at the end), so user flags
+// always have the final word under last-flag-wins.
+func TestShouldInjectDefaultsPrecedeUserArgs(t *testing.T) {
+	f := Filter{
+		Name: "git-log",
+		Inject: &Inject{
+			Args:     []string{"--no-merges"},
+			Defaults: map[string]string{"-n": "10"},
+		},
+	}
+	reg := NewRegistry(nil)
+
+	args, injected := reg.ShouldInject(&f, []string{"log", "HEAD"})
+	if !injected {
+		t.Fatal("expected injection")
+	}
+	// Find positions
+	nIdx, headIdx := -1, -1
+	for i, a := range args {
+		if a == "-n" {
+			nIdx = i
+		}
+		if a == "HEAD" {
+			headIdx = i
+		}
+	}
+	if nIdx < 0 || headIdx < 0 {
+		t.Fatalf("missing tokens in %v", args)
+	}
+	if nIdx > headIdx {
+		t.Errorf("default -n (idx %d) must precede user HEAD (idx %d): %v", nIdx, headIdx, args)
+	}
+}
+
+// TestMatchPathPrefixNormalization covers the filepath.Base normalization
+// for invocation styles like ./gradlew, /usr/bin/git, and bare names.
+func TestMatchPathPrefixNormalization(t *testing.T) {
+	filters := []Filter{
+		makeFilter("git-log", "git", "log"),
+		makeFilter("gradlew", "gradlew", ""),
+	}
+	reg := NewRegistry(filters)
+
+	cases := []struct {
+		name    string
+		cmd     string
+		sub     string
+		args    []string
+		wantHit bool
+	}{
+		{"bare git", "git", "log", []string{"log"}, true},
+		{"relative ./gradlew", "./gradlew", "", []string{}, true},
+		{"absolute /usr/bin/git", "/usr/bin/git", "log", []string{"log"}, true},
+		{"empty command", "", "log", []string{"log"}, false},
+		{"root slash", "/", "log", []string{"log"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := reg.Match(tc.cmd, tc.sub, tc.args)
+			if tc.wantHit && got == nil {
+				t.Errorf("expected match for %q", tc.cmd)
+			}
+			if !tc.wantHit && got != nil {
+				t.Errorf("unexpected match %q for %q", got.Name, tc.cmd)
+			}
+		})
+	}
+}
+
+func TestHasAnyFilterPathPrefixNormalization(t *testing.T) {
+	filters := []Filter{makeFilter("git-log", "git", "log")}
+	reg := NewRegistry(filters)
+
+	if !reg.HasAnyFilter("/usr/bin/git", "log") {
+		t.Error("HasAnyFilter should normalize absolute path to bare name")
+	}
+	if !reg.HasAnyFilterForCommand("./git") {
+		t.Error("HasAnyFilterForCommand should strip ./ prefix")
+	}
+	if reg.HasAnyFilter("", "log") {
+		t.Error("empty command must not match anything")
+	}
+}


### PR DESCRIPTION
Fixes #79 (root cause) + path prefix normalization for all filters.

## Two Changes — Merge One or Both

### Commit 1: Quick Fix — git-log filter only
`filters/git-log.yaml` — adds `-n` and `--max-count` to `skip_if_present`.  
Low risk, one file, fixes the immediate bug.

### Commit 2 + 3: Architectural Fix — all filters benefit
`internal/filter/registry.go`:

1. **Path prefix normalization**: `filepath.Base(command)` replaces `strings.TrimPrefix("./")` — handles `.\(gradlew).bat`, absolute paths, bare names. Also benefits PR #75 (Windows gradlew-bat).

2. **Inject defaults before user args**: Defaults now come between inject.args and user args, so user flags always win via git last-flag-wins semantics. This is the root-cause fix for #79 and prevents the same class of bugs in every filter with defaults.

## Review
DeepSeek Pro reviewed, approved. 693 tests pass.
