### PR TITLE
fix: docker-build no longer swallows docker run output (closes #85)

### DIFF
--- a/filters/docker-build.yaml
+++ b/filters/docker-build.yaml
@@ -1,9 +1,14 @@
 name: "docker-build"
-version: 3
+version: 4
 description: "Condensed docker build: step names, final result, and errors"
 
+# Scoped to `docker build` only. A command-only match used to swallow the
+# output of every docker subcommand (run, exec, cp, ...) because its keep_lines
+# step drops anything that isn't build output (issue #85). Note: `docker buildx
+# build` (subcommand "buildx") is not matched and passes through unfiltered.
 match:
   command: "docker"
+  subcommand: "build"
   exclude_flags: ["--version", "-v"]
 
 streams:

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -118,6 +118,18 @@ func (p *Pipeline) Run(command string, args []string) int {
 		filtered = pipelineInput
 	}
 
+	// Safety net: a filter that strips every line would send empty output to
+	// the LLM, which is worse than the raw result and triggers wasteful retry
+	// loops (issue #85). Fall back to raw unless the input was itself empty.
+	// Filters with a legitimately empty result use the on_empty action to emit
+	// a message, so they never reach this state.
+	if shouldRestoreRaw(filtered, pipelineInput) {
+		if p.Verbose > 0 {
+			fmt.Fprintf(os.Stderr, "snip: filter %q produced empty output, using raw\n", f.Name)
+		}
+		filtered = pipelineInput
+	}
+
 	// Tee: save raw output if needed
 	hint := tee.MaybeSave(pipelineInput, result.ExitCode, command, p.TeeConfig)
 
@@ -156,6 +168,13 @@ func (p *Pipeline) Passthrough(command string, args []string) int {
 	}
 
 	return code
+}
+
+// shouldRestoreRaw reports whether a filter produced an empty (whitespace-only)
+// result from non-empty input. In that case the engine restores the raw output
+// rather than sending nothing to the LLM (issue #85).
+func shouldRestoreRaw(filtered, raw string) bool {
+	return strings.TrimSpace(filtered) == "" && strings.TrimSpace(raw) != ""
 }
 
 // isFilterEnabled returns whether a filter is enabled. A nil map means all

--- a/internal/engine/pipeline_test.go
+++ b/internal/engine/pipeline_test.go
@@ -128,6 +128,28 @@ func TestApplyPipelineGracefulDegradation(t *testing.T) {
 	}
 }
 
+func TestShouldRestoreRaw(t *testing.T) {
+	cases := []struct {
+		name     string
+		filtered string
+		raw      string
+		want     bool
+	}{
+		{"emptied non-empty input", "\n", "real output\nmore\n", true},
+		{"whitespace-only result", "   \n\t\n", "real output\n", true},
+		{"normal filtered output", "kept\n", "kept\ndropped\n", false},
+		{"legitimately empty input", "\n", "\n", false},
+		{"both empty", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldRestoreRaw(tc.filtered, tc.raw); got != tc.want {
+				t.Errorf("shouldRestoreRaw(%q, %q) = %v, want %v", tc.filtered, tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestIsFilterEnabledNilMap(t *testing.T) {
 	p := &Pipeline{FilterEnabled: nil}
 	for _, name := range []string{"git-diff", "git-status", "unknown"} {

--- a/internal/filter/registry_test.go
+++ b/internal/filter/registry_test.go
@@ -1,8 +1,34 @@
 package filter
 
 import (
+	"os"
 	"testing"
 )
+
+// TestDockerBuildScopedToBuild guards against the docker-build filter matching
+// unrelated docker subcommands (e.g. docker run/exec), which would strip their
+// output to nothing. See issue #85. Parses the real shipped filter file.
+func TestDockerBuildScopedToBuild(t *testing.T) {
+	data, err := os.ReadFile("../../filters/docker-build.yaml")
+	if err != nil {
+		t.Fatalf("read docker-build.yaml: %v", err)
+	}
+	f, err := ParseFilter(data)
+	if err != nil {
+		t.Fatalf("parse docker-build.yaml: %v", err)
+	}
+	reg := NewRegistry([]Filter{*f})
+
+	if got := reg.Match("docker", "build", []string{"-t", "app", "."}); got == nil || got.Name != "docker-build" {
+		t.Errorf("docker build should match docker-build, got %v", got)
+	}
+
+	for _, sub := range []string{"run", "exec", "cp", "inspect", "logs"} {
+		if got := reg.Match("docker", sub, []string{"--rm", "ubuntu", "ls"}); got != nil {
+			t.Errorf("docker %s must not match any filter, got %q", sub, got.Name)
+		}
+	}
+}
 
 func makeFilter(name, cmd, subcmd string) Filter {
 	return Filter{


### PR DESCRIPTION
## Problem

`snip docker run ...` (and `exec`, `cp`, `inspect`, ...) produced **empty output**, sending nothing to the LLM and triggering wasteful retry loops (issue #85).

**Root cause:** the `docker-build` filter matched `command: docker` with no subcommand, so it applied to *every* docker subcommand. Its `keep_lines` step only retains build-related lines, so the output of `docker run` (e.g. `ls`, `find`) matched nothing and was stripped entirely.

## Fix (defense in depth)

**A. Scope the filter** (`filters/docker-build.yaml`, v3 → v4)
- Added `subcommand: "build"`. `docker run/exec/cp/...` are no longer intercepted.
- Note: `docker buildx build` (subcommand "buildx") is now passthrough, documented in the filter.

**B. Engine-level safety net** (`internal/engine/pipeline.go`)
- New `shouldRestoreRaw`: when a filter empties non-empty input, fall back to raw output instead of sending nothing. Aligns with the project's graceful-degradation constraint and covers the whole class of over-aggressive filters, not just docker.
- Filters with a legitimately empty result use the `on_empty` action to emit a message, so they never reach this state and are unaffected.

## Tests (TDD)
- `TestDockerBuildScopedToBuild` — parses the shipped YAML; asserts `docker build` matches and `run/exec/cp/inspect/logs` match nothing.
- `TestShouldRestoreRaw` — table covering emptied / whitespace-only / normal / legitimately-empty / both-empty cases.

## Validation
- `golangci-lint run`: 0 issues
- `make test-race`: all packages pass