### PR TITLE
feat(engine): apply transparent runner prefixes on the direct-run path (closes #95)

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -346,14 +346,15 @@ func runPipeline(command string, args []string, flags Flags) int {
 	teeCfg.MaxFileSize = cfg.Tee.MaxFileSize
 
 	pipeline := &engine.Pipeline{
-		Registry:      registry,
-		Tracker:       tracker,
-		TeeConfig:     teeCfg,
-		Verbose:       flags.Verbose,
-		UltraCompact:  flags.UltraCompact,
-		QuietNoFilter: cfg.Display.QuietNoFilter,
-		FilterEnabled: projectCfg.Filters.Enable,
-		Config:        projectCfg,
+		Registry:            registry,
+		Tracker:             tracker,
+		TeeConfig:           teeCfg,
+		Verbose:             flags.Verbose,
+		UltraCompact:        flags.UltraCompact,
+		QuietNoFilter:       cfg.Display.QuietNoFilter,
+		FilterEnabled:       projectCfg.Filters.Enable,
+		Config:              projectCfg,
+		TransparentPrefixes: hook.MergeTransparentPrefixes(projectCfg.Filters.TransparentPrefixes),
 	}
 
 	return pipeline.Run(command, args)

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -3,10 +3,12 @@ package engine
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/edouard-claude/snip/internal/config"
 	"github.com/edouard-claude/snip/internal/filter"
+	"github.com/edouard-claude/snip/internal/hook"
 	"github.com/edouard-claude/snip/internal/tee"
 	"github.com/edouard-claude/snip/internal/tracking"
 	"github.com/edouard-claude/snip/internal/utils"
@@ -22,30 +24,46 @@ type Pipeline struct {
 	QuietNoFilter bool
 	FilterEnabled map[string]bool
 	Config        *config.Config // merged user+project config (nil if not loaded)
+	// TransparentPrefixes are runner wrappers (uv run, poetry run, ...) whose
+	// inner command's filter should apply when run directly via `snip <prefix>
+	// <cmd>`. Empty disables transparent unwrapping on the direct-run path.
+	TransparentPrefixes []hook.TransparentPrefix
 }
 
 // Run executes a command through the full pipeline.
 func (p *Pipeline) Run(command string, args []string) int {
-	// Extract subcommand (first non-flag arg)
-	subcommand := ""
-	filterArgs := args
-	if len(args) > 0 {
-		subcommand = args[0]
-		filterArgs = args[1:]
-	}
-
 	// Check if command is in the project-level bypass list.
 	// Bypassed commands pass through unfiltered regardless of filter match.
-	if p.Config != nil {
-		for _, cmd := range p.Config.Filters.Bypass.Commands {
-			if cmd == command {
+	if p.isBypassed(command) {
+		return p.Passthrough(command, args)
+	}
+
+	// Resolve the filter target. fcmd/fargs are the command whose filter applies
+	// and its args; runnerPrefix is the transparent wrapper tokens (e.g. "run",
+	// "--python", "3.12") that precede the inner command and must be replayed at
+	// execution time. For a normal command these are (command, args, nil).
+	fcmd, fargs := command, args
+	var runnerPrefix []string
+
+	subcommand, filterArgs := splitFirstArg(fargs)
+	f := p.Registry.Match(fcmd, subcommand, filterArgs)
+
+	// No direct filter: if command starts with a transparent runner prefix
+	// (uv run, poetry run, ...), unwrap to the inner command so its filter
+	// applies while the full wrapper still executes (issue #95).
+	if f == nil && len(p.TransparentPrefixes) > 0 {
+		if inner, innerArgs, runner, ok := p.unwrapTransparent(command, args); ok {
+			// Honor the bypass list for the inner command too: a bypassed inner
+			// runs the full wrapper unfiltered, mirroring the outer check above.
+			if p.isBypassed(inner) {
 				return p.Passthrough(command, args)
+			}
+			isub, ifilter := splitFirstArg(innerArgs)
+			if f2 := p.Registry.Match(inner, isub, ifilter); f2 != nil {
+				f, fcmd, fargs, runnerPrefix = f2, inner, innerArgs, runner
 			}
 		}
 	}
-
-	// Match filter
-	f := p.Registry.Match(command, subcommand, filterArgs)
 
 	// No filter found: passthrough.
 	// Only print a hint when no filter is registered for the base command at
@@ -67,11 +85,19 @@ func (p *Pipeline) Run(command string, args []string) int {
 		return p.Passthrough(command, args)
 	}
 
-	// Compute injected args
+	// Compute injected args for the (inner) filter, then reattach the runner
+	// prefix so the full wrapper still executes.
 	fullArgs := args
-	finalArgs := args
-	if injected, ok := p.Registry.ShouldInject(f, args); ok {
+	finalArgs := fargs
+	if injected, ok := p.Registry.ShouldInject(f, fargs); ok {
 		finalArgs = injected
+	}
+	if runnerPrefix != nil {
+		exec := make([]string, 0, len(runnerPrefix)+1+len(finalArgs))
+		exec = append(exec, runnerPrefix...)
+		exec = append(exec, fcmd)
+		exec = append(exec, finalArgs...)
+		finalArgs = exec
 	}
 
 	// Start SQLite init concurrently with command execution
@@ -155,6 +181,84 @@ func (p *Pipeline) Run(command string, args []string) int {
 	}
 
 	return result.ExitCode
+}
+
+// isBypassed reports whether command is in the project-level bypass list, which
+// forces unfiltered passthrough regardless of any filter match.
+func (p *Pipeline) isBypassed(command string) bool {
+	if p.Config == nil {
+		return false
+	}
+	for _, cmd := range p.Config.Filters.Bypass.Commands {
+		if cmd == command {
+			return true
+		}
+	}
+	return false
+}
+
+// splitFirstArg returns the first arg (the subcommand) and the remaining args.
+// Both are empty for a no-argument command.
+func splitFirstArg(args []string) (first string, rest []string) {
+	if len(args) > 0 {
+		return args[0], args[1:]
+	}
+	return "", nil
+}
+
+// unwrapTransparent detects a transparent runner prefix (e.g. "uv run") at the
+// head of command+args and locates the inner command so its filter applies
+// while the full wrapper still executes. It returns the inner command token,
+// the inner command's own args, and the runner tokens within args that precede
+// the inner command (e.g. ["run", "--python", "3.12"]). ok is false when no
+// prefix matches or the first non-flag token is not a known snip command — fail
+// closed, mirroring the hook's LocateInner so an argument is never mistaken for
+// the inner command.
+func (p *Pipeline) unwrapTransparent(command string, args []string) (inner string, innerArgs, runnerArgs []string, ok bool) {
+	full := make([]string, 0, len(args)+1)
+	full = append(full, command)
+	full = append(full, args...)
+
+	for _, tp := range p.TransparentPrefixes {
+		pre := strings.Fields(tp.Prefix)
+		if len(pre) == 0 || len(full) <= len(pre) || !prefixMatches(full, pre) {
+			continue
+		}
+		for i := len(pre); i < len(full); i++ {
+			t := full[i]
+			if strings.HasPrefix(t, "-") {
+				if !tp.SkipFlags {
+					break // flag before the inner command: fail closed for this prefix
+				}
+				if tp.ValueFlags[t] && !strings.Contains(t, "=") {
+					i++ // value-taking flag also consumes the next token
+				}
+				continue
+			}
+			// HasAnyFilterForCommand base-normalizes the token, so a path- or
+			// ./-qualified inner command still matches its filter.
+			if p.Registry.HasAnyFilterForCommand(t) {
+				// full[0] is command, so the args index is i-1.
+				return t, full[i+1:], args[:i-1], true
+			}
+			break // first non-flag token is not a known command: fail closed
+		}
+	}
+	return "", nil, nil, false
+}
+
+// prefixMatches reports whether full begins with the prefix tokens, comparing
+// the leading runner by base name so /usr/bin/uv still matches the "uv" prefix.
+func prefixMatches(full, pre []string) bool {
+	if filepath.Base(full[0]) != pre[0] {
+		return false
+	}
+	for i := 1; i < len(pre); i++ {
+		if full[i] != pre[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // Passthrough runs a command directly without filtering.

--- a/internal/engine/transparent_test.go
+++ b/internal/engine/transparent_test.go
@@ -1,0 +1,157 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/edouard-claude/snip/internal/config"
+	"github.com/edouard-claude/snip/internal/filter"
+	"github.com/edouard-claude/snip/internal/hook"
+)
+
+// transparentTestPipeline builds a pipeline whose registry knows "git" (with a
+// git-log subcommand filter) and "pytest", plus the built-in transparent runner
+// prefixes and a custom single-word user prefix "myrunner".
+func transparentTestPipeline() *Pipeline {
+	filters := []filter.Filter{
+		{Name: "git-log", Match: filter.Match{Command: "git", Subcommand: "log"}},
+		{Name: "pytest", Match: filter.Match{Command: "pytest"}},
+	}
+	return &Pipeline{
+		Registry:            filter.NewRegistry(filters),
+		TransparentPrefixes: hook.MergeTransparentPrefixes([]string{"myrunner"}),
+	}
+}
+
+func sliceEq(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestUnwrapTransparent(t *testing.T) {
+	p := transparentTestPipeline()
+
+	cases := []struct {
+		name          string
+		command       string
+		args          []string
+		wantOK        bool
+		wantInner     string
+		wantInnerArgs []string
+		wantRunner    []string
+	}{
+		{
+			name: "uv run with inner subcommand and args",
+			command: "uv", args: []string{"run", "git", "log", "-5"},
+			wantOK: true, wantInner: "git", wantInnerArgs: []string{"log", "-5"}, wantRunner: []string{"run"},
+		},
+		{
+			name: "uv run skips value-taking flag and its value",
+			command: "uv", args: []string{"run", "--python", "3.12", "pytest"},
+			wantOK: true, wantInner: "pytest", wantInnerArgs: nil, wantRunner: []string{"run", "--python", "3.12"},
+		},
+		{
+			name: "uv run handles flag=value form",
+			command: "uv", args: []string{"run", "--python=3.12", "pytest", "-x"},
+			wantOK: true, wantInner: "pytest", wantInnerArgs: []string{"-x"}, wantRunner: []string{"run", "--python=3.12"},
+		},
+		{
+			// A single-word user prefix puts the inner command at args[0], so the
+			// runner prefix is empty. (The built-in single-word prefixes exec/
+			// noglob/nocorrect/command are shell builtins: exec is intercepted by
+			// unproxyableReason before the pipeline, and the others aren't real
+			// binaries, so a custom prefix is the realistic single-word case.)
+			name: "single-word prefix puts inner at args[0]",
+			command: "myrunner", args: []string{"git", "log"},
+			wantOK: true, wantInner: "git", wantInnerArgs: []string{"log"}, wantRunner: []string{},
+		},
+		{
+			name: "path-qualified runner still matches by base name",
+			command: "/usr/local/bin/uv", args: []string{"run", "git", "log"},
+			wantOK: true, wantInner: "git", wantInnerArgs: []string{"log"}, wantRunner: []string{"run"},
+		},
+		{
+			name: "unknown inner command fails closed",
+			command: "uv", args: []string{"run", "unknowncmd", "x"},
+			wantOK: false,
+		},
+		{
+			name: "flag before inner on a non-skip prefix fails closed",
+			command: "command", args: []string{"-v", "git"},
+			wantOK: false,
+		},
+		{
+			name: "no transparent prefix",
+			command: "git", args: []string{"log"},
+			wantOK: false,
+		},
+		{
+			name: "prefix alone with no inner command",
+			command: "uv", args: []string{"run"},
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inner, innerArgs, runner, ok := p.unwrapTransparent(tc.command, tc.args)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (inner=%q innerArgs=%v runner=%v)", ok, tc.wantOK, inner, innerArgs, runner)
+			}
+			if !ok {
+				return
+			}
+			if inner != tc.wantInner {
+				t.Errorf("inner = %q, want %q", inner, tc.wantInner)
+			}
+			if !sliceEq(innerArgs, tc.wantInnerArgs) {
+				t.Errorf("innerArgs = %v, want %v", innerArgs, tc.wantInnerArgs)
+			}
+			if !sliceEq(runner, tc.wantRunner) {
+				t.Errorf("runner = %v, want %v", runner, tc.wantRunner)
+			}
+		})
+	}
+}
+
+// TestUnwrapTransparentDisabledWhenNoPrefixes verifies unwrapping is inert when
+// no transparent prefixes are configured.
+func TestUnwrapTransparentDisabledWhenNoPrefixes(t *testing.T) {
+	p := &Pipeline{
+		Registry:            filter.NewRegistry([]filter.Filter{{Name: "git-log", Match: filter.Match{Command: "git", Subcommand: "log"}}}),
+		TransparentPrefixes: nil,
+	}
+	if _, _, _, ok := p.unwrapTransparent("uv", []string{"run", "git", "log"}); ok {
+		t.Error("expected no unwrap when TransparentPrefixes is empty")
+	}
+}
+
+// TestIsBypassed verifies the bypass-list check used for both the outer command
+// and the unwrapped inner command (so `snip uv run git ...` is bypassed when
+// "git" is bypassed, mirroring the outer check).
+func TestIsBypassed(t *testing.T) {
+	p := &Pipeline{
+		Config: &config.Config{
+			Filters: config.FiltersConfig{
+				Bypass: config.FilterBypassConfig{Commands: []string{"git", "docker"}},
+			},
+		},
+	}
+	if !p.isBypassed("git") {
+		t.Error("git should be bypassed")
+	}
+	if p.isBypassed("go") {
+		t.Error("go should not be bypassed")
+	}
+
+	// A nil Config never bypasses.
+	if (&Pipeline{}).isBypassed("git") {
+		t.Error("nil Config must not bypass")
+	}
+}


### PR DESCRIPTION
Closes #95 (the `snip uv run pytest` "does nothing" part). The crash part of #95 is fixed in #99.

> [!NOTE]
> Stacked on #99 (the `ShouldInject` empty-args fix), since `snip uv run pytest` resolves pytest with no args. Base will retarget to `master` automatically when #99 merges. Review #99 first.

## Problem

Running a runner-wrapped command directly (`snip uv run pytest`) produced no rewrite and no tracking: the pipeline matched the runner (`uv`) as the command, found no `uv` filter, and passed through. The transparent-prefix unwrapping added in #91 only ran on the **hook-rewrite** path, not the direct `snip <cmd>` pipeline.

## Fix

When no direct filter matches, `Pipeline.Run` now detects a transparent runner prefix (`uv run`, `poetry run`, ...), locates the inner command, and applies the **inner** command's filter while still executing the **full** wrapper:

```
Execute(command, runnerPrefix + inner + injectedInnerArgs)
```

e.g. `snip uv run pytest` → executes `uv run pytest --tb=line -q` (pytest's injected flags) and filters the output with the pytest filter. Confirmed end-to-end: the command is filtered **and** shows up in `snip gain`.

Inner detection mirrors the hook's `LocateInner` and **fails closed**: the first non-flag token must be a known snip command, value-taking runner flags (`--python 3.12`) are skipped with their value, and a flag before the inner command on a non-`SkipFlags` prefix is rejected — an argument is never mistaken for the inner command.

## Review fixes (from an adversarial pass)

- **Bypass consistency:** the `filters.bypass.commands` list is now honored for the unwrapped **inner** command too (a bypassed inner runs the full wrapper unfiltered), matching the existing outer-command and filter-disable checks.
- **Shell-builtin prefixes** (`noglob`, `nocorrect`, ...) are inherently not runnable as a subprocess, so they only take effect where the system provides a real binary (e.g. `/usr/bin/command`). This is unchanged behavior (those were never runnable via `snip` directly); the unit test now uses a realistic custom prefix rather than the `exec` builtin (which `unproxyableReason` intercepts before the pipeline).

## Tests

`internal/engine/transparent_test.go`: `unwrapTransparent` across runner/value-flag/single-word/path-qualified/fail-closed cases, plus the inner-bypass check. `make test`, `golangci-lint run`, `go test -race ./...`, and the `-tags lite` build all green. Verified end-to-end with a stub `uv` that the inner filter (git-log) applies and the run is tracked.