### PR TITLE
feat(filters): add markdownlint-cli2 filter (closes #100)

### DIFF
--- a/filters/markdownlint-cli2.yaml
+++ b/filters/markdownlint-cli2.yaml
@@ -1,0 +1,49 @@
+name: "markdownlint-cli2"
+version: 1
+description: "Condensed markdownlint-cli2 output: issues by file"
+
+match:
+  command: "markdownlint-cli2"
+
+streams:
+  - stdout
+  - stderr
+
+pipeline:
+  - action: "strip_ansi"
+  - action: "compact_path"
+  - action: "remove_lines"
+    pattern: "^markdownlint-cli2 v"
+  - action: "remove_lines"
+    pattern: "^(Finding|Linting): "
+  - action: "truncate_lines"
+    max: 120
+  - action: "head"
+    n: 30
+    overflow_msg: "... more issues"
+  - action: "on_empty"
+    message: "Summary: 0 error(s)"
+
+on_error: "passthrough"
+
+tests:
+  - name: "banner removed, issues and summary kept"
+    input: |
+      markdownlint-cli2 v0.13.0 (markdownlint v0.34.0)
+      Finding: **/*.md
+      Linting: 3 file(s)
+      Summary: 2 error(s)
+      README.md:12 MD013/line-length Line length [Expected: 80; Actual: 95]
+      docs/guide.md:5:1 MD022/blanks-around-headings Headings should be surrounded by blank lines
+    expected: |
+      Summary: 2 error(s)
+      README.md:12 MD013/line-length Line length [Expected: 80; Actual: 95]
+      docs/guide.md:5:1 MD022/blanks-around-headings Headings should be surrounded by blank lines
+  - name: "clean run keeps only the summary"
+    input: |
+      markdownlint-cli2 v0.13.0 (markdownlint v0.34.0)
+      Finding: **/*.md
+      Linting: 3 file(s)
+      Summary: 0 error(s)
+    expected: |
+      Summary: 0 error(s)


### PR DESCRIPTION
Closes #100.

Adds a `markdownlint-cli2` filter, based on the draft in the issue and modelled on the existing `markdownlint` filter.

## Behaviour

It condenses `markdownlint-cli2` output by:
- `strip_ansi` + `compact_path`
- dropping the tool's banner lines (`^markdownlint-cli2 v`, `^(Finding|Linting): `) while **keeping** the `Summary:` line and the per-file issues
- `truncate_lines max: 120`, then `head 30` with `... more issues`
- `on_empty` → `Summary: 0 error(s)`

`on_error: passthrough`, so any unexpected output falls back to raw.

Example:

```
markdownlint-cli2 v0.13.0 (markdownlint v0.34.0)   ┐
Finding: **/*.md                                   │ removed
Linting: 3 file(s)                                 ┘
Summary: 2 error(s)                                ┐
README.md:12 MD013/line-length ...                 │ kept
docs/guide.md:5:1 MD022/blanks-around-headings ... ┘
```

## Tests

Unlike the original `markdownlint` filter, this one ships **inline tests** (`snip verify`): one for a run with issues (banner removed, summary + issues kept) and one for a clean run (only the summary). `snip verify` → `markdownlint-cli2 ... 2/2 passed`; `make test`, `golangci-lint run`, and the full suite are green.