### PR TITLE
feat: add tee.project_marker to write tee files under the repo root

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,12 @@ enabled = true
 mode = "failures"    # "failures" | "always" | "never"
 max_files = 20
 max_file_size = 1048576
+# project_marker = ".git"  # write tee files to <repo-root>/.snip/tee/ instead
+                           # of the global dir when the marker is found by
+                           # walking up from the working directory; a
+                           # .gitignore is created there so logs are never
+                           # committed, and snip falls back to the global dir
+                           # if the repo root is not writable
 ```
 
 ### Multiple Filter Directories

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -142,6 +142,7 @@ func Run(args []string) int {
 		fmt.Printf("filters.dir: %s\n", strings.Join(cfg.Filters.Dirs(), ", "))
 		fmt.Printf("tee.mode: %s\n", cfg.Tee.Mode)
 		fmt.Printf("tee.max_files: %d\n", cfg.Tee.MaxFiles)
+		fmt.Printf("tee.project_marker: %s\n", cfg.Tee.ProjectMarker)
 		fmt.Printf("display.color: %v\n", cfg.Display.Color)
 		fmt.Printf("display.emoji: %v\n", cfg.Display.Emoji)
 		fmt.Printf("display.quiet_no_filter: %v\n", cfg.Display.QuietNoFilter)
@@ -389,6 +390,7 @@ func runPipeline(command string, args []string, flags Flags) int {
 	teeCfg.Mode = cfg.Tee.Mode
 	teeCfg.MaxFiles = cfg.Tee.MaxFiles
 	teeCfg.MaxFileSize = cfg.Tee.MaxFileSize
+	teeCfg.ProjectMarker = cfg.Tee.ProjectMarker
 
 	pipeline := &engine.Pipeline{
 		Registry:            registry,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -102,6 +102,13 @@ type TeeConfig struct {
 	Mode        string `toml:"mode"` // "failures", "always", "never"
 	MaxFiles    int    `toml:"max_files"`
 	MaxFileSize int64  `toml:"max_file_size"`
+	// ProjectMarker, when set (e.g. ".git"), makes tee walk upward from the
+	// current working directory looking for that file or directory. If found
+	// in directory D, tee files are written to D/.snip/tee/ instead of the
+	// global tee directory (falling back to the global directory when the
+	// project directory is not writable). Empty (default) keeps the global
+	// directory. See issue #107.
+	ProjectMarker string `toml:"project_marker"`
 }
 
 // DefaultConfig returns sensible defaults.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -294,6 +294,7 @@ db_path = "/custom/path.db"
 [tee]
 mode = "always"
 max_files = 5
+project_marker = ".git"
 `
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatal(err)
@@ -313,6 +314,9 @@ max_files = 5
 	}
 	if cfg.Tee.MaxFiles != 5 {
 		t.Errorf("expected max_files 5, got %d", cfg.Tee.MaxFiles)
+	}
+	if cfg.Tee.ProjectMarker != ".git" {
+		t.Errorf("expected project_marker '.git', got %q", cfg.Tee.ProjectMarker)
 	}
 }
 

--- a/internal/tee/tee.go
+++ b/internal/tee/tee.go
@@ -16,6 +16,12 @@ type Config struct {
 	MaxFiles    int
 	MaxFileSize int64
 	Dir         string
+	// ProjectMarker, when non-empty, redirects tee files to
+	// <markerRoot>/.snip/tee/ where markerRoot is the closest ancestor of
+	// the working directory containing the marker (e.g. ".git"). Falls back
+	// to Dir when the marker is not found or the project directory is not
+	// writable.
+	ProjectMarker string
 }
 
 // DefaultConfig returns tee defaults.
@@ -54,14 +60,7 @@ func MaybeSave(raw string, exitCode int, cmd string, cfg Config) string {
 		return ""
 	}
 
-	dir := cfg.Dir
-	if envDir := os.Getenv("SNIP_TEE_DIR"); envDir != "" {
-		dir = envDir
-	}
-
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return "" // Silent failure
-	}
+	dir, project := resolveDir(cfg)
 
 	// Truncate if too large (rune-safe)
 	data := raw
@@ -87,9 +86,15 @@ func MaybeSave(raw string, exitCode int, cmd string, cfg Config) string {
 	}, cmd)
 
 	filename := fmt.Sprintf("%d-%s.log", time.Now().Unix(), safeName)
-	path := filepath.Join(dir, filename)
 
-	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+	path, ok := writeTo(dir, project, filename, data)
+	if !ok && project {
+		// Project dir not writable (read-only checkout, root-owned repo):
+		// fall back to the global dir rather than losing the recovery log.
+		dir = cfg.Dir
+		path, ok = writeTo(dir, false, filename, data)
+	}
+	if !ok {
 		return "" // Silent failure
 	}
 
@@ -97,6 +102,60 @@ func MaybeSave(raw string, exitCode int, cmd string, cfg Config) string {
 	rotateFiles(dir, cfg.MaxFiles)
 
 	return fmt.Sprintf("[full output: %s]", path)
+}
+
+// writeTo creates dir and writes the log file into it. For project dirs it
+// also drops a .gitignore so agent-driven `git add -A` never commits raw
+// command output into the repo.
+func writeTo(dir string, project bool, filename, data string) (string, bool) {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", false
+	}
+	if project {
+		gi := filepath.Join(dir, ".gitignore")
+		if _, err := os.Stat(gi); err != nil {
+			_ = os.WriteFile(gi, []byte("*\n"), 0644)
+		}
+	}
+	path := filepath.Join(dir, filename)
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		return "", false
+	}
+	return path, true
+}
+
+// resolveDir returns the directory tee files are written to, and whether it
+// is a project-local directory derived from the marker walk-up.
+// Priority: SNIP_TEE_DIR env > project marker walk-up > cfg.Dir.
+func resolveDir(cfg Config) (string, bool) {
+	if envDir := os.Getenv("SNIP_TEE_DIR"); envDir != "" {
+		return envDir, false
+	}
+	if cfg.ProjectMarker != "" {
+		if root := findMarkerRoot(cfg.ProjectMarker); root != "" {
+			return filepath.Join(root, ".snip", "tee"), true
+		}
+	}
+	return cfg.Dir, false
+}
+
+// findMarkerRoot walks upward from the current working directory looking for
+// marker (a file or directory name, e.g. ".git"). Returns the directory
+// containing the marker, or "" if none is found up to the filesystem root.
+func findMarkerRoot(marker string) string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	for dir := cwd; ; dir = filepath.Dir(dir) {
+		if _, err := os.Stat(filepath.Join(dir, marker)); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "" // reached root on this platform
+		}
+	}
 }
 
 func rotateFiles(dir string, maxFiles int) {

--- a/internal/tee/tee_test.go
+++ b/internal/tee/tee_test.go
@@ -94,6 +94,130 @@ func TestMaybeSaveEnvDisable(t *testing.T) {
 	}
 }
 
+func TestMaybeSaveProjectMarkerFound(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(repo, "a", "b")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(sub)
+
+	fallback := t.TempDir()
+	cfg := testConfig(fallback)
+	cfg.ProjectMarker = ".git"
+	raw := strings.Repeat("error output\n", 100)
+
+	hint := MaybeSave(raw, 1, "git push", cfg)
+	if hint == "" {
+		t.Fatal("expected hint, got empty")
+	}
+
+	teeDir := filepath.Join(repo, ".snip", "tee")
+	entries, err := os.ReadDir(teeDir)
+	if err != nil {
+		t.Fatalf("expected tee dir at %s: %v", teeDir, err)
+	}
+	logCount := 0
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".log") {
+			logCount++
+		}
+	}
+	if logCount != 1 {
+		t.Errorf("expected 1 log file in %s, got %d", teeDir, logCount)
+	}
+	if fbEntries, _ := os.ReadDir(fallback); len(fbEntries) != 0 {
+		t.Errorf("expected fallback dir empty, got %d files", len(fbEntries))
+	}
+
+	// A .gitignore must guard the project tee dir against git add -A.
+	gi, err := os.ReadFile(filepath.Join(teeDir, ".gitignore"))
+	if err != nil {
+		t.Fatalf("expected .gitignore in project tee dir: %v", err)
+	}
+	if string(gi) != "*\n" {
+		t.Errorf("unexpected .gitignore content: %q", string(gi))
+	}
+}
+
+func TestMaybeSaveProjectMarkerUnwritableFallsBack(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repo)
+
+	if err := os.Chmod(repo, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(repo, 0o755) })
+
+	fallback := t.TempDir()
+	cfg := testConfig(fallback)
+	cfg.ProjectMarker = ".git"
+	raw := strings.Repeat("error output\n", 100)
+
+	hint := MaybeSave(raw, 1, "git push", cfg)
+	if hint == "" {
+		t.Fatal("expected hint from fallback dir, got empty")
+	}
+
+	entries, _ := os.ReadDir(fallback)
+	if len(entries) != 1 {
+		t.Errorf("expected 1 file in fallback dir, got %d", len(entries))
+	}
+}
+
+func TestMaybeSaveProjectMarkerNotFound(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	fallback := t.TempDir()
+	cfg := testConfig(fallback)
+	cfg.ProjectMarker = ".snip-test-marker-does-not-exist"
+	raw := strings.Repeat("error output\n", 100)
+
+	hint := MaybeSave(raw, 1, "git push", cfg)
+	if hint == "" {
+		t.Fatal("expected hint, got empty")
+	}
+
+	entries, _ := os.ReadDir(fallback)
+	if len(entries) != 1 {
+		t.Errorf("expected 1 file in fallback dir, got %d", len(entries))
+	}
+}
+
+func TestMaybeSaveEnvDirOverridesProjectMarker(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repo)
+
+	envDir := t.TempDir()
+	t.Setenv("SNIP_TEE_DIR", envDir)
+
+	cfg := testConfig(t.TempDir())
+	cfg.ProjectMarker = ".git"
+	raw := strings.Repeat("error output\n", 100)
+
+	hint := MaybeSave(raw, 1, "git push", cfg)
+	if hint == "" {
+		t.Fatal("expected hint, got empty")
+	}
+
+	entries, _ := os.ReadDir(envDir)
+	if len(entries) != 1 {
+		t.Errorf("expected 1 file in SNIP_TEE_DIR, got %d", len(entries))
+	}
+	if _, err := os.Stat(filepath.Join(repo, ".snip")); !os.IsNotExist(err) {
+		t.Errorf("expected no .snip dir in repo when SNIP_TEE_DIR is set")
+	}
+}
+
 func TestRotateFiles(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
Closes #107

## What

New optional `tee.project_marker` config field:

```toml
[tee]
project_marker = ".git"
```

When set, tee walks upward from the working directory looking for that file or directory. If found in directory `D`, tee recovery logs are written to `D/.snip/tee/` instead of the global `~/.local/share/snip/tee`. This keeps logs inside the repo the agent operates on and matches the existing `.snip/` project convention (`.snip/config.toml`).

Unset (default) keeps the current behavior unchanged.

## Behavior details

- Priority: `SNIP_TEE_DIR` env > project marker walk-up > global dir
- A `.gitignore` containing `*` is dropped in the project tee directory so agent-driven `git add -A` never commits raw command output (which can contain env dumps or tokens)
- If the project directory is not writable (read-only checkout, root-owned repo like a Homebrew checkout), tee falls back to the global directory instead of silently losing the recovery log
- `snip config` now prints `tee.project_marker`

## Tests

- marker found: log lands in `<root>/.snip/tee/`, `.gitignore` present, global dir untouched
- marker not found: falls back to the global dir
- unwritable marker root (chmod 0555): falls back to the global dir, log preserved
- `SNIP_TEE_DIR` wins over the marker
- TOML parsing of the new field

Local CI: `golangci-lint run` 0 issues, `go test -race -cover ./...` green.