### PR TITLE
fix: don't condense `gh pr diff` output (closes #87)

### DIFF
--- a/filters/gh-pr.yaml
+++ b/filters/gh-pr.yaml
@@ -5,6 +5,10 @@ description: "Condensed gh pr output: PR list/view summary"
 match:
   command: "gh"
   subcommand: "pr"
+  # `gh pr diff` emits a unified diff, not a PR list. Condensing it (head + "...
+  # more PRs") truncates the diff and breaks review/comparison flows, so let it
+  # pass through untouched. See issue #87.
+  exclude_flags: ["diff"]
 
 pipeline:
   - action: "strip_ansi"

--- a/internal/filter/registry_test.go
+++ b/internal/filter/registry_test.go
@@ -30,6 +30,34 @@ func TestDockerBuildScopedToBuild(t *testing.T) {
 	}
 }
 
+// TestGhPrDiffNotCondensed guards against the gh-pr filter matching `gh pr
+// diff`, whose output is a unified diff, not a PR list. Condensing it (head 30 +
+// "... more PRs") truncates the diff and breaks Claude Code's /review flow. The
+// filter must stay scoped to list/view-style subcommands. See issue #87.
+func TestGhPrDiffNotCondensed(t *testing.T) {
+	data, err := os.ReadFile("../../filters/gh-pr.yaml")
+	if err != nil {
+		t.Fatalf("read gh-pr.yaml: %v", err)
+	}
+	f, err := ParseFilter(data)
+	if err != nil {
+		t.Fatalf("parse gh-pr.yaml: %v", err)
+	}
+	reg := NewRegistry([]Filter{*f})
+
+	// gh pr diff must pass through (no filter), so /review gets the full diff.
+	if got := reg.Match("gh", "pr", []string{"diff", "123"}); got != nil {
+		t.Errorf("gh pr diff must not be condensed, matched %q", got.Name)
+	}
+
+	// List/view subcommands still benefit from condensation.
+	for _, args := range [][]string{{"list"}, {"view", "123"}, {"status"}} {
+		if got := reg.Match("gh", "pr", args); got == nil || got.Name != "gh-pr" {
+			t.Errorf("gh pr %v should match gh-pr, got %v", args, got)
+		}
+	}
+}
+
 func makeFilter(name, cmd, subcmd string) Filter {
 	return Filter{
 		Name:    name,


### PR DESCRIPTION
## Summary

Fixes #87. The `gh-pr` filter matched **every** `gh pr` subcommand because routing keys on `command:subcommand` only. `gh pr diff <id>` emits a unified diff, but the filter condensed it like a PR list (truncate to 120 cols, `head` 30 lines, append `... more PRs`), so the diff was truncated and trailed by a nonsensical message.

Claude Code's `/review` command runs `gh pr diff <id>`, so reviews received a mangled diff and fell back to reading files one by one.

## Fix

Scope the filter to list/view-style subcommands by adding `exclude_flags: ["diff"]`, the same discrimination mechanism other filters already use. `gh pr diff` now passes through untouched; `gh pr list` / `view` / `status` stay condensed.

```yaml
match:
  command: "gh"
  subcommand: "pr"
  exclude_flags: ["diff"]
```

The only false-positive is a stray `diff` token elsewhere (e.g. a branch named `diff-x` in `gh pr checkout`), which falls back to passthrough — safe, never a mangled output.

## Tests

`TestGhPrDiffNotCondensed` parses the shipped filter and asserts `gh pr diff` matches no filter while `list` / `view` / `status` still match `gh-pr`. It mirrors `TestDockerBuildScopedToBuild`, the analogous scoping fix from #85. Verified failing before the change, passing after. Local CI green (`golangci-lint`, `make test-race`).

## Scope note

This PR deliberately fixes only the reproduced bug (`gh pr diff`). The issue also raises a broader point — that diff-condensing filters (`git-diff` injecting `--stat`, `diff` truncation) hurt review/comparison flows in general. That is a wider default-behavior policy decision affecting deployed users and is worth measuring on its own, so it is intentionally left out of this focused fix.

Closes #87.