### PR TITLE
fix(tracking): degrade silently when the DB path is unwritable (#93)

### DIFF
--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -149,7 +150,10 @@ func (p *Pipeline) Run(command string, args []string) int {
 		originalCmd := command + " " + strings.Join(fullArgs, " ")
 		snipCmd := command + " " + strings.Join(finalArgs, " ")
 		outputTokens := utils.EstimateTokens(filtered)
-		if err := timed.Track(originalCmd, snipCmd, inputTokens, outputTokens); err != nil {
+		if err := timed.Track(originalCmd, snipCmd, inputTokens, outputTokens); err != nil && !errors.Is(err, tracking.ErrUnavailable) {
+			// A genuine runtime tracking error is surfaced; an unwritable DB
+			// (sandboxed/read-only filesystem) degrades silently so hooks don't
+			// emit a stderr line on every command. See issue #93.
 			fmt.Fprintf(os.Stderr, "snip: tracking error: %v\n", err)
 		}
 	}

--- a/internal/tracking/tracker.go
+++ b/internal/tracking/tracker.go
@@ -2,11 +2,19 @@ package tracking
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
 )
+
+// ErrUnavailable reports that token tracking is unavailable because the SQLite
+// database could not be created or opened (e.g. a read-only or sandboxed
+// filesystem where the DB path is unwritable). It wraps the underlying cause.
+// Best-effort callers (the run pipeline) should detect it with errors.Is and
+// degrade silently rather than printing a tracking error on every command.
+var ErrUnavailable = errors.New("tracking unavailable")
 
 // Tracker manages token savings tracking in SQLite.
 type Tracker struct {
@@ -40,13 +48,13 @@ func (t *Tracker) ensureOpen() error {
 	t.once.Do(func() {
 		dir := filepath.Dir(t.dbPath)
 		if err := os.MkdirAll(dir, 0755); err != nil {
-			t.initErr = fmt.Errorf("create db dir: %w", err)
+			t.initErr = fmt.Errorf("%w: create db dir: %v", ErrUnavailable, err)
 			return
 		}
 
 		db, err := sql.Open("sqlite", t.dbPath)
 		if err != nil {
-			t.initErr = fmt.Errorf("open db: %w", err)
+			t.initErr = fmt.Errorf("%w: open db: %v", ErrUnavailable, err)
 			return
 		}
 
@@ -55,7 +63,7 @@ func (t *Tracker) ensureOpen() error {
 
 		if _, err := db.Exec(createTableSQL); err != nil {
 			_ = db.Close()
-			t.initErr = fmt.Errorf("create table: %w", err)
+			t.initErr = fmt.Errorf("%w: create table: %v", ErrUnavailable, err)
 			return
 		}
 

--- a/internal/tracking/tracker_test.go
+++ b/internal/tracking/tracker_test.go
@@ -3,9 +3,33 @@
 package tracking
 
 import (
+	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 )
+
+// TestTrackUnwritableDBIsUnavailable verifies that when the tracking DB path is
+// unwritable (sandboxed/read-only filesystem), Track returns an error wrapping
+// ErrUnavailable so best-effort callers can degrade silently (issue #93).
+func TestTrackUnwritableDBIsUnavailable(t *testing.T) {
+	// A regular file used as a parent directory makes os.MkdirAll fail with
+	// ENOTDIR, deterministically simulating an unwritable DB location.
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dbPath := filepath.Join(blocker, "sub", "tracking.db")
+
+	tr := NewLazyTracker(dbPath)
+	err := tr.Track("git status", "snip run -- git status", 100, 10, 5)
+	if err == nil {
+		t.Fatal("expected an error when the DB path is unwritable")
+	}
+	if !errors.Is(err, ErrUnavailable) {
+		t.Errorf("error %v should wrap ErrUnavailable", err)
+	}
+}
 
 func newTestTracker(t *testing.T) *Tracker {
 	t.Helper()


### PR DESCRIPTION
Addresses the sandbox-tracking follow-up noted in #93.

## Problem

In a sandboxed or read-only filesystem (e.g. a hook running under a restricted FS), the tracking SQLite DB cannot be created or opened. SQLite returns *"unable to open database file" (error 14)*. The run pipeline tracks token savings on a best-effort basis but printed:

```
snip: tracking error: track: create table: unable to open database file (14)
```

to **stderr on every command**, leaking a noisy error line into hook contexts where tracking simply isn't possible.

## Fix

- Add a `tracking.ErrUnavailable` sentinel that wraps the DB create/open/mkdir failures in `ensureOpen`.
- The pipeline now skips the stderr line when the error wraps `ErrUnavailable` (`errors.Is`), degrading silently.
- **Genuine** runtime tracking errors (e.g. a failed insert on an otherwise healthy DB) are still surfaced.
- User-facing stats commands (`gain`, `cc-economics`) call `NewTracker` directly and keep reporting DB errors to the user who asked for them.

## Tests

`TestTrackUnwritableDBIsUnavailable` points the DB under a regular file so `os.MkdirAll` fails with `ENOTDIR` (deterministic, cross-platform), and asserts `errors.Is(err, ErrUnavailable)`. Verified end-to-end: with `SNIP_DB_PATH` pointing at an unwritable path, `snip run -- git status` produces no `tracking error` line on stderr. `make test`, `golangci-lint run`, `go test -race ./...`, and the `-tags lite` build all green.