### PR TITLE
feat(tracking): opt-in tracking of unfiltered commands (closes #96)

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -135,6 +135,7 @@ func Run(args []string) int {
 			return 1
 		}
 		fmt.Printf("tracking.db_path: %s\n", cfg.Tracking.DBPath)
+		fmt.Printf("tracking.track_unfiltered: %v\n", cfg.Tracking.TrackUnfiltered)
 		fmt.Printf("filters.dir: %s\n", strings.Join(cfg.Filters.Dirs(), ", "))
 		fmt.Printf("tee.mode: %s\n", cfg.Tee.Mode)
 		fmt.Printf("tee.max_files: %d\n", cfg.Tee.MaxFiles)
@@ -374,6 +375,7 @@ func runPipeline(command string, args []string, flags Flags) int {
 		FilterEnabled:       projectCfg.Filters.Enable,
 		Config:              projectCfg,
 		TransparentPrefixes: hook.MergeTransparentPrefixes(projectCfg.Filters.TransparentPrefixes),
+		TrackUnfiltered:     cfg.Tracking.TrackUnfiltered,
 	}
 
 	return pipeline.Run(command, args)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,11 @@ type Config struct {
 
 type TrackingConfig struct {
 	DBPath string `toml:"db_path"`
+	// TrackUnfiltered, when true, records commands that ran with no matching
+	// filter at all so `snip gain --unfiltered` can surface filter-coverage
+	// gaps. Off by default to keep the passthrough path free of extra work.
+	// See issue #96.
+	TrackUnfiltered bool `toml:"track_unfiltered"`
 }
 
 type DisplayConfig struct {

--- a/internal/display/gain.go
+++ b/internal/display/gain.go
@@ -19,17 +19,18 @@ func RunGain(tracker *tracking.Tracker, args []string) error {
 
 	// Parse args
 	var (
-		showDaily   bool
-		showWeekly  bool
-		showMonthly bool
-		showJSON    bool
-		showCSV     bool
-		showTop     bool
-		showQuota   bool
-		noTruncate  bool
-		historyN    int
-		topN        int
-		days        = 7
+		showDaily      bool
+		showWeekly     bool
+		showMonthly    bool
+		showJSON       bool
+		showCSV        bool
+		showTop        bool
+		showQuota      bool
+		showUnfiltered bool
+		noTruncate     bool
+		historyN       int
+		topN           int
+		days           = 7
 	)
 
 	for i := 0; i < len(args); i++ {
@@ -48,6 +49,15 @@ func RunGain(tracker *tracking.Tracker, args []string) error {
 			showQuota = true
 		case "--top":
 			showTop = true
+			if i+1 < len(args) {
+				_, _ = fmt.Sscanf(args[i+1], "%d", &topN)
+				i++
+			}
+			if topN <= 0 {
+				topN = 10
+			}
+		case "--unfiltered":
+			showUnfiltered = true
 			if i+1 < len(args) {
 				_, _ = fmt.Sscanf(args[i+1], "%d", &topN)
 				i++
@@ -78,6 +88,10 @@ func RunGain(tracker *tracking.Tracker, args []string) error {
 	}
 	if showCSV {
 		return exportCSV(tracker, days)
+	}
+
+	if showUnfiltered {
+		return showUnfilteredCommands(tracker, topN, noTruncate)
 	}
 
 	if historyN > 0 {
@@ -236,6 +250,63 @@ func showByCommand(tracker *tracking.Tracker, limit int, noTruncate bool) error 
 			utils.FormatTokens(s.SavedTokens),
 			ColorSavings(s.AvgSavings),
 			bar,
+		})
+	}
+
+	fmt.Print(FormatTable(headers, rows))
+	fmt.Println()
+	return nil
+}
+
+// showUnfilteredCommands prints the most frequent commands that ran with no
+// matching filter at all — a guide to filter-coverage gaps (issue #96).
+func showUnfilteredCommands(tracker *tracking.Tracker, limit int, noTruncate bool) error {
+	stats, err := tracker.GetUnfiltered(limit)
+	if err != nil {
+		return err
+	}
+
+	tty := IsTerminal()
+	fmt.Println()
+	if tty {
+		fmt.Println(DimStyle.Render("  Unfiltered commands by frequency"))
+	} else {
+		fmt.Println("  Unfiltered commands by frequency")
+	}
+	fmt.Println()
+
+	if len(stats) == 0 {
+		hint := "  (none recorded — enable [tracking] track_unfiltered = true in config.toml)"
+		if tty {
+			fmt.Println(DimStyle.Render(hint))
+		} else {
+			fmt.Println(hint)
+		}
+		fmt.Println()
+		return nil
+	}
+
+	maxRuns := 0
+	for _, s := range stats {
+		if s.Count > maxRuns {
+			maxRuns = s.Count
+		}
+	}
+
+	headers := []string{"Command", "Runs", "Frequency", "Last seen"}
+	var rows [][]string
+	// Fixed columns: Runs(4) + Frequency(12) + Last seen(19) + 3×sep(6) = 41
+	maxCmd := cmdColWidth(TerminalWidth(), 41)
+	for _, s := range stats {
+		cmd := s.Command
+		if !noTruncate && len(cmd) > maxCmd {
+			cmd = cmd[:maxCmd-3] + "..."
+		}
+		rows = append(rows, []string{
+			cmd,
+			fmt.Sprintf("%d", s.Count),
+			ColorBar(s.Count, maxRuns, 12),
+			s.LastSeen,
 		})
 	}
 

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -29,6 +29,9 @@ type Pipeline struct {
 	// inner command's filter should apply when run directly via `snip <prefix>
 	// <cmd>`. Empty disables transparent unwrapping on the direct-run path.
 	TransparentPrefixes []hook.TransparentPrefix
+	// TrackUnfiltered records no-filter passthrough commands for coverage
+	// analysis (issue #96). Off keeps the passthrough path free of extra work.
+	TrackUnfiltered bool
 }
 
 // Run executes a command through the full pipeline.
@@ -72,10 +75,14 @@ func (p *Pipeline) Run(command string, args []string) int {
 	// only covers other subcommands (e.g. git-commit but not git checkout),
 	// stay silent to avoid the misleading "no filter for git" message (#56).
 	if f == nil {
-		if !p.QuietNoFilter && !p.Registry.HasAnyFilterForCommand(command) {
+		// hasAny distinguishes "no filter at all for this command" (a genuine
+		// coverage gap, worth recording) from "a filter exists but was excluded
+		// by flags or only covers other subcommands" (already partly covered).
+		hasAny := p.Registry.HasAnyFilterForCommand(command)
+		if !p.QuietNoFilter && !hasAny {
 			fmt.Fprintf(os.Stderr, "snip: no filter for %q, passing through -- you can run %q directly\n", command, command)
 		}
-		return p.Passthrough(command, args)
+		return p.passthroughUnfiltered(command, args, hasAny)
 	}
 
 	// Filter disabled via config: treat as no filter
@@ -263,6 +270,23 @@ func prefixMatches(full, pre []string) bool {
 		}
 	}
 	return true
+}
+
+// passthroughUnfiltered runs a no-filter command via plain Passthrough (the
+// child keeps the terminal's file descriptors directly, so TTY detection and
+// streaming are unchanged). When unfiltered tracking is enabled and the command
+// has no filter at all, it records the invocation afterwards for coverage
+// analysis (issue #96). Recording is best-effort and never affects the outcome.
+func (p *Pipeline) passthroughUnfiltered(command string, args []string, hasAnyFilter bool) int {
+	if !p.TrackUnfiltered || p.Tracker == nil || hasAnyFilter {
+		return p.Passthrough(command, args)
+	}
+
+	p.Tracker.WarmUp()
+	code := p.Passthrough(command, args)
+	full := strings.TrimSpace(command + " " + strings.Join(args, " "))
+	_ = p.Tracker.TrackUnfiltered(command, full)
+	return code
 }
 
 // Passthrough runs a command directly without filtering.

--- a/internal/tracking/schema.go
+++ b/internal/tracking/schema.go
@@ -16,6 +16,37 @@ CREATE TABLE IF NOT EXISTS commands (
 
 const cleanupSQL = `DELETE FROM commands WHERE timestamp < datetime('now', '-90 days');`
 
+// unfiltered_commands records commands that ran with no matching filter at all,
+// used to surface filter-coverage gaps (issue #96). Only the command name and
+// invocation are stored — the passthrough output is streamed straight to the
+// terminal (never intercepted), so output size is not captured.
+const createUnfilteredTableSQL = `
+CREATE TABLE IF NOT EXISTS unfiltered_commands (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	timestamp DATETIME DEFAULT (datetime('now')),
+	command TEXT NOT NULL,
+	full_cmd TEXT NOT NULL
+);
+`
+
+const insertUnfilteredSQL = `
+INSERT INTO unfiltered_commands (command, full_cmd)
+VALUES (?, ?);
+`
+
+const cleanupUnfilteredSQL = `DELETE FROM unfiltered_commands WHERE timestamp < datetime('now', '-14 days');`
+
+const byUnfilteredSQL = `
+SELECT
+	command,
+	COUNT(*) as count,
+	MAX(timestamp) as last_seen
+FROM unfiltered_commands
+GROUP BY command
+ORDER BY count DESC, last_seen DESC
+LIMIT ?;
+`
+
 const insertSQL = `
 INSERT INTO commands (original_cmd, snip_cmd, input_tokens, output_tokens, saved_tokens, savings_pct, exec_time_ms)
 VALUES (?, ?, ?, ?, ?, ?, ?);
@@ -131,6 +162,14 @@ type CommandStats struct {
 	OutputTokens int
 	SavedTokens  int
 	AvgSavings   float64
+}
+
+// UnfilteredStat holds aggregate stats for a command that ran with no matching
+// filter (issue #96).
+type UnfilteredStat struct {
+	Command  string
+	Count    int
+	LastSeen string
 }
 
 // PeriodStats holds aggregate stats for a time period (week or month).

--- a/internal/tracking/tracker.go
+++ b/internal/tracking/tracker.go
@@ -67,6 +67,12 @@ func (t *Tracker) ensureOpen() error {
 			return
 		}
 
+		if _, err := db.Exec(createUnfilteredTableSQL); err != nil {
+			_ = db.Close()
+			t.initErr = fmt.Errorf("create unfiltered table: %w", err)
+			return
+		}
+
 		t.db = db
 	})
 	return t.initErr
@@ -97,6 +103,45 @@ func (t *Tracker) Track(originalCmd, snipCmd string, inputTokens, outputTokens i
 // TrackPassthrough records a passthrough (unfiltered) command.
 func (t *Tracker) TrackPassthrough(cmd string, tokens int, execTimeMs int64) error {
 	return t.Track(cmd, cmd, tokens, tokens, execTimeMs)
+}
+
+// TrackUnfiltered records a command that ran with no matching filter so
+// coverage gaps can be surfaced later (issue #96). command is the base command;
+// fullCmd is the full invocation. Best-effort: callers should ignore the error.
+func (t *Tracker) TrackUnfiltered(command, fullCmd string) error {
+	if err := t.ensureOpen(); err != nil {
+		return fmt.Errorf("track unfiltered: %w", err)
+	}
+	if _, err := t.db.Exec(insertUnfilteredSQL, command, fullCmd); err != nil {
+		return fmt.Errorf("track unfiltered: %w", err)
+	}
+	_, _ = t.db.Exec(cleanupUnfilteredSQL)
+	return nil
+}
+
+// GetUnfiltered returns the most frequent unfiltered commands.
+func (t *Tracker) GetUnfiltered(limit int) ([]UnfilteredStat, error) {
+	if err := t.ensureOpen(); err != nil {
+		return nil, fmt.Errorf("unfiltered: %w", err)
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+	rows, err := t.db.Query(byUnfilteredSQL, limit)
+	if err != nil {
+		return nil, fmt.Errorf("unfiltered: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var stats []UnfilteredStat
+	for rows.Next() {
+		var s UnfilteredStat
+		if err := rows.Scan(&s.Command, &s.Count, &s.LastSeen); err != nil {
+			return nil, fmt.Errorf("unfiltered scan: %w", err)
+		}
+		stats = append(stats, s)
+	}
+	return stats, rows.Err()
 }
 
 // GetSummary returns aggregate tracking stats.

--- a/internal/tracking/tracker_test.go
+++ b/internal/tracking/tracker_test.go
@@ -42,6 +42,51 @@ func newTestTracker(t *testing.T) *Tracker {
 	return tracker
 }
 
+func TestTrackUnfiltered(t *testing.T) {
+	tr := newTestTracker(t)
+
+	if err := tr.TrackUnfiltered("cargo", "cargo build"); err != nil {
+		t.Fatalf("track unfiltered: %v", err)
+	}
+	if err := tr.TrackUnfiltered("cargo", "cargo build --release"); err != nil {
+		t.Fatalf("track unfiltered: %v", err)
+	}
+	if err := tr.TrackUnfiltered("make", "make all"); err != nil {
+		t.Fatalf("track unfiltered: %v", err)
+	}
+
+	stats, err := tr.GetUnfiltered(10)
+	if err != nil {
+		t.Fatalf("get unfiltered: %v", err)
+	}
+	if len(stats) != 2 {
+		t.Fatalf("got %d unfiltered commands, want 2", len(stats))
+	}
+	// Ordered by frequency DESC: cargo (2 runs) before make (1 run).
+	if stats[0].Command != "cargo" {
+		t.Errorf("first = %q, want cargo", stats[0].Command)
+	}
+	if stats[0].Count != 2 {
+		t.Errorf("cargo count = %d, want 2", stats[0].Count)
+	}
+	if stats[1].Command != "make" || stats[1].Count != 1 {
+		t.Errorf("second = %q (count %d), want make (1)", stats[1].Command, stats[1].Count)
+	}
+}
+
+// TestGetUnfilteredEmpty verifies an empty result (and table creation) when
+// nothing has been recorded.
+func TestGetUnfilteredEmpty(t *testing.T) {
+	tr := newTestTracker(t)
+	stats, err := tr.GetUnfiltered(10)
+	if err != nil {
+		t.Fatalf("get unfiltered: %v", err)
+	}
+	if len(stats) != 0 {
+		t.Errorf("expected no rows, got %d", len(stats))
+	}
+}
+
 func TestNewTracker(t *testing.T) {
 	tracker := newTestTracker(t)
 	if tracker == nil {


### PR DESCRIPTION
Closes #96.

## What

Adds an opt-in `[tracking] track_unfiltered` setting (default **off**). When enabled, commands that run with **no matching filter at all** are recorded so `snip gain --unfiltered` can surface filter-coverage gaps, ranked by frequency:

```
  Unfiltered commands by frequency

Command  Runs  Frequency     Last seen
───────  ────  ────────────  ───────────────────
cargo    12    ████████████  2026-06-26 12:10:37
make      3    ███░░░░░░░░░  2026-06-26 11:55:02
```

## Design decisions

- **Only genuine coverage gaps.** A command is recorded only when the base command has no filter at all — not when a filter exists but was excluded by flags or only covers other subcommands (e.g. `git checkout` when only `git-log`/`git-commit` exist). Those are already partly covered and would be noise.
- **Name + frequency, not output bytes.** Recording uses plain `Passthrough`, so the child keeps the terminal's file descriptors directly: TTY detection, live streaming, and exit codes are unchanged, and a backgrounding/daemonizing child can't stall snip. The streamed output is never intercepted, so output size isn't captured. (An earlier attempt to count output bytes by wrapping stdio in a pipe was dropped: per `os/exec`, a non-`*os.File` stdout forces a copy goroutine that `Wait` drains until every inherited fd closes — which would hang on daemonizing commands — and makes the child see a pipe instead of a TTY.)
- **Best-effort & inert by default.** A failed record never changes the command's exit code; off by default and inert on `-tags lite` (no tracker), so the passthrough hot path is untouched unless explicitly enabled.
- **Retention:** 14 days for the `unfiltered_commands` table.

## Surfaces

- `snip gain --unfiltered [N]` — the new view (N defaults to 10).
- `snip config` shows `tracking.track_unfiltered`.

## Tests

`TestTrackUnfiltered`/`TestGetUnfilteredEmpty` (tracker), and existing suites. `make test`, `golangci-lint run`, `go test -race ./...`, and the `-tags lite` build all green. Verified end-to-end: with the flag on, `seq` is recorded while `git checkout` (partly covered) is not.