### PR TITLE
feat: support optional -- separator for snip proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ snip discover --since 30    # scan last 30 days
 snip discover --all         # scan all projects
 snip -v <command>           # verbose mode (show filter details)
 snip proxy <command>        # force passthrough (no filtering)
+snip proxy -- <command>     # same, with explicit separator (like run/check)
 snip config                 # show config
 snip init                       # install Claude Code hook
 snip init --agent cursor        # install Cursor hook

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -211,7 +211,11 @@ func Run(args []string) int {
 		return runCheck(targetCmd, targetArgs, flags)
 
 	case "proxy":
-		// Direct passthrough without filtering
+		// Direct passthrough without filtering. The "--" separator is
+		// optional (unlike run/check) to keep "snip proxy <cmd>" working.
+		if len(cmdArgs) > 0 && cmdArgs[0] == "--" {
+			cmdArgs = cmdArgs[1:]
+		}
 		if len(cmdArgs) == 0 {
 			display.PrintError("proxy requires a command argument")
 			return 1
@@ -482,7 +486,7 @@ Commands:
   config          Show current configuration
   trust           Trust project-local filter file(s) by SHA-256 hash
   untrust         Remove filter file(s) from the trust store
-  proxy           Passthrough without filtering
+  proxy           Passthrough without filtering (optional -- separator)
   inspect         Code quality checks for snip's own source
                   --dead-fields   find tagged struct fields never read
                   --append-safety find shared-state append() calls

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -182,6 +182,49 @@ func TestCheckRejectsArgsBeforeSeparator(t *testing.T) {
 	}
 }
 
+func TestProxyAcceptsSeparator(t *testing.T) {
+	code := Run([]string{"snip", "proxy", "--", "true"})
+	if code != 0 {
+		t.Errorf("Run(proxy -- true) = %d, want 0", code)
+	}
+}
+
+func TestProxyPreservesExitCodeWithSeparator(t *testing.T) {
+	// Distinctive exit code: 1 would collide with snip's own error return.
+	code := Run([]string{"snip", "proxy", "--", "sh", "-c", "exit 3"})
+	if code != 3 {
+		t.Errorf("Run(proxy -- sh -c 'exit 3') = %d, want 3", code)
+	}
+}
+
+func TestProxyEmptyAfterSeparator(t *testing.T) {
+	var code int
+	stderr := captureStderr(func() {
+		code = Run([]string{"snip", "proxy", "--"})
+	})
+	if code != 1 {
+		t.Errorf("Run(proxy --) = %d, want 1", code)
+	}
+	if !strings.Contains(stderr, "proxy requires a command argument") {
+		t.Errorf("expected usage error on stderr, got %q", stderr)
+	}
+}
+
+func TestProxyWithoutSeparator(t *testing.T) {
+	code := Run([]string{"snip", "proxy", "true"})
+	if code != 0 {
+		t.Errorf("Run(proxy true) = %d, want 0", code)
+	}
+}
+
+func TestProxyKeepsNonLeadingSeparator(t *testing.T) {
+	// Only a leading "--" is stripped; a later one belongs to the child.
+	code := Run([]string{"snip", "proxy", "sh", "-c", `test "$1" = "--"`, "_", "--"})
+	if code != 0 {
+		t.Errorf("Run(proxy sh -c 'test $1 = --' _ --) = %d, want 0", code)
+	}
+}
+
 func TestCheckNoFilter(t *testing.T) {
 	home := t.TempDir()
 	filterDir := filepath.Join(home, ".config", "snip", "filters")


### PR DESCRIPTION
Closes #108

## What

`snip proxy -- <command> [args...]` now works, consistent with `run` and `check`. The separator stays **optional** so existing `snip proxy <command>` invocations keep working (unlike `run`/`check` where it is required).

## How

In the `proxy` case of `cli.Run`, a single leading `--` is stripped from the args before passthrough. A non-leading `--` still belongs to the child command and is passed verbatim.

## Tests

- `snip proxy -- true` exits 0
- `snip proxy -- sh -c "exit 3"` exits 3 (distinctive code, pins exit-code propagation through the `--` path)
- `snip proxy --` exits 1 with the `proxy requires a command argument` usage error on stderr
- `snip proxy true` (no separator) still works
- `snip proxy sh -c 'test "$1" = "--"' _ --` exits 0 (non-leading `--` reaches the child verbatim)

Local CI: `golangci-lint run` 0 issues, `go test -race -cover ./...` green.