### PR TITLE
feat(init): add Grok Build (xAI) agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ snip integrates with every major AI coding assistant. One binary, universal comp
 | **Gemini CLI** | `snip init --agent gemini` | GEMINI.md prompt injection |
 | **Codex (OpenAI)** | `snip init --agent codex` | AGENTS.md prompt injection |
 | **Pi (pi.dev)** | `snip init --agent pi` | PreToolUse hook (via [pi-hooks](https://github.com/hsingjui/pi-hooks)) |
+| **Grok Build (xAI)** | `snip init --agent grok` | PreToolUse hook (deny + re-run suggestion) |
 | **Windsurf** | `snip init --agent windsurf` | .windsurfrules prompt injection |
 | **Cline / Roo Code** | `snip init --agent cline` | .clinerules prompt injection |
 | **Kilo Code** | `snip init --agent kilocode` | .kilocode/rules/ prompt injection |
@@ -200,6 +201,23 @@ Then run `/reload` (or restart Pi). Once active, snip rewrites supported command
 ```bash
 snip init --agent pi --uninstall   # remove the hook
 ```
+
+### Grok Build (xAI)
+
+```bash
+snip init --agent grok
+```
+
+This writes `~/.grok/hooks/snip.json` with a `PreToolUse` hook matching the shell tool. Grok Build hooks cannot rewrite commands in place (the hook contract is allow/deny only), so snip denies matched commands with a re-run suggestion (`"…/snip" run -- <command>`), the same pattern as Codex. Non-matching commands pass through untouched, and the hook is fail-open: if snip breaks, commands simply run unfiltered.
+
+Prefer prompt injection instead? Grok Build reads `AGENTS.md` natively:
+
+```bash
+snip init --agent grok --mode prompt   # creates AGENTS.md
+snip init --agent grok --uninstall     # remove the hook
+```
+
+`AGENTS.md` is shared with Codex, so `--uninstall` never deletes it; it prints a reminder instead.
 
 ### Copilot / Gemini / Codex / Windsurf / Cline / Kilo Code / Antigravity
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -68,6 +68,9 @@ func Run(args []string) int {
 		if len(cmdArgs) > 0 && cmdArgs[0] == "copilot" {
 			return runHookCopilot()
 		}
+		if len(cmdArgs) > 0 && cmdArgs[0] == "grok" {
+			return runHookGrok()
+		}
 		return runHook()
 
 	case "hook-audit":
@@ -293,6 +296,27 @@ func runHookCopilot() int {
 	return 0
 }
 
+// grokDenyExitCode is the exit code Grok Build requires for a PreToolUse deny
+// to take effect (exit 0 allows; anything else but 2 is fail-open).
+const grokDenyExitCode = 2
+
+// runHookGrok handles "snip hook grok" — Grok Build's PreToolUse hook entry.
+// Grok Build cannot rewrite the command in place, so the handler responds with
+// a deny + suggested rewrite; the deny only takes effect with exit code 2.
+// Every other path returns 0 (graceful degradation: Grok Build hooks are
+// fail-open, so the command runs unfiltered).
+func runHookGrok() int {
+	snipBin, commands, prefixes, ok := loadHookContext()
+	if !ok {
+		return 0
+	}
+	denied, _ := hook.RunGrok(os.Stdin, os.Stdout, commands, prefixes, snipBin)
+	if denied {
+		return grokDenyExitCode
+	}
+	return 0
+}
+
 // loadHookContext resolves the snip binary path and loads the filter
 // registry. Returns ok=false on any failure so callers can exit 0 silently.
 func loadHookContext() (snipBin string, commands []string, prefixes []hook.TransparentPrefix, ok bool) {
@@ -467,7 +491,7 @@ Commands:
 Init flags:
   --agent <name>  Agent to configure:
                   claude-code (default), cursor, codex, pi, windsurf, cline,
-                  copilot, gemini, kilocode, antigravity
+                  copilot, gemini, kilocode, antigravity, grok
   --uninstall     Remove snip integration for the agent
 
 Flags:

--- a/internal/hook/codex.go
+++ b/internal/hook/codex.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"strings"
 	"time"
 
 	"github.com/edouard-claude/snip/internal/hookaudit"
@@ -47,58 +46,30 @@ func RunCodex(r io.Reader, w io.Writer, commands []string, prefixes []Transparen
 		return nil
 	}
 
-	firstLine := ti.Command
-	if idx := strings.IndexByte(firstLine, '\n'); idx >= 0 {
-		firstLine = firstLine[:idx]
-	}
-	firstSegment := ExtractFirstSegment(firstLine)
-
-	prefix, envVars, bareCmd := ParseSegment(firstSegment)
-	base := BaseCommand(bareCmd)
-
-	quotedBin := fmt.Sprintf("%q", snipBin)
-	trimmed := strings.TrimLeft(bareCmd, " \t")
-	if base == quotedBin || base == snipBin ||
-		strings.HasPrefix(trimmed, quotedBin) || strings.HasPrefix(trimmed, snipBin) {
-		return nil
-	}
-
 	cmdSet := make(map[string]struct{}, len(commands))
 	for _, c := range commands {
 		cmdSet[c] = struct{}{}
 	}
 
-	restOfCmd := ti.Command[len(firstSegment):]
-
-	// Transparent runner prefix (e.g. "uv run pytest"): suggest wrapping the
-	// inner command so its filter applies, leaving the prefix in place. Only when
-	// a known inner command is located; otherwise fall back to the plain base
-	// check below.
-	var suggested string
-	if tp, restAfter, ok := matchTransparentPrefix(bareCmd, prefixes); ok {
-		if before, _, found := LocateInner(restAfter, cmdSet, tp.ValueFlags, tp.SkipFlags); found {
-			suggested = prefix + envVars + tp.Prefix + " " + before + quotedBin + " run -- " + restAfter[len(before):] + restOfCmd
+	sug := suggestSnipRerun(ti.Command, cmdSet, prefixes, snipBin)
+	if sug.alreadySnip {
+		return nil
+	}
+	if sug.command == "" {
+		if audit {
+			hookaudit.Append(hookaudit.Event{
+				Timestamp: time.Now().UTC(),
+				Command:   ti.Command,
+				Base:      sug.base,
+				Matched:   false,
+				Rewritten: false,
+				Agent:     codexAgent,
+			})
 		}
+		return nil
 	}
 
-	if suggested == "" {
-		if _, ok := cmdSet[base]; !ok {
-			if audit {
-				hookaudit.Append(hookaudit.Event{
-					Timestamp: time.Now().UTC(),
-					Command:   ti.Command,
-					Base:      base,
-					Matched:   false,
-					Rewritten: false,
-					Agent:     codexAgent,
-				})
-			}
-			return nil
-		}
-		suggested = prefix + envVars + quotedBin + " run -- " + bareCmd + restOfCmd
-	}
-
-	reason := fmt.Sprintf("snip can filter this command. Re-run as: %s", suggested)
+	reason := fmt.Sprintf("snip can filter this command. Re-run as: %s", sug.command)
 
 	output := map[string]any{
 		"hookSpecificOutput": map[string]any{
@@ -112,7 +83,7 @@ func RunCodex(r io.Reader, w io.Writer, commands []string, prefixes []Transparen
 		hookaudit.Append(hookaudit.Event{
 			Timestamp: time.Now().UTC(),
 			Command:   ti.Command,
-			Base:      base,
+			Base:      sug.base,
 			Matched:   true,
 			Rewritten: false,
 			Agent:     codexAgent,

--- a/internal/hook/grok.go
+++ b/internal/hook/grok.go
@@ -1,0 +1,117 @@
+package hook
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/edouard-claude/snip/internal/hookaudit"
+)
+
+// grokAgent is the value written to hookaudit.Event.Agent for Grok Build events.
+const grokAgent = "grok"
+
+// grokToolName is the native shell tool name of Grok Build (xAI's coding CLI).
+// Grok Build also maps Claude-style tool aliases, so "Bash" is accepted too.
+const grokToolName = "run_terminal_cmd"
+
+// grokInput represents the PreToolUse payload from Grok Build. Grok Build
+// sends camelCase keys, unlike Claude Code's snake_case:
+//
+//	{"hookEventName":"pre_tool_use","toolName":"run_terminal_cmd",
+//	 "toolInput":{"command":"npm test"},...}
+type grokInput struct {
+	ToolName  string          `json:"toolName"`
+	ToolInput json.RawMessage `json:"toolInput"`
+}
+
+// RunGrok reads a Grok Build PreToolUse JSON payload from r, determines if the
+// command matches a snip filter, and writes a deny-with-suggestion response
+// telling Grok Build (and the user) to re-run the command through snip:
+//
+//	{"decision":"deny","reason":"snip can filter this command. Re-run as: ..."}
+//
+// Grok Build's PreToolUse hook cannot rewrite the command in place — the
+// documented stdout contract is allow/deny only, with no updatedInput
+// equivalent. A deny takes effect only when the hook process exits with code
+// 2, so RunGrok returns denied=true and the caller must exit 2; every other
+// path must exit 0. Grok Build is fail-open (crashes, timeouts, and malformed
+// output let the command run unchanged), which preserves snip's graceful
+// degradation.
+//
+// Errors are returned but the caller should still exit 0 unless denied is true.
+func RunGrok(r io.Reader, w io.Writer, commands []string, prefixes []TransparentPrefix, snipBin string) (denied bool, err error) {
+	audit := hookaudit.Enabled()
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return false, fmt.Errorf("read stdin: %w", err)
+	}
+
+	var input grokInput
+	if err := json.Unmarshal(data, &input); err != nil {
+		return false, nil // malformed JSON: pass through silently
+	}
+
+	if input.ToolName != grokToolName && input.ToolName != "Bash" {
+		return false, nil
+	}
+
+	var ti toolInput
+	if err := json.Unmarshal(input.ToolInput, &ti); err != nil {
+		return false, nil
+	}
+	if ti.Command == "" {
+		return false, nil
+	}
+
+	cmdSet := make(map[string]struct{}, len(commands))
+	for _, c := range commands {
+		cmdSet[c] = struct{}{}
+	}
+
+	sug := suggestSnipRerun(ti.Command, cmdSet, prefixes, snipBin)
+	if sug.alreadySnip {
+		return false, nil
+	}
+	if sug.command == "" {
+		if audit {
+			hookaudit.Append(hookaudit.Event{
+				Timestamp: time.Now().UTC(),
+				Command:   ti.Command,
+				Base:      sug.base,
+				Matched:   false,
+				Rewritten: false,
+				Agent:     grokAgent,
+			})
+		}
+		return false, nil
+	}
+
+	reason := fmt.Sprintf("snip can filter this command. Re-run as: %s", sug.command)
+
+	output := map[string]any{
+		"decision": "deny",
+		"reason":   reason,
+	}
+
+	if audit {
+		hookaudit.Append(hookaudit.Event{
+			Timestamp: time.Now().UTC(),
+			Command:   ti.Command,
+			Base:      sug.base,
+			Matched:   true,
+			Rewritten: false,
+			Agent:     grokAgent,
+		})
+	}
+
+	enc := json.NewEncoder(w)
+	if err := enc.Encode(output); err != nil {
+		// The deny envelope never reached Grok Build; report allow (exit 0) so
+		// the fail-open contract lets the command run unfiltered.
+		return false, err
+	}
+	return true, nil
+}

--- a/internal/hook/grok_test.go
+++ b/internal/hook/grok_test.go
@@ -1,0 +1,246 @@
+package hook
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// makeGrokPayload builds a Grok Build PreToolUse stdin payload. Grok Build
+// sends camelCase keys (toolName/toolInput), unlike Claude Code's snake_case.
+func makeGrokPayload(toolName, command string) string {
+	payload := map[string]any{
+		"hookEventName": "pre_tool_use",
+		"toolName":      toolName,
+		"toolInput":     map[string]any{"command": command},
+	}
+	data, _ := json.Marshal(payload)
+	return string(data)
+}
+
+// extractGrokDenyReason validates the Grok Build deny envelope
+// ({"decision":"deny","reason":"..."}) and returns the reason.
+func extractGrokDenyReason(t *testing.T, output string) string {
+	t.Helper()
+	var result map[string]any
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, output)
+	}
+	if result["decision"] != "deny" {
+		t.Errorf("decision = %v, want deny", result["decision"])
+	}
+	if _, ok := result["hookSpecificOutput"]; ok {
+		t.Errorf("hookSpecificOutput must not be set in Grok Build response: %s", output)
+	}
+	reason, _ := result["reason"].(string)
+	if reason == "" {
+		t.Fatalf("reason is empty")
+	}
+	return reason
+}
+
+func TestRunGrokDeniesSupportedCommand(t *testing.T) {
+	commands := []string{"git", "go"}
+	snipBin := "/usr/local/bin/snip"
+
+	input := makeGrokPayload("run_terminal_cmd", "git log -10")
+	var out bytes.Buffer
+	denied, err := RunGrok(strings.NewReader(input), &out, commands, nil, snipBin)
+	if err != nil {
+		t.Fatalf("RunGrok: %v", err)
+	}
+	if !denied {
+		t.Fatal("expected denied=true for supported command")
+	}
+	if out.Len() == 0 {
+		t.Fatal("expected deny output for supported command, got empty")
+	}
+
+	reason := extractGrokDenyReason(t, out.String())
+	wantSuggestion := `"/usr/local/bin/snip" run -- git log -10`
+	if !strings.Contains(reason, wantSuggestion) {
+		t.Errorf("reason = %q, want it to contain %q", reason, wantSuggestion)
+	}
+}
+
+// TestRunGrokBashAliasToolName covers payloads carrying the Claude-style tool
+// name "Bash" instead of Grok Build's native "run_terminal_cmd".
+func TestRunGrokBashAliasToolName(t *testing.T) {
+	commands := []string{"git"}
+	snipBin := "/usr/local/bin/snip"
+
+	input := makeGrokPayload("Bash", "git status")
+	var out bytes.Buffer
+	denied, err := RunGrok(strings.NewReader(input), &out, commands, nil, snipBin)
+	if err != nil {
+		t.Fatalf("RunGrok: %v", err)
+	}
+	if !denied {
+		t.Fatal("expected denied=true for Bash alias tool name")
+	}
+	reason := extractGrokDenyReason(t, out.String())
+	wantSuggestion := `"/usr/local/bin/snip" run -- git status`
+	if !strings.Contains(reason, wantSuggestion) {
+		t.Errorf("reason = %q, want it to contain %q", reason, wantSuggestion)
+	}
+}
+
+func TestRunGrokUnsupportedPassthrough(t *testing.T) {
+	commands := []string{"git", "go"}
+	snipBin := "/usr/local/bin/snip"
+
+	input := makeGrokPayload("run_terminal_cmd", "ls -la")
+	var out bytes.Buffer
+	denied, err := RunGrok(strings.NewReader(input), &out, commands, nil, snipBin)
+	if err != nil {
+		t.Fatalf("RunGrok: %v", err)
+	}
+	if denied {
+		t.Error("expected denied=false for unsupported command")
+	}
+	if out.Len() != 0 {
+		t.Errorf("expected no output for unsupported command, got: %s", out.String())
+	}
+}
+
+func TestRunGrokAlreadyRewritten(t *testing.T) {
+	commands := []string{"git"}
+	snipBin := "/usr/local/bin/snip"
+
+	already := `"/usr/local/bin/snip" run -- git status`
+	input := makeGrokPayload("run_terminal_cmd", already)
+	var out bytes.Buffer
+	denied, err := RunGrok(strings.NewReader(input), &out, commands, nil, snipBin)
+	if err != nil {
+		t.Fatalf("RunGrok: %v", err)
+	}
+	if denied {
+		t.Error("expected denied=false for already-rewritten command")
+	}
+	if out.Len() != 0 {
+		t.Errorf("expected no output for already-rewritten command, got: %s", out.String())
+	}
+}
+
+func TestRunGrokMultiSegmentSuggestionIncludesTail(t *testing.T) {
+	commands := []string{"git"}
+	snipBin := "/usr/local/bin/snip"
+
+	input := makeGrokPayload("run_terminal_cmd", "git add . && git commit -m 'fix'")
+	var out bytes.Buffer
+	denied, err := RunGrok(strings.NewReader(input), &out, commands, nil, snipBin)
+	if err != nil {
+		t.Fatalf("RunGrok: %v", err)
+	}
+	if !denied {
+		t.Fatal("expected denied=true")
+	}
+
+	reason := extractGrokDenyReason(t, out.String())
+	wantSuggestion := `"/usr/local/bin/snip" run -- git add . && git commit -m 'fix'`
+	if !strings.Contains(reason, wantSuggestion) {
+		t.Errorf("reason = %q, want it to contain %q", reason, wantSuggestion)
+	}
+}
+
+func TestRunGrokEnvVarPrefix(t *testing.T) {
+	commands := []string{"go"}
+	snipBin := "/usr/local/bin/snip"
+
+	input := makeGrokPayload("run_terminal_cmd", "CGO_ENABLED=0 go test ./...")
+	var out bytes.Buffer
+	denied, err := RunGrok(strings.NewReader(input), &out, commands, nil, snipBin)
+	if err != nil {
+		t.Fatalf("RunGrok: %v", err)
+	}
+	if !denied {
+		t.Fatal("expected denied=true")
+	}
+
+	reason := extractGrokDenyReason(t, out.String())
+	wantSuggestion := `CGO_ENABLED=0 "/usr/local/bin/snip" run -- go test ./...`
+	if !strings.Contains(reason, wantSuggestion) {
+		t.Errorf("reason = %q, want it to contain %q", reason, wantSuggestion)
+	}
+}
+
+func TestRunGrokNonShellTool(t *testing.T) {
+	commands := []string{"git"}
+	snipBin := "/usr/local/bin/snip"
+
+	payload := map[string]any{
+		"hookEventName": "pre_tool_use",
+		"toolName":      "read_file",
+		"toolInput":     map[string]any{"path": "/tmp/foo"},
+	}
+	data, _ := json.Marshal(payload)
+
+	var out bytes.Buffer
+	denied, err := RunGrok(strings.NewReader(string(data)), &out, commands, nil, snipBin)
+	if err != nil {
+		t.Fatalf("RunGrok: %v", err)
+	}
+	if denied {
+		t.Error("expected denied=false for non-shell tool")
+	}
+	if out.Len() != 0 {
+		t.Errorf("expected no output for non-shell tool, got: %s", out.String())
+	}
+}
+
+func TestRunGrokEmptyCommand(t *testing.T) {
+	commands := []string{"git"}
+	snipBin := "/usr/local/bin/snip"
+
+	input := makeGrokPayload("run_terminal_cmd", "")
+	var out bytes.Buffer
+	denied, err := RunGrok(strings.NewReader(input), &out, commands, nil, snipBin)
+	if err != nil {
+		t.Fatalf("RunGrok: %v", err)
+	}
+	if denied {
+		t.Error("expected denied=false for empty command")
+	}
+	if out.Len() != 0 {
+		t.Errorf("expected no output for empty command, got: %s", out.String())
+	}
+}
+
+func TestRunGrokMalformedJSON(t *testing.T) {
+	commands := []string{"git"}
+	snipBin := "/usr/local/bin/snip"
+
+	var out bytes.Buffer
+	denied, err := RunGrok(strings.NewReader("{invalid json"), &out, commands, nil, snipBin)
+	if err != nil {
+		t.Fatalf("RunGrok must not error on malformed JSON: %v", err)
+	}
+	if denied {
+		t.Error("expected denied=false for malformed JSON")
+	}
+	if out.Len() != 0 {
+		t.Errorf("expected no output for malformed JSON, got: %s", out.String())
+	}
+}
+
+// TestRunGrokClaudeStylePayloadIgnored documents that RunGrok only consumes
+// Grok Build's camelCase payload: a Claude Code snake_case payload carries no
+// toolName and must pass through untouched.
+func TestRunGrokClaudeStylePayloadIgnored(t *testing.T) {
+	commands := []string{"git"}
+	snipBin := "/usr/local/bin/snip"
+
+	input := makePayload("Bash", "git status") // snake_case tool_name/tool_input
+	var out bytes.Buffer
+	denied, err := RunGrok(strings.NewReader(input), &out, commands, nil, snipBin)
+	if err != nil {
+		t.Fatalf("RunGrok: %v", err)
+	}
+	if denied {
+		t.Error("expected denied=false for Claude-style payload")
+	}
+	if out.Len() != 0 {
+		t.Errorf("expected no output for Claude-style payload, got: %s", out.String())
+	}
+}

--- a/internal/hook/suggest.go
+++ b/internal/hook/suggest.go
@@ -1,0 +1,62 @@
+package hook
+
+import (
+	"fmt"
+	"strings"
+)
+
+// snipSuggestion is the outcome of analyzing a command for a deny-and-steer
+// re-run suggestion, used by hosts whose PreToolUse hooks cannot rewrite the
+// command in place (Codex, Grok Build).
+type snipSuggestion struct {
+	// command is the full suggested re-run command; empty when no snip filter
+	// matched.
+	command string
+	// base is the base command of the first segment, for audit events.
+	base string
+	// alreadySnip is true when the command is already wrapped through snip.
+	alreadySnip bool
+}
+
+// suggestSnipRerun builds the "re-run through snip" suggestion for command.
+// Only the first runnable segment is inspected; any remainder (further
+// segments, extra lines) is carried into the suggestion verbatim.
+func suggestSnipRerun(command string, cmdSet map[string]struct{}, prefixes []TransparentPrefix, snipBin string) snipSuggestion {
+	firstLine := command
+	if idx := strings.IndexByte(firstLine, '\n'); idx >= 0 {
+		firstLine = firstLine[:idx]
+	}
+	firstSegment := ExtractFirstSegment(firstLine)
+
+	prefix, envVars, bareCmd := ParseSegment(firstSegment)
+	base := BaseCommand(bareCmd)
+
+	quotedBin := fmt.Sprintf("%q", snipBin)
+	trimmed := strings.TrimLeft(bareCmd, " \t")
+	if base == quotedBin || base == snipBin ||
+		strings.HasPrefix(trimmed, quotedBin) || strings.HasPrefix(trimmed, snipBin) {
+		return snipSuggestion{base: base, alreadySnip: true}
+	}
+
+	restOfCmd := command[len(firstSegment):]
+
+	// Transparent runner prefix (e.g. "uv run pytest"): suggest wrapping the
+	// inner command so its filter applies, leaving the prefix in place. Only when
+	// a known inner command is located; otherwise fall back to the plain base
+	// check below.
+	var suggested string
+	if tp, restAfter, ok := matchTransparentPrefix(bareCmd, prefixes); ok {
+		if before, _, found := LocateInner(restAfter, cmdSet, tp.ValueFlags, tp.SkipFlags); found {
+			suggested = prefix + envVars + tp.Prefix + " " + before + quotedBin + " run -- " + restAfter[len(before):] + restOfCmd
+		}
+	}
+
+	if suggested == "" {
+		if _, ok := cmdSet[base]; !ok {
+			return snipSuggestion{base: base}
+		}
+		suggested = prefix + envVars + quotedBin + " run -- " + bareCmd + restOfCmd
+	}
+
+	return snipSuggestion{command: suggested, base: base}
+}

--- a/internal/initcmd/codex.go
+++ b/internal/initcmd/codex.go
@@ -95,10 +95,9 @@ func uninstallCodex() error {
 		return fmt.Errorf("unpatch codex config.toml: %w", err)
 	}
 
-	// Best-effort cleanup of a legacy AGENTS.md.
-	if legacy := detectLegacyAgentsMD("."); legacy != "" {
-		_ = os.Remove(legacy)
-	}
+	// Best-effort cleanup of a legacy AGENTS.md. Skipped when the file is shared
+	// with another prompt-mode agent (grok), which the helper reports on.
+	removeLegacyPromptFile("codex")
 
 	fmt.Println("snip uninstalled (codex)")
 	return nil

--- a/internal/initcmd/copilot.go
+++ b/internal/initcmd/copilot.go
@@ -109,6 +109,11 @@ func uninstallCopilot() error {
 
 // removeLegacyPromptFile deletes the prompt-injection file for agent if it still
 // contains the snip template marker, then prunes any empty parent directories.
+//
+// Files shared by several agents (AGENTS.md, written identically by codex and
+// grok) are never deleted: snip cannot tell which agent wrote one, so removing
+// it would silently break the other agent's integration. The user is told to
+// remove it manually instead.
 func removeLegacyPromptFile(agent string) {
 	filename, ok := promptAgentFiles[agent]
 	if !ok {
@@ -120,6 +125,10 @@ func removeLegacyPromptFile(agent string) {
 		return
 	}
 	if !strings.Contains(string(data), snipPromptMarker) {
+		return
+	}
+	if promptFileShared(filename) {
+		fmt.Printf("  kept %s (shared with another agent) — delete it manually if unused\n", targetPath)
 		return
 	}
 	if err := os.Remove(targetPath); err != nil {

--- a/internal/initcmd/grok.go
+++ b/internal/initcmd/grok.go
@@ -1,0 +1,110 @@
+package initcmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// grokHookSubcommand is the snip subsubcommand Grok Build invokes.
+const grokHookSubcommand = "hook grok"
+
+// grokMatcher is the PreToolUse matcher written to the hook config. The field
+// is a regex tested against the tool name; it covers Grok Build's native shell
+// tool (run_terminal_cmd) and the Claude-style alias (Bash) it also accepts.
+const grokMatcher = "Bash|run_terminal_cmd"
+
+// grokHookFile is the snip-owned hook config filename. Grok Build loads every
+// *.json under its hooks directory, so snip writes a dedicated file rather
+// than merging into a shared one (install = write, uninstall = remove).
+const grokHookFile = "snip.json"
+
+// grokHooksDir returns the Grok Build global hooks directory for the given
+// home. Global hooks are always trusted (no /hooks-trust needed).
+func grokHooksDir(home string) string {
+	return filepath.Join(home, ".grok", "hooks")
+}
+
+// grokHookPath returns the snip hook config path for the given home.
+func grokHookPath(home string) string {
+	return filepath.Join(grokHooksDir(home), grokHookFile)
+}
+
+// initGrok installs the snip Grok Build hook: writes ~/.grok/hooks/snip.json
+// with a PreToolUse entry that pipes shell commands through `snip hook grok`.
+func initGrok(snipBin, home, filterDir string) error {
+	// Grok Build runs the hook command through a shell; the binary path is
+	// quoted so a space in it cannot break the invocation. Grok Build hooks are
+	// fail-open (a crash or malformed output lets the command run unfiltered),
+	// so a broken hook never blocks the agent.
+	hookCommand := fmt.Sprintf("%q %s", snipBin, grokHookSubcommand)
+	path := grokHookPath(home)
+	if err := writeGrokHookConfig(path, hookCommand); err != nil {
+		return fmt.Errorf("write grok hook: %w", err)
+	}
+
+	fmt.Println("snip init complete:")
+	fmt.Printf("  agent: grok\n")
+	fmt.Printf("  hook: %s\n", hookCommand)
+	fmt.Printf("  filters: %s\n", filterDir)
+	fmt.Printf("  config: %s\n", path)
+	fmt.Println()
+	fmt.Println("note: Grok Build hooks cannot rewrite commands in place, so snip denies")
+	fmt.Println("      matched commands with a re-run suggestion (same pattern as Codex).")
+	fmt.Println("      Verify the hook is loaded with `grok inspect` or /hooks-list.")
+	fmt.Println("      For the prompt-injection setup instead use:")
+	fmt.Println("        snip init --agent grok --mode prompt")
+	return nil
+}
+
+// buildGrokHookConfig returns the Grok Build hook config object that pipes
+// matched shell commands through hookCommand.
+func buildGrokHookConfig(hookCommand string) map[string]any {
+	return map[string]any{
+		"hooks": map[string]any{
+			"PreToolUse": []any{
+				map[string]any{
+					"matcher": grokMatcher,
+					"hooks": []any{
+						map[string]any{"type": "command", "command": hookCommand},
+					},
+				},
+			},
+		},
+	}
+}
+
+// writeGrokHookConfig writes the snip-owned Grok Build hook file, creating the
+// hooks directory if needed.
+func writeGrokHookConfig(path, hookCommand string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create hooks dir: %w", err)
+	}
+	out, err := json.MarshalIndent(buildGrokHookConfig(hookCommand), "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal hook config: %w", err)
+	}
+	return os.WriteFile(path, out, 0o644)
+}
+
+// uninstallGrok removes the snip Grok Build hook file and, best-effort, a
+// legacy prompt-injection file left by `--mode prompt`.
+func uninstallGrok() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("get home dir: %w", err)
+	}
+
+	// Remove the snip-owned hook file (snip owns this filename entirely).
+	if err := os.Remove(grokHookPath(home)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove grok hook: %w", err)
+	}
+
+	// Best-effort cleanup of a prompt-injection file, only when it still
+	// matches the snip template (don't touch a file the user has edited).
+	removeLegacyPromptFile("grok")
+
+	fmt.Println("snip uninstalled (grok)")
+	return nil
+}

--- a/internal/initcmd/grok_test.go
+++ b/internal/initcmd/grok_test.go
@@ -1,0 +1,192 @@
+package initcmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildGrokHookConfig(t *testing.T) {
+	cfg := buildGrokHookConfig(`"/usr/local/bin/snip" hook grok`)
+
+	hooks, ok := cfg["hooks"].(map[string]any)
+	if !ok {
+		t.Fatalf("hooks missing: %v", cfg)
+	}
+	pre, ok := hooks["PreToolUse"].([]any)
+	if !ok || len(pre) != 1 {
+		t.Fatalf("PreToolUse = %v, want 1 entry", hooks["PreToolUse"])
+	}
+	matcher := pre[0].(map[string]any)
+	if matcher["matcher"] != grokMatcher {
+		t.Errorf("matcher = %v, want %q", matcher["matcher"], grokMatcher)
+	}
+	inner, ok := matcher["hooks"].([]any)
+	if !ok || len(inner) != 1 {
+		t.Fatalf("nested hooks = %v, want 1 entry", matcher["hooks"])
+	}
+	entry := inner[0].(map[string]any)
+	if entry["type"] != "command" {
+		t.Errorf("type = %v, want command", entry["type"])
+	}
+	cmd, _ := entry["command"].(string)
+	if !strings.HasSuffix(cmd, " hook grok") {
+		t.Errorf("command = %q, want suffix ' hook grok'", cmd)
+	}
+}
+
+func TestInitGrokEndToEnd(t *testing.T) {
+	home := t.TempDir()
+	filterDir := filepath.Join(home, ".config", "snip", "filters")
+	if err := os.MkdirAll(filterDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := initGrok("/usr/local/bin/snip", home, filterDir); err != nil {
+		t.Fatalf("initGrok: %v", err)
+	}
+
+	path := grokHookPath(home)
+	cfg := readSettings(t, path)
+
+	pre := cfg["hooks"].(map[string]any)["PreToolUse"].([]any)
+	if len(pre) != 1 {
+		t.Fatalf("expected 1 PreToolUse entry, got %d", len(pre))
+	}
+	inner := pre[0].(map[string]any)["hooks"].([]any)
+	cmd := inner[0].(map[string]any)["command"].(string)
+	if !strings.HasSuffix(cmd, " hook grok") {
+		t.Errorf("hook command = %q, want suffix ' hook grok'", cmd)
+	}
+	// The binary path must be quoted so a space in it cannot break the shell
+	// invocation (Grok Build runs the hook command through a shell).
+	if !strings.HasPrefix(cmd, `"`) {
+		t.Errorf("hook command = %q, want quoted binary path", cmd)
+	}
+}
+
+// TestInitGrokIdempotent verifies running init twice leaves a single valid
+// snip-owned hook file (install = write, so the second run overwrites).
+func TestInitGrokIdempotent(t *testing.T) {
+	home := t.TempDir()
+	filterDir := filepath.Join(home, ".config", "snip", "filters")
+	_ = os.MkdirAll(filterDir, 0o755)
+
+	if err := initGrok("/usr/local/bin/snip", home, filterDir); err != nil {
+		t.Fatalf("first initGrok: %v", err)
+	}
+	if err := initGrok("/usr/local/bin/snip", home, filterDir); err != nil {
+		t.Fatalf("second initGrok: %v", err)
+	}
+
+	cfg := readSettings(t, grokHookPath(home))
+	pre := cfg["hooks"].(map[string]any)["PreToolUse"].([]any)
+	if len(pre) != 1 {
+		t.Fatalf("expected 1 PreToolUse entry after re-init, got %d", len(pre))
+	}
+}
+
+func TestInitGrokThenUninstall(t *testing.T) {
+	home := t.TempDir()
+	filterDir := filepath.Join(home, ".config", "snip", "filters")
+	_ = os.MkdirAll(filterDir, 0o755)
+
+	if err := initGrok("/usr/local/bin/snip", home, filterDir); err != nil {
+		t.Fatalf("initGrok: %v", err)
+	}
+	path := grokHookPath(home)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("hook file should exist after init: %v", err)
+	}
+
+	t.Setenv("HOME", home)
+	if err := uninstallGrok(); err != nil {
+		t.Fatalf("uninstallGrok: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("hook file should be removed after uninstall, stat err = %v", err)
+	}
+}
+
+// TestUninstallGrokNoHookFile verifies uninstall is a no-op (no error) when
+// nothing was installed.
+func TestUninstallGrokNoHookFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := uninstallGrok(); err != nil {
+		t.Fatalf("uninstallGrok on clean home: %v", err)
+	}
+}
+
+// TestPromptFileShared verifies AGENTS.md is recognized as shared (codex and
+// grok both write it) while single-agent files are not.
+func TestPromptFileShared(t *testing.T) {
+	if !promptFileShared("AGENTS.md") {
+		t.Error("AGENTS.md should be shared (codex + grok)")
+	}
+	for _, f := range []string{"GEMINI.md", ".windsurfrules", ".clinerules"} {
+		if promptFileShared(f) {
+			t.Errorf("%s should not be shared", f)
+		}
+	}
+}
+
+// TestUninstallGrokKeepsSharedAgentsMD guards the shared-file regression:
+// AGENTS.md is written by both codex and grok with byte-identical content, so
+// uninstalling grok must not delete a file codex may still rely on.
+func TestUninstallGrokKeepsSharedAgentsMD(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Chdir(t.TempDir())
+
+	if err := initPromptAgent("codex", "/usr/local/bin/snip", "/tmp/filters"); err != nil {
+		t.Fatalf("initPromptAgent(codex): %v", err)
+	}
+	if _, err := os.Stat("AGENTS.md"); err != nil {
+		t.Fatalf("AGENTS.md should exist after codex prompt init: %v", err)
+	}
+
+	if err := uninstallGrok(); err != nil {
+		t.Fatalf("uninstallGrok: %v", err)
+	}
+	if _, err := os.Stat("AGENTS.md"); err != nil {
+		t.Errorf("uninstallGrok must not delete the shared AGENTS.md: %v", err)
+	}
+}
+
+// TestUninstallCodexKeepsSharedAgentsMD is the symmetric guard: uninstalling
+// codex must not delete an AGENTS.md that grok's prompt mode may rely on.
+func TestUninstallCodexKeepsSharedAgentsMD(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Chdir(t.TempDir())
+
+	if err := initPromptAgent("grok", "/usr/local/bin/snip", "/tmp/filters"); err != nil {
+		t.Fatalf("initPromptAgent(grok): %v", err)
+	}
+	if _, err := os.Stat("AGENTS.md"); err != nil {
+		t.Fatalf("AGENTS.md should exist after grok prompt init: %v", err)
+	}
+
+	if err := uninstallCodex(); err != nil {
+		t.Fatalf("uninstallCodex: %v", err)
+	}
+	if _, err := os.Stat("AGENTS.md"); err != nil {
+		t.Errorf("uninstallCodex must not delete the shared AGENTS.md: %v", err)
+	}
+}
+
+// TestRemoveLegacyPromptFileStillRemovesUnsharedFile verifies the shared-file
+// guard did not disable cleanup of single-agent prompt files.
+func TestRemoveLegacyPromptFileStillRemovesUnsharedFile(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if err := initPromptAgent("gemini", "/usr/local/bin/snip", "/tmp/filters"); err != nil {
+		t.Fatalf("initPromptAgent(gemini): %v", err)
+	}
+	removeLegacyPromptFile("gemini")
+	if _, err := os.Stat("GEMINI.md"); !os.IsNotExist(err) {
+		t.Errorf("GEMINI.md should be removed (not shared), stat err = %v", err)
+	}
+}

--- a/internal/initcmd/init.go
+++ b/internal/initcmd/init.go
@@ -18,19 +18,34 @@ const (
 // validAgents lists all supported agent names.
 var validAgents = []string{
 	"claude-code", "cursor", "codex", "pi", "windsurf", "cline",
-	"copilot", "gemini", "kilocode", "antigravity",
+	"copilot", "gemini", "kilocode", "antigravity", "grok",
 }
 
 // promptAgentFiles maps prompt-injection agents to their target file paths.
 // Paths may include subdirectories (created automatically on init).
 var promptAgentFiles = map[string]string{
 	"codex":       "AGENTS.md",
+	"grok":        "AGENTS.md",
 	"windsurf":    ".windsurfrules",
 	"cline":       ".clinerules",
 	"copilot":     filepath.Join(".github", "copilot-instructions.md"),
 	"gemini":      "GEMINI.md",
 	"kilocode":    filepath.Join(".kilocode", "rules", "snip-rules.md"),
 	"antigravity": filepath.Join(".agents", "rules", "snip-rules.md"),
+}
+
+// promptFileShared reports whether more than one agent writes filename. Shared
+// files (AGENTS.md, claimed by both codex and grok) carry agent-agnostic
+// content, so snip cannot tell which agent wrote one and must never delete it
+// on a single-agent uninstall.
+func promptFileShared(filename string) bool {
+	n := 0
+	for _, f := range promptAgentFiles {
+		if f == filename {
+			n++
+		}
+	}
+	return n > 1
 }
 
 // parseAgent extracts the --agent value from args.
@@ -140,6 +155,13 @@ func Run(args []string) error {
 			return initPromptAgent(agent, snipBin, filterDir)
 		}
 		return initCopilotHook(snipBin, home, filterDir)
+	case "grok":
+		// Grok Build defaults to runtime hooks; --mode prompt selects the
+		// AGENTS.md prompt-injection path (Grok Build reads AGENTS.md natively).
+		if mode == "prompt" {
+			return initPromptAgent(agent, snipBin, filterDir)
+		}
+		return initGrok(snipBin, home, filterDir)
 	case "windsurf", "cline", "gemini", "kilocode", "antigravity":
 		return initPromptAgent(agent, snipBin, filterDir)
 	}
@@ -268,6 +290,8 @@ func Uninstall(agent string) error {
 		return uninstallPi()
 	case "copilot":
 		return uninstallCopilot()
+	case "grok":
+		return uninstallGrok()
 	case "windsurf", "cline", "gemini", "kilocode", "antigravity":
 		return uninstallPromptAgent(agent)
 	}

--- a/internal/initcmd/init_test.go
+++ b/internal/initcmd/init_test.go
@@ -329,7 +329,7 @@ func TestParseAgentEquals(t *testing.T) {
 func TestIsValidAgent(t *testing.T) {
 	valid := []string{
 		"claude-code", "cursor", "codex", "windsurf", "cline",
-		"copilot", "gemini", "kilocode", "antigravity",
+		"copilot", "gemini", "kilocode", "antigravity", "grok",
 	}
 	for _, a := range valid {
 		if !isValidAgent(a) {
@@ -515,6 +515,7 @@ func TestPromptAgentFiles(t *testing.T) {
 		filename string
 	}{
 		{"codex", "AGENTS.md"},
+		{"grok", "AGENTS.md"},
 		{"windsurf", ".windsurfrules"},
 		{"cline", ".clinerules"},
 		{"copilot", filepath.Join(".github", "copilot-instructions.md")},


### PR DESCRIPTION
Closes #105.

Adds `grok` as a supported agent for `snip init`, requested in #105.

## Why deny-and-steer rather than transparent rewrite

Grok Build's `PreToolUse` hook contract is **allow/deny only**. Unlike Claude Code, it has no `updatedInput` field, so a hook cannot rewrite a command in place. This was verified against the official docs (docs.x.ai/build/features/hooks): the documented stdout schema is `{"decision":"allow|deny","reason":"..."}` and nothing else. Everything but an explicit deny (crash, timeout, malformed output, exit 1) is fail-open.

So snip reuses the pattern it already ships for Codex: deny the matched command with a reason telling the agent to re-run it through snip.

## What lands

- **`snip init --agent grok`** writes `~/.grok/hooks/snip.json` with a `PreToolUse` entry. The matcher covers Grok Build's native shell tool `run_terminal_cmd` and the `Bash` alias it also accepts. Global hooks are always trusted, so no `/hooks-trust` step is needed.
- **`snip hook grok`** parses Grok Build's payload, which is **camelCase** (`toolName` / `toolInput`) where Claude Code is snake_case (`tool_name` / `tool_input`). It emits:
  ```json
  {"decision":"deny","reason":"snip can filter this command. Re-run as: \"/usr/local/bin/snip\" run -- git log -10"}
  ```
  A deny only takes effect when the hook exits **2**; snip exits 0 on every other path. Unmatched commands and already-wrapped commands pass through untouched.
- **`--mode prompt`** selects `AGENTS.md` prompt injection, which Grok Build reads natively.
- `suggestSnipRerun` is extracted from `RunCodex` into `internal/hook/suggest.go` so both deny-and-steer handlers derive the same re-run command (transparent runner prefixes, env-var prefixes, multi-segment tails included).

## Bug found during review and fixed here

`AGENTS.md` is now claimed by **both** `codex` and `grok`, with byte-identical content and the same `# Snip - CLI Token Optimizer` marker. snip therefore cannot tell which agent wrote it, and the existing uninstall paths delete it on marker match. That meant `snip init --agent grok --uninstall` would silently delete a Codex user's `AGENTS.md`, and vice versa.

`removeLegacyPromptFile` now refuses to delete a prompt file claimed by more than one agent (derived from `promptAgentFiles`, so it stays correct if another agent is added) and prints a reminder instead. `uninstallCodex` routes through the same helper rather than its own `os.Remove`. Two regression tests cover both directions and fail without the guard.

## Graceful degradation

Grok Build also reads `~/.claude/settings.json` for compat, so a user with `snip init` (claude-code) installed will have `snip hook` fire inside Grok Build sessions. It receives a camelCase payload, matches nothing, writes nothing, exits 0 -- fail-open, verified end-to-end. No conflict when both hooks are installed.

## Verification

`golangci-lint run` (0 issues), `make test-race` (all packages), full + `-tags lite` builds and tests. Hook behavior driven end-to-end against the real binary for each path: supported command (deny + exit 2), unsupported (silent + exit 0), already wrapped (silent + exit 0), `Bash` alias, cross-agent payloads, malformed JSON.

## Known unknown

It is not documented whether Grok Build surfaces the deny `reason` back to the model. The `reason` field, the `PermissionDenied` event, and Grok Build's broader mirroring of Claude Code semantics all point to yes, and this is the same contract snip already relies on for Codex, but I could not verify it against a live install. If it turns out the reason is swallowed, `--mode prompt` is the documented fallback and `--uninstall` the escape hatch.

The [wiki Integration page](https://github.com/edouard-claude/snip/wiki/Integration) is updated in a separate push.