### PR TITLE
feat: token-neutral summary line shows AI what filters were applied

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ db_path = "~/.local/share/snip/tracking.db"
 color = true
 emoji = true
 quiet_no_filter = false  # suppress "no filter" stderr messages
+summary = false          # prepend a "[snip: ...]" line showing which filter/args were applied
 
 [filters]
 dir = "~/.config/snip/filters"

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -142,6 +142,7 @@ func Run(args []string) int {
 		fmt.Printf("display.color: %v\n", cfg.Display.Color)
 		fmt.Printf("display.emoji: %v\n", cfg.Display.Emoji)
 		fmt.Printf("display.quiet_no_filter: %v\n", cfg.Display.QuietNoFilter)
+		fmt.Printf("display.summary: %v\n", cfg.Display.Summary)
 		if len(cfg.Filters.Enable) == 0 {
 			fmt.Println("filters.enable: (all enabled)")
 		} else {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,7 @@ type DisplayConfig struct {
 	Color         bool `toml:"color"`
 	Emoji         bool `toml:"emoji"`
 	QuietNoFilter bool `toml:"quiet_no_filter"`
+	Summary       bool `toml:"summary"`
 }
 
 type FiltersConfig struct {
@@ -114,8 +115,9 @@ func DefaultConfig() *Config {
 			DBPath: filepath.Join(home, ".local", "share", "snip", "tracking.db"),
 		},
 		Display: DisplayConfig{
-			Color: true,
-			Emoji: true,
+			Color:   true,
+			Emoji:   true,
+			Summary: true,
 		},
 		Filters: FiltersConfig{
 			Dir: filepath.Join(home, ".config", "snip", "filters"),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -117,7 +117,7 @@ func DefaultConfig() *Config {
 		Display: DisplayConfig{
 			Color:   true,
 			Emoji:   true,
-			Summary: true,
+			Summary: false,
 		},
 		Filters: FiltersConfig{
 			Dir: filepath.Join(home, ".config", "snip", "filters"),

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -164,6 +164,19 @@ func (p *Pipeline) Run(command string, args []string) int {
 		filtered = pipelineInput
 	}
 
+	// Apply summary line (token-neutral)
+	if p.summaryEnabled() && filterErr == nil {
+		info := SummaryInfo{
+			FilterName:    f.Name,
+			FilterVersion: f.Version,
+			InjectedArgs:  ComputeInjectedArgs(fullArgs, finalArgs),
+			PipelineNames: f.PipelineActionNames(),
+		}
+		if summary := BuildSummaryLine(info); summary != "" {
+			filtered = ApplySummary(filtered, summary)
+		}
+	}
+
 	// Tee: save raw output if needed
 	hint := tee.MaybeSave(pipelineInput, result.ExitCode, command, p.TeeConfig)
 
@@ -307,6 +320,16 @@ func (p *Pipeline) Passthrough(command string, args []string) int {
 // rather than sending nothing to the LLM (issue #85).
 func shouldRestoreRaw(filtered, raw string) bool {
 	return strings.TrimSpace(filtered) == "" && strings.TrimSpace(raw) != ""
+}
+
+func (p *Pipeline) summaryEnabled() bool {
+	if p.UltraCompact {
+		return false
+	}
+	if p.Config != nil {
+		return p.Config.Display.Summary
+	}
+	return true
 }
 
 // isFilterEnabled returns whether a filter is enabled. A nil map means all

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -164,7 +164,11 @@ func (p *Pipeline) Run(command string, args []string) int {
 		filtered = pipelineInput
 	}
 
-	// Apply summary line (token-neutral)
+	// Compute token counts before summary so we can use savings as the budget
+	inputTokens := utils.EstimateTokens(pipelineInput)
+	filteredTokens := utils.EstimateTokens(filtered)
+
+	// Apply summary line (additive only — never removes content)
 	if p.summaryEnabled() && filterErr == nil {
 		info := SummaryInfo{
 			FilterName:    f.Name,
@@ -173,7 +177,7 @@ func (p *Pipeline) Run(command string, args []string) int {
 			PipelineNames: f.PipelineActionNames(),
 		}
 		if summary := BuildSummaryLine(info); summary != "" {
-			filtered = ApplySummary(filtered, summary)
+			filtered = PrependSummary(filtered, summary, inputTokens, filteredTokens)
 		}
 	}
 
@@ -191,7 +195,6 @@ func (p *Pipeline) Run(command string, args []string) int {
 	}
 
 	// Track (skip if no input — nothing meaningful to measure)
-	inputTokens := utils.EstimateTokens(pipelineInput)
 	if inputTokens > 0 {
 		originalCmd := command + " " + strings.Join(fullArgs, " ")
 		snipCmd := command + " " + strings.Join(finalArgs, " ")

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -332,7 +332,7 @@ func (p *Pipeline) summaryEnabled() bool {
 	if p.Config != nil {
 		return p.Config.Display.Summary
 	}
-	return true
+	return false
 }
 
 // isFilterEnabled returns whether a filter is enabled. A nil map means all

--- a/internal/engine/summary.go
+++ b/internal/engine/summary.go
@@ -1,0 +1,107 @@
+package engine
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/edouard-claude/snip/internal/utils"
+)
+
+// SummaryInfo holds the data needed to build a summary line.
+type SummaryInfo struct {
+	FilterName    string
+	FilterVersion int
+	InjectedArgs  []string
+	PipelineNames []string
+}
+
+const maxArgDisplayLen = 20
+const minLinesForSummary = 3
+
+// BuildSummaryLine constructs a compact summary string from filter metadata.
+func BuildSummaryLine(info SummaryInfo) string {
+	if len(info.InjectedArgs) == 0 && len(info.PipelineNames) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "[snip: %s v%d", info.FilterName, info.FilterVersion)
+
+	if len(info.InjectedArgs) > 0 {
+		b.WriteString(" | ")
+		for i, arg := range info.InjectedArgs {
+			if i > 0 {
+				b.WriteByte(' ')
+			}
+			b.WriteByte('+')
+			if len(arg) > maxArgDisplayLen {
+				b.WriteString(arg[:maxArgDisplayLen-3])
+				b.WriteString("...")
+			} else {
+				b.WriteString(arg)
+			}
+		}
+	}
+
+	if len(info.PipelineNames) > 0 {
+		b.WriteString(" | ")
+		b.WriteString(strings.Join(info.PipelineNames, ">"))
+	}
+
+	b.WriteByte(']')
+	return b.String()
+}
+
+// ApplySummary prepends a summary line to filtered output while maintaining
+// token neutrality. Returns the original output unchanged if the summary
+// cannot fit within the token budget.
+func ApplySummary(filtered string, summary string) string {
+	if summary == "" {
+		return filtered
+	}
+
+	lines := strings.Split(strings.TrimRight(filtered, "\n"), "\n")
+	if len(lines) < minLinesForSummary {
+		return filtered
+	}
+
+	summaryWithNewline := summary + "\n"
+	summaryTokens := utils.EstimateTokens(summaryWithNewline)
+	filteredTokens := utils.EstimateTokens(filtered)
+
+	if summaryTokens >= filteredTokens {
+		return filtered
+	}
+
+	// Trim trailing lines until the summary fits within the original budget
+	remaining := lines
+	remainingStr := strings.Join(remaining, "\n") + "\n"
+	for len(remaining) > 1 && utils.EstimateTokens(remainingStr)+summaryTokens > filteredTokens {
+		remaining = remaining[:len(remaining)-1]
+		remainingStr = strings.Join(remaining, "\n") + "\n"
+	}
+
+	if utils.EstimateTokens(remainingStr)+summaryTokens > filteredTokens {
+		return filtered
+	}
+
+	return summaryWithNewline + remainingStr
+}
+
+// ComputeInjectedArgs returns args present in finalArgs but not in fullArgs.
+func ComputeInjectedArgs(fullArgs, finalArgs []string) []string {
+	original := make(map[string]int, len(fullArgs))
+	for _, a := range fullArgs {
+		original[a]++
+	}
+
+	var injected []string
+	seen := make(map[string]int, len(finalArgs))
+	for _, a := range finalArgs {
+		seen[a]++
+		if seen[a] > original[a] {
+			injected = append(injected, a)
+		}
+	}
+	return injected
+}

--- a/internal/engine/summary.go
+++ b/internal/engine/summary.go
@@ -34,12 +34,7 @@ func BuildSummaryLine(info SummaryInfo) string {
 				b.WriteByte(' ')
 			}
 			b.WriteByte('+')
-			if len(arg) > maxArgDisplayLen {
-				b.WriteString(arg[:maxArgDisplayLen-3])
-				b.WriteString("...")
-			} else {
-				b.WriteString(arg)
-			}
+			b.WriteString(utils.Truncate(arg, maxArgDisplayLen))
 		}
 	}
 
@@ -61,8 +56,9 @@ func PrependSummary(filtered string, summary string, inputTokens, filteredTokens
 		return filtered
 	}
 
-	lines := strings.Split(strings.TrimRight(filtered, "\n"), "\n")
-	if len(lines) < minLinesForSummary {
+	// Count lines without allocating a slice: line count == "\n" count + 1
+	// once trailing newlines are ignored.
+	if strings.Count(strings.TrimRight(filtered, "\n"), "\n")+1 < minLinesForSummary {
 		return filtered
 	}
 

--- a/internal/engine/summary.go
+++ b/internal/engine/summary.go
@@ -52,10 +52,11 @@ func BuildSummaryLine(info SummaryInfo) string {
 	return b.String()
 }
 
-// ApplySummary prepends a summary line to filtered output while maintaining
-// token neutrality. Returns the original output unchanged if the summary
-// cannot fit within the token budget.
-func ApplySummary(filtered string, summary string) string {
+// PrependSummary prepends a summary line to filtered output without removing
+// any content. The summary is only added when the token savings from filtering
+// exceed the cost of the summary line itself, guaranteeing the output with
+// summary is always smaller than the original raw output.
+func PrependSummary(filtered string, summary string, inputTokens, filteredTokens int) string {
 	if summary == "" {
 		return filtered
 	}
@@ -65,27 +66,13 @@ func ApplySummary(filtered string, summary string) string {
 		return filtered
 	}
 
-	summaryWithNewline := summary + "\n"
-	summaryTokens := utils.EstimateTokens(summaryWithNewline)
-	filteredTokens := utils.EstimateTokens(filtered)
-
-	if summaryTokens >= filteredTokens {
+	summaryTokens := utils.EstimateTokens(summary + "\n")
+	savedTokens := inputTokens - filteredTokens
+	if summaryTokens >= savedTokens {
 		return filtered
 	}
 
-	// Trim trailing lines until the summary fits within the original budget
-	remaining := lines
-	remainingStr := strings.Join(remaining, "\n") + "\n"
-	for len(remaining) > 1 && utils.EstimateTokens(remainingStr)+summaryTokens > filteredTokens {
-		remaining = remaining[:len(remaining)-1]
-		remainingStr = strings.Join(remaining, "\n") + "\n"
-	}
-
-	if utils.EstimateTokens(remainingStr)+summaryTokens > filteredTokens {
-		return filtered
-	}
-
-	return summaryWithNewline + remainingStr
+	return summary + "\n" + filtered
 }
 
 // ComputeInjectedArgs returns args present in finalArgs but not in fullArgs.

--- a/internal/engine/summary_test.go
+++ b/internal/engine/summary_test.go
@@ -1,0 +1,183 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/edouard-claude/snip/internal/utils"
+)
+
+func TestBuildSummaryLineInjectionOnly(t *testing.T) {
+	got := BuildSummaryLine(SummaryInfo{
+		FilterName:    "git-status",
+		FilterVersion: 2,
+		InjectedArgs:  []string{"--porcelain"},
+	})
+	want := "[snip: git-status v2 | +--porcelain]"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildSummaryLinePipelineOnly(t *testing.T) {
+	got := BuildSummaryLine(SummaryInfo{
+		FilterName:    "find",
+		FilterVersion: 1,
+		PipelineNames: []string{"compact_path", "head"},
+	})
+	want := "[snip: find v1 | compact_path>head]"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildSummaryLineBoth(t *testing.T) {
+	got := BuildSummaryLine(SummaryInfo{
+		FilterName:    "git-log",
+		FilterVersion: 1,
+		InjectedArgs:  []string{"--no-merges"},
+		PipelineNames: []string{"keep_lines", "truncate_lines", "format_template"},
+	})
+	want := "[snip: git-log v1 | +--no-merges | keep_lines>truncate_lines>format_template]"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildSummaryLineEmpty(t *testing.T) {
+	got := BuildSummaryLine(SummaryInfo{
+		FilterName:    "noop",
+		FilterVersion: 1,
+	})
+	if got != "" {
+		t.Errorf("expected empty string, got %q", got)
+	}
+}
+
+func TestBuildSummaryLineLongArgTruncated(t *testing.T) {
+	got := BuildSummaryLine(SummaryInfo{
+		FilterName:    "git-log",
+		FilterVersion: 1,
+		InjectedArgs:  []string{"--pretty=format:%h %s (%ar) <%an>"},
+	})
+	want := "[snip: git-log v1 | +--pretty=format:%...]"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildSummaryLineMultipleArgs(t *testing.T) {
+	got := BuildSummaryLine(SummaryInfo{
+		FilterName:    "git-log",
+		FilterVersion: 1,
+		InjectedArgs:  []string{"--no-merges", "-n", "10"},
+		PipelineNames: []string{"keep_lines"},
+	})
+	want := "[snip: git-log v1 | +--no-merges +-n +10 | keep_lines]"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestApplySummaryEmptySkipped(t *testing.T) {
+	filtered := "line1\nline2\nline3\n"
+	got := ApplySummary(filtered, "")
+	if got != filtered {
+		t.Errorf("expected unchanged output, got %q", got)
+	}
+}
+
+func TestApplySummarySingleLineSkipped(t *testing.T) {
+	filtered := "line1\n"
+	got := ApplySummary(filtered, "[snip: test v1 | +--flag]")
+	if got != filtered {
+		t.Errorf("expected unchanged output, got %q", got)
+	}
+}
+
+func TestApplySummaryTwoLinesSkipped(t *testing.T) {
+	filtered := "line1\nline2\n"
+	got := ApplySummary(filtered, "[snip: test v1 | +--flag]")
+	if got != filtered {
+		t.Errorf("expected unchanged output, got %q", got)
+	}
+}
+
+func TestApplySummarySufficientOutput(t *testing.T) {
+	filtered := "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n"
+	summary := "[snip: test v1 | +--x]"
+	got := ApplySummary(filtered, summary)
+	if !strings.HasPrefix(got, summary+"\n") {
+		t.Errorf("expected output to start with summary, got %q", got)
+	}
+}
+
+func TestApplySummaryLargerThanOutputSkipped(t *testing.T) {
+	filtered := "ab\ncd\nef\n"
+	summary := "[snip: very-long-filter-name-here v999 | +--extremely-long-flag | action1>action2>action3>action4]"
+	got := ApplySummary(filtered, summary)
+	if got != filtered {
+		t.Errorf("expected unchanged output, got %q", got)
+	}
+}
+
+func TestApplySummaryTokenNeutral(t *testing.T) {
+	inputs := []string{
+		"line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n",
+		strings.Repeat("a long line with content\n", 20),
+		"short\nmedium length line\na very long line that has quite a lot of content in it\nfourth\nfifth\nsixth\n",
+	}
+	summaries := []string{
+		"[snip: git-status v2 | +--porcelain | keep_lines>group_by]",
+		"[snip: test v1 | +--flag]",
+		"[snip: go-test v3 | +-json | keep_lines>aggregate>format_template]",
+	}
+
+	for _, filtered := range inputs {
+		for _, summary := range summaries {
+			result := ApplySummary(filtered, summary)
+			originalTokens := utils.EstimateTokens(filtered)
+			resultTokens := utils.EstimateTokens(result)
+
+			if resultTokens > originalTokens {
+				t.Errorf("token neutrality violated: original=%d, result=%d, summary=%q, filtered=%q",
+					originalTokens, resultTokens, summary, filtered[:min(50, len(filtered))])
+			}
+		}
+	}
+}
+
+func TestComputeInjectedArgsBasic(t *testing.T) {
+	got := ComputeInjectedArgs([]string{"status"}, []string{"status", "--porcelain"})
+	if len(got) != 1 || got[0] != "--porcelain" {
+		t.Errorf("got %v, want [--porcelain]", got)
+	}
+}
+
+func TestComputeInjectedArgsNoChange(t *testing.T) {
+	got := ComputeInjectedArgs([]string{"log", "--oneline"}, []string{"log", "--oneline"})
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty", got)
+	}
+}
+
+func TestComputeInjectedArgsDefaults(t *testing.T) {
+	got := ComputeInjectedArgs([]string{"log"}, []string{"log", "-n", "10", "--no-merges"})
+	want := []string{"-n", "10", "--no-merges"}
+	if len(got) != len(want) {
+		t.Errorf("got %v, want %v", got, want)
+		return
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("got[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestComputeInjectedArgsDuplicatePreserved(t *testing.T) {
+	got := ComputeInjectedArgs([]string{"diff", "--stat"}, []string{"diff", "--stat"})
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty", got)
+	}
+}

--- a/internal/engine/summary_test.go
+++ b/internal/engine/summary_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/edouard-claude/snip/internal/utils"
 )
@@ -61,6 +62,24 @@ func TestBuildSummaryLineLongArgTruncated(t *testing.T) {
 		InjectedArgs:  []string{"--pretty=format:%h %s (%ar) <%an>"},
 	})
 	want := "[snip: git-log v1 | +--pretty=format:%...]"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildSummaryLineMultibyteArgTruncated(t *testing.T) {
+	// 25 two-byte runes (50 bytes). A byte-based slice would cut mid-rune and
+	// emit invalid UTF-8; truncation must be rune-safe.
+	arg := strings.Repeat("é", 25)
+	got := BuildSummaryLine(SummaryInfo{
+		FilterName:    "git-log",
+		FilterVersion: 1,
+		InjectedArgs:  []string{arg},
+	})
+	if !utf8.ValidString(got) {
+		t.Fatalf("summary contains invalid UTF-8: %q", got)
+	}
+	want := "[snip: git-log v1 | +" + strings.Repeat("é", 17) + "...]"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}

--- a/internal/engine/summary_test.go
+++ b/internal/engine/summary_test.go
@@ -79,53 +79,87 @@ func TestBuildSummaryLineMultipleArgs(t *testing.T) {
 	}
 }
 
-func TestApplySummaryEmptySkipped(t *testing.T) {
+func TestPrependSummaryEmptySkipped(t *testing.T) {
 	filtered := "line1\nline2\nline3\n"
-	got := ApplySummary(filtered, "")
+	got := PrependSummary(filtered, "", 100, 10)
 	if got != filtered {
 		t.Errorf("expected unchanged output, got %q", got)
 	}
 }
 
-func TestApplySummarySingleLineSkipped(t *testing.T) {
+func TestPrependSummarySingleLineSkipped(t *testing.T) {
 	filtered := "line1\n"
-	got := ApplySummary(filtered, "[snip: test v1 | +--flag]")
+	got := PrependSummary(filtered, "[snip: test v1 | +--flag]", 1000, 10)
 	if got != filtered {
 		t.Errorf("expected unchanged output, got %q", got)
 	}
 }
 
-func TestApplySummaryTwoLinesSkipped(t *testing.T) {
+func TestPrependSummaryTwoLinesSkipped(t *testing.T) {
 	filtered := "line1\nline2\n"
-	got := ApplySummary(filtered, "[snip: test v1 | +--flag]")
+	got := PrependSummary(filtered, "[snip: test v1 | +--flag]", 1000, 10)
 	if got != filtered {
 		t.Errorf("expected unchanged output, got %q", got)
 	}
 }
 
-func TestApplySummarySufficientOutput(t *testing.T) {
+func TestPrependSummaryAddsLine(t *testing.T) {
 	filtered := "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n"
 	summary := "[snip: test v1 | +--x]"
-	got := ApplySummary(filtered, summary)
+	got := PrependSummary(filtered, summary, 1000, utils.EstimateTokens(filtered))
 	if !strings.HasPrefix(got, summary+"\n") {
 		t.Errorf("expected output to start with summary, got %q", got)
 	}
-}
-
-func TestApplySummaryLargerThanOutputSkipped(t *testing.T) {
-	filtered := "ab\ncd\nef\n"
-	summary := "[snip: very-long-filter-name-here v999 | +--extremely-long-flag | action1>action2>action3>action4]"
-	got := ApplySummary(filtered, summary)
-	if got != filtered {
-		t.Errorf("expected unchanged output, got %q", got)
+	if !strings.HasSuffix(got, filtered) {
+		t.Errorf("expected original content preserved, got %q", got)
 	}
 }
 
-func TestApplySummaryTokenNeutral(t *testing.T) {
-	inputs := []string{
-		"line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n",
-		strings.Repeat("a long line with content\n", 20),
-		"short\nmedium length line\na very long line that has quite a lot of content in it\nfourth\nfifth\nsixth\n",
+func TestPrependSummaryPreservesAllContent(t *testing.T) {
+	filtered := "line1\nline2\nline3\nline4\nline5\n"
+	summary := "[snip: git-status v2 | +--porcelain]"
+	got := PrependSummary(filtered, summary, 1000, utils.EstimateTokens(filtered))
+	for _, line := range []string{"line1", "line2", "line3", "line4", "line5"} {
+		if !strings.Contains(got, line) {
+			t.Errorf("expected %q to be preserved in output, got %q", line, got)
+		}
+	}
+}
+
+func TestPrependSummarySkipsWhenSavingsTooSmall(t *testing.T) {
+	filtered := "line1\nline2\nline3\n"
+	summary := "[snip: test v1 | +--flag]"
+	summaryTokens := utils.EstimateTokens(summary + "\n")
+	filteredTokens := utils.EstimateTokens(filtered)
+	// inputTokens just barely above filteredTokens — savings < summary cost
+	inputTokens := filteredTokens + summaryTokens - 1
+	got := PrependSummary(filtered, summary, inputTokens, filteredTokens)
+	if got != filtered {
+		t.Errorf("expected unchanged output when savings too small, got %q", got)
+	}
+}
+
+func TestPrependSummaryAppliesWhenSavingsSufficient(t *testing.T) {
+	filtered := "line1\nline2\nline3\n"
+	summary := "[snip: test v1 | +--flag]"
+	summaryTokens := utils.EstimateTokens(summary + "\n")
+	filteredTokens := utils.EstimateTokens(filtered)
+	// inputTokens well above filteredTokens — savings > summary cost
+	inputTokens := filteredTokens + summaryTokens + 100
+	got := PrependSummary(filtered, summary, inputTokens, filteredTokens)
+	if !strings.HasPrefix(got, summary+"\n") {
+		t.Errorf("expected summary prepended, got %q", got)
+	}
+}
+
+func TestPrependSummaryNeverExceedsRawInput(t *testing.T) {
+	inputs := []struct {
+		filtered    string
+		inputTokens int
+	}{
+		{"line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n", 500},
+		{strings.Repeat("a long line with content\n", 20), 2000},
+		{"short\nmedium length line\na very long line that has quite a lot of content in it\nfourth\nfifth\nsixth\n", 300},
 	}
 	summaries := []string{
 		"[snip: git-status v2 | +--porcelain | keep_lines>group_by]",
@@ -133,15 +167,14 @@ func TestApplySummaryTokenNeutral(t *testing.T) {
 		"[snip: go-test v3 | +-json | keep_lines>aggregate>format_template]",
 	}
 
-	for _, filtered := range inputs {
+	for _, tc := range inputs {
+		filteredTokens := utils.EstimateTokens(tc.filtered)
 		for _, summary := range summaries {
-			result := ApplySummary(filtered, summary)
-			originalTokens := utils.EstimateTokens(filtered)
+			result := PrependSummary(tc.filtered, summary, tc.inputTokens, filteredTokens)
 			resultTokens := utils.EstimateTokens(result)
-
-			if resultTokens > originalTokens {
-				t.Errorf("token neutrality violated: original=%d, result=%d, summary=%q, filtered=%q",
-					originalTokens, resultTokens, summary, filtered[:min(50, len(filtered))])
+			if resultTokens > tc.inputTokens {
+				t.Errorf("output exceeds raw input: input=%d, result=%d, summary=%q",
+					tc.inputTokens, resultTokens, summary)
 			}
 		}
 	}

--- a/internal/filter/types.go
+++ b/internal/filter/types.go
@@ -93,5 +93,14 @@ type ActionResult struct {
 	Metadata map[string]any
 }
 
+// PipelineActionNames returns the ordered list of action names in the pipeline.
+func (f *Filter) PipelineActionNames() []string {
+	names := make([]string, len(f.Pipeline))
+	for i, a := range f.Pipeline {
+		names[i] = a.ActionName
+	}
+	return names
+}
+
 // ActionFunc is the signature for built-in action implementations.
 type ActionFunc func(input ActionResult, params map[string]any) (ActionResult, error)


### PR DESCRIPTION
### Problem
LLMs sometimes want the content that is being snipped, and start diagnosing their output as they don't understand the cause.

### Solution
By explaining what snip changed, the LLM understands better the cause of unexpected change.
In this PR we add a diagnostic line showing added flags and pipeline stages, but only if the amount of content reduces is enough to offset the stat line.

```bash
$ ./snip run -- git log
[snip: git-log v1 | +--pretty=format:%... +--no-merges +-n +10 | keep_lines>truncate_lines>format_template]
10 commits:
946a365 feat: token-neutral summary line shows AI what filters were applied (...
9028d2d test: cover inject defaults order + path prefix normalization (11 hou...
fe7f82f fix: add empty/root guard to HasAnyFilter + clarify path comment (13 ...
2b068a9 fix: git-log filter no longer overrides user commit-count flags (clos...
1937ce8 fix: guard empty and root paths in filepath.Base normalization (14 ho...
11f6f0f fix: path prefix normalization + inject defaults before user args (14...
07b8593 refactor(engine): split lookPath by platform, preserve Windows PATHEX...
1204a92 fix: 绕过 Android 内核不支持的 faccessat2 系统调用 (5 days ago) <assesvgs>

$ ./snip run -- git diff HEAD~1
[snip: git-diff v1 | +--stat | keep_lines>truncate_lines>head>format_template]
6 files changed:
 internal/config/config.go       |   6 +-
 internal/engine/pipeline.go     |  23 +++++
 internal/engine/summary.go      | 107 +++++++++++++++++++++++
 internal/engine/summary_test.go | 183 ++++++++++++++++++++++++++++++++++++++++
```

LLM response:
```
the git-diff filter is the wrong one for AI use. When I need a diff, I need the patch. With snip hooked in, I'd have to fall back to the Read tool on the file itself, or use git show, which may
  or may not have its own filter.
  
  ./snip run -- git show --format="" HEAD -- internal/engine/summary.go
  ...
  git show works — no filter intercepts it, so I get the full patch. That's my escape hatch if snip is hooked in and I need actual diff content.
```

And the summary does not occur if not enough lines were saved.
```bash
$ touch a b c && ./snip run -- git status && rm a b c
?? a
?? b
?? c
??: 3

$ touch a b c d e f g h i j k l m n o p q r s t && ./snip run -- git status && rm a b c d e f g h i j k l m n o p q r s t
[snip: git-status v2 | +--porcelain | keep_lines>group_by]
?? a
?? b
?? c
?? d
?? e
?? f
?? g
?? h
?? i

$ touch a b c && git status && rm a b c
On branch summary
Your branch is up to date with 'greg/summary'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	a b c

nothing added to commit but untracked files present (use "git add" to track)
```

### Notes
I am not a Go developer and Claude Opus 4.6 was used to generate this patch.

### Todo from feedback
- Ensure the output is not truncated during the ApplySummary phase.