### PR TITLE
fix(filter): prevent ShouldInject panic on a no-argument command (closes #97)

### DIFF
--- a/internal/filter/registry.go
+++ b/internal/filter/registry.go
@@ -119,7 +119,16 @@ func (r *Registry) ShouldInject(f *Filter, args []string) ([]string, bool) {
 		}
 		result = append(result, args[dashDashIdx:]...)
 	} else {
-		result = append(result, args[0])
+		// No "--" separator: args[0] is the subcommand (if any), injected flags
+		// follow it, and args[1:] is the rest. Guard the empty case: a command
+		// run with no arguments (e.g. `snip pytest`) has no subcommand, so only
+		// the injected flags are emitted (issue #97).
+		var head, rest []string
+		if len(args) > 0 {
+			head = args[:1]
+			rest = args[1:]
+		}
+		result = append(result, head...)
 		result = append(result, f.Inject.Args...)
 		// Inject defaults before user args so user flags win (last-flag-wins semantics)
 		for flag, val := range f.Inject.Defaults {
@@ -130,7 +139,7 @@ func (r *Registry) ShouldInject(f *Filter, args []string) ([]string, bool) {
 					break
 				}
 			}
-			for _, arg := range args[1:] {
+			for _, arg := range rest {
 				if strings.HasPrefix(arg, flag) {
 					found = true
 					break
@@ -140,7 +149,7 @@ func (r *Registry) ShouldInject(f *Filter, args []string) ([]string, bool) {
 				result = append(result, flag, val)
 			}
 		}
-		result = append(result, args[1:]...)
+		result = append(result, rest...)
 	}
 
 	return result, true

--- a/internal/filter/registry_test.go
+++ b/internal/filter/registry_test.go
@@ -321,6 +321,35 @@ func TestShouldInject(t *testing.T) {
 	}
 }
 
+// TestShouldInjectEmptyArgs guards against a panic when a command is run with no
+// arguments (e.g. `snip pytest`) and the matched filter has an inject block. The
+// else branch indexed args[0] unconditionally; an empty args slice panicked with
+// "index out of range [0] with length 0" (issue #97).
+func TestShouldInjectEmptyArgs(t *testing.T) {
+	f := Filter{
+		Name: "pytest",
+		Inject: &Inject{
+			Args:     []string{"--tb=line", "-q"},
+			Defaults: map[string]string{"--maxfail": "1"},
+		},
+	}
+	reg := NewRegistry(nil)
+
+	args, injected := reg.ShouldInject(&f, nil)
+	if !injected {
+		t.Fatal("expected injection for empty args")
+	}
+	want := []string{"--tb=line", "-q", "--maxfail", "1"}
+	if len(args) != len(want) {
+		t.Fatalf("args = %v, want %v", args, want)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Errorf("args[%d] = %q, want %q (full: %v)", i, args[i], want[i], args)
+		}
+	}
+}
+
 func TestShouldInjectNoInject(t *testing.T) {
 	f := Filter{Name: "test"}
 	reg := NewRegistry(nil)


### PR DESCRIPTION
Closes #97. Also resolves the `uv run snip pytest` crash reported in #95.

## Bug

`uv run snip pytest` (i.e. `snip pytest` with no further arguments) panicked:

```
panic: runtime error: index out of range [0] with length 0
  filter.(*Registry).ShouldInject  internal/filter/registry.go:122
  engine.(*Pipeline).Run           internal/engine/pipeline.go:73
```

When a command is run with **no arguments** and its filter has an `inject` block (the `pytest` filter injects `--tb=line -q`), the no-`--` branch of `ShouldInject` indexed `args[0]` (and sliced `args[1:]`) unconditionally, panicking on the empty slice.

## Fix

Guard the empty case. With no arguments there is no leading subcommand, so only the injected flags are emitted:

```go
var head, rest []string
if len(args) > 0 {
    head = args[:1]
    rest = args[1:]
}
```

Behavior for non-empty args is byte-identical (`head = args[:1]`, `rest = args[1:]`), so existing injection semantics are unchanged.

## Tests

`TestShouldInjectEmptyArgs` reproduces the panic (filter with inject + empty args) and asserts the injected flags are emitted. Verified end-to-end: `snip pytest` no longer panics (falls through to running pytest). `make test`, `golangci-lint run`, `go test -race ./...`, and the `-tags lite` build all green.

## Note on #95

#95 has two parts: (1) the `uv run snip pytest` crash, fixed here; (2) `snip uv run pytest` produces no rewrite/stats. Part (2) is a separate feature gap: transparent runner-prefix unwrapping (#91) is applied on the hook-rewrite path but not on the direct `snip <cmd>` pipeline path. Tracked separately.