### PR TITLE
fix: scope uv-sync filter to subcommand (closes #83)

### DIFF
--- a/filters/uv-add.yaml
+++ b/filters/uv-add.yaml
@@ -1,10 +1,10 @@
-name: "uv-sync"
+name: "uv-add"
 version: 1
-description: "Condensed uv output: install summary"
+description: "Condensed uv add output: install summary"
 
 match:
   command: "uv"
-  subcommand: "sync"
+  subcommand: "add"
   exclude_flags: ["--version", "-V"]
 
 streams:

--- a/filters/uv-lock.yaml
+++ b/filters/uv-lock.yaml
@@ -1,10 +1,10 @@
-name: "uv-sync"
+name: "uv-lock"
 version: 1
-description: "Condensed uv output: install summary"
+description: "Condensed uv lock output: resolve summary"
 
 match:
   command: "uv"
-  subcommand: "sync"
+  subcommand: "lock"
   exclude_flags: ["--version", "-V"]
 
 streams:

--- a/filters/uv-remove.yaml
+++ b/filters/uv-remove.yaml
@@ -1,10 +1,10 @@
-name: "uv-sync"
+name: "uv-remove"
 version: 1
-description: "Condensed uv output: install summary"
+description: "Condensed uv remove output: uninstall summary"
 
 match:
   command: "uv"
-  subcommand: "sync"
+  subcommand: "remove"
   exclude_flags: ["--version", "-V"]
 
 streams:


### PR DESCRIPTION
## Summary
- `filters/uv-sync.yaml` matched any `uv` invocation because it declared `command: uv` with no `subcommand`. Running `snip uv run pytest ...` therefore went through the install-summary pipeline, which dropped all pytest output (issue #83).
- Scope `uv-sync` to `subcommand: sync` so `uv run`, `uv tool`, `uv venv`, etc. pass through unfiltered.
- Add sibling filters `uv-lock`, `uv-add`, `uv-remove` reusing the same pipeline so the install-summary filtering still applies to the other package operations that share that output shape.

## Test plan
- [x] `make test`
- [x] `make test-race`
- [x] `make lint` (`go vet` clean)
- [x] `snip check -- uv run pytest tests/ -x -v` reports `no filter` (was `uv-sync` before)
- [x] `snip check -- uv sync` → `uv-sync`, `uv lock` → `uv-lock`, `uv add X` → `uv-add`, `uv remove X` → `uv-remove`