### PR TITLE
feat(config): add filters.override.<name>.compact_path to disable path compaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,9 @@ dir = "~/.config/snip/filters"
 [filters.enable]
 # git-diff = false       # disable a specific built-in filter
 
+[filters.override.rg]
+# compact_path = false   # keep full paths instead of stripping src/, internal/, ...
+
 [tee]
 enabled = true
 mode = "failures"    # "failures" | "always" | "never"
@@ -434,6 +437,40 @@ max_file_size = 1048576
                            # committed, and snip falls back to the global dir
                            # if the repo root is not writable
 ```
+
+### Tuning a Filter
+
+`[filters.override.<name>]` adjusts a single built-in filter without replacing
+its YAML file. Each key targets one pipeline stage:
+
+| Key | Effect |
+|---|---|
+| `head` | Set the `head` stage's line count |
+| `tail` | Set the `tail` stage's line count |
+| `truncate_lines` | Set the max line length |
+| `keep_lines` | Replace the keep pattern |
+| `remove_lines` | Replace the remove pattern |
+| `compact_path` | `false` removes the `compact_path` stage |
+| `stream_mode` | `"full"` skips the whole pipeline for this filter |
+
+```toml
+[filters.override.rg]
+compact_path = false     # paths stay as ripgrep printed them
+head = 200               # but keep the other savings
+
+[filters.override.tsc]
+compact_path = false     # diagnostics stay openable as file:line
+```
+
+Every key except `compact_path` and `stream_mode` is appended to the pipeline if
+the filter does not already declare that stage. `compact_path` is only ever
+removed, never added, because the stage takes no parameters.
+
+Use `compact_path = false` when the path in the output is meant to be opened or
+parsed — search results and compiler/linter diagnostics — since the stage strips
+a leading `src/`, `lib/`, `internal/`, `pkg/` or `vendor/` segment, and the
+result no longer resolves relative to the working directory. `stream_mode` and
+`[filters.enable]` also restore the paths, but at the cost of every other stage.
 
 ### Multiple Filter Directories
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,6 +66,11 @@ type FilterOverride struct {
 	KeepLines     string `toml:"keep_lines"`
 	RemoveLines   string `toml:"remove_lines"`
 	StreamMode    string `toml:"stream_mode"` // "full" = skip the entire pipeline
+	// CompactPath removes the compact_path stage when set to false. It is a
+	// pointer because the zero value of bool cannot distinguish "explicitly
+	// false" from "absent", and false is the only meaningful setting: the
+	// stage is already present in the filters that declare it.
+	CompactPath *bool `toml:"compact_path"`
 }
 
 // FilterBypassConfig contains commands that should always bypass filtering.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -320,6 +320,55 @@ project_marker = ".git"
 	}
 }
 
+// compact_path is a *bool so that "explicitly false" is distinguishable from
+// "absent". Both states must survive TOML decoding, since only the first one
+// removes the stage.
+func TestLoadOverrideCompactPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	content := `
+[filters.override.rg]
+compact_path = false
+
+[filters.override.tsc]
+compact_path = true
+
+[filters.override.eslint]
+head = 200
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("SNIP_CONFIG", path)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	rg := cfg.Filters.Override["rg"].CompactPath
+	if rg == nil {
+		t.Fatal("rg compact_path = nil, want explicit false")
+	}
+	if *rg {
+		t.Error("rg compact_path = true, want false")
+	}
+
+	tsc := cfg.Filters.Override["tsc"].CompactPath
+	if tsc == nil {
+		t.Fatal("tsc compact_path = nil, want explicit true")
+	}
+	if !*tsc {
+		t.Error("tsc compact_path = false, want true")
+	}
+
+	if cfg.Filters.Override["eslint"].CompactPath != nil {
+		t.Error("eslint compact_path should stay nil when the key is absent")
+	}
+}
+
 func TestLoadMergedNoProjectConfig(t *testing.T) {
 	// When no .snip/config.toml exists in the directory tree,
 	// LoadMerged should return the user config unchanged.

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -390,10 +390,23 @@ func ApplyPipeline(f *filter.Filter, input string) (string, error) {
 // passthrough). Otherwise, matching pipeline actions are updated with the
 // override values. Override targets not found in the existing pipeline are
 // appended as new actions (consistent with applyGlobalLimit's behavior).
+//
+// compact_path is the exception to that pattern: it takes no parameters, so it
+// is removed rather than reconfigured, and it is never appended.
 func applyOverride(f *filter.Filter, o *config.FilterOverride) {
 	if o.StreamMode == "full" {
 		f.Pipeline = nil
 		return
+	}
+	if o.CompactPath != nil && !*o.CompactPath {
+		kept := make(filter.Pipeline, 0, len(f.Pipeline))
+		for _, action := range f.Pipeline {
+			if action.ActionName == filter.ActionCompactPath {
+				continue
+			}
+			kept = append(kept, action)
+		}
+		f.Pipeline = kept
 	}
 	applied := map[string]bool{}
 	for i, action := range f.Pipeline {

--- a/internal/engine/pipeline_test.go
+++ b/internal/engine/pipeline_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -330,6 +331,150 @@ func TestApplyOverrideStreamModeFull(t *testing.T) {
 	if f.Pipeline != nil {
 		t.Errorf("pipeline should be nil after stream_mode=full, got %v", f.Pipeline)
 	}
+}
+
+func TestApplyOverrideCompactPathFalse(t *testing.T) {
+	f := filterForTest("test-filter",
+		filter.Pipeline{
+			{ActionName: "strip_ansi"},
+			{ActionName: "compact_path"},
+			{ActionName: "truncate_lines", Params: map[string]any{"max": 120}},
+		},
+	)
+
+	disabled := false
+	o := config.FilterOverride{CompactPath: &disabled}
+	applyOverride(&f, &o)
+
+	names := actionNames(f.Pipeline)
+	want := []string{"strip_ansi", "truncate_lines"}
+	if !reflect.DeepEqual(names, want) {
+		t.Errorf("pipeline = %v, want %v", names, want)
+	}
+}
+
+// The surrounding stages must keep working, so compact_path removal has to
+// compose with a parameter override applied in the same call.
+func TestApplyOverrideCompactPathFalseWithOtherOverrides(t *testing.T) {
+	f := filterForTest("test-filter",
+		filter.Pipeline{
+			{ActionName: "compact_path"},
+			{ActionName: "truncate_lines", Params: map[string]any{"max": 120}},
+			{ActionName: "head", Params: map[string]any{"n": 50}},
+		},
+	)
+
+	disabled := false
+	o := config.FilterOverride{CompactPath: &disabled, Head: 500}
+	applyOverride(&f, &o)
+
+	names := actionNames(f.Pipeline)
+	want := []string{"truncate_lines", "head"}
+	if !reflect.DeepEqual(names, want) {
+		t.Fatalf("pipeline = %v, want %v", names, want)
+	}
+	if f.Pipeline[1].Params["n"] != 500 {
+		t.Errorf("head n = %v, want 500", f.Pipeline[1].Params["n"])
+	}
+}
+
+// Absent and true must both leave the stage in place: absent is the default for
+// every existing config, and true is the stage's own default behavior.
+func TestApplyOverrideCompactPathKeptWhenNotDisabled(t *testing.T) {
+	enabled := true
+	for name, o := range map[string]config.FilterOverride{
+		"absent": {Head: 25},
+		"true":   {CompactPath: &enabled},
+	} {
+		t.Run(name, func(t *testing.T) {
+			f := filterForTest("test-filter",
+				filter.Pipeline{
+					{ActionName: "compact_path"},
+					{ActionName: "head", Params: map[string]any{"n": 10}},
+				},
+			)
+			applyOverride(&f, &o)
+
+			names := actionNames(f.Pipeline)
+			want := []string{"compact_path", "head"}
+			if !reflect.DeepEqual(names, want) {
+				t.Errorf("pipeline = %v, want %v", names, want)
+			}
+		})
+	}
+}
+
+// compact_path takes no parameters, so unlike head/tail/truncate_lines it must
+// never be appended to a filter that did not already declare it.
+func TestApplyOverrideCompactPathNeverAppended(t *testing.T) {
+	disabled := false
+	f := filterForTest("test-filter",
+		filter.Pipeline{
+			{ActionName: "head", Params: map[string]any{"n": 10}},
+		},
+	)
+
+	o := config.FilterOverride{CompactPath: &disabled}
+	applyOverride(&f, &o)
+
+	names := actionNames(f.Pipeline)
+	want := []string{"head"}
+	if !reflect.DeepEqual(names, want) {
+		t.Errorf("pipeline = %v, want %v", names, want)
+	}
+}
+
+// The structural tests above assert on the same action-name literal that
+// applyOverride filters on, so they would both survive a rename that desynced
+// it from the action registry. This one runs the real pipeline and checks the
+// observable effect: with the stage removed, paths must reach the caller
+// exactly as the underlying tool printed them.
+func TestApplyOverrideCompactPathFalseKeepsPathsIntact(t *testing.T) {
+	input := "internal/soak/report.go\nsrc/app/main.go\ncmd/tool/main.go\n"
+
+	pipeline := func() filter.Pipeline {
+		return filter.Pipeline{
+			{ActionName: "strip_ansi"},
+			{ActionName: filter.ActionCompactPath},
+			{ActionName: "head", Params: map[string]any{"n": 50}},
+		}
+	}
+
+	// Control: the stage is what corrupts the paths.
+	base := filterForTest("rg", pipeline())
+	before, err := ApplyPipeline(&base, input)
+	if err != nil {
+		t.Fatalf("ApplyPipeline: %v", err)
+	}
+	if strings.Contains(before, "internal/soak/report.go") {
+		t.Fatal("precondition failed: compact_path did not strip the prefix")
+	}
+	if !strings.Contains(before, "soak/report.go") {
+		t.Fatalf("precondition failed: unexpected output %q", before)
+	}
+
+	disabled := false
+	f := filterForTest("rg", pipeline())
+	o := config.FilterOverride{CompactPath: &disabled}
+	applyOverride(&f, &o)
+
+	after, err := ApplyPipeline(&f, input)
+	if err != nil {
+		t.Fatalf("ApplyPipeline: %v", err)
+	}
+	for _, want := range []string{"internal/soak/report.go", "src/app/main.go", "cmd/tool/main.go"} {
+		if !strings.Contains(after, want) {
+			t.Errorf("output missing %q, got %q", want, after)
+		}
+	}
+}
+
+func actionNames(p filter.Pipeline) []string {
+	names := make([]string, 0, len(p))
+	for _, a := range p {
+		names = append(names, a.ActionName)
+	}
+	return names
 }
 
 func TestApplyGlobalLimit(t *testing.T) {

--- a/internal/filter/actions.go
+++ b/internal/filter/actions.go
@@ -12,6 +12,11 @@ import (
 	"github.com/edouard-claude/snip/internal/utils"
 )
 
+// ActionCompactPath is the name of the path-compaction action. It is exported
+// because engine.applyOverride removes this stage by name, and a rename that
+// updated only the registry would silently turn that override into a no-op.
+const ActionCompactPath = "compact_path"
+
 // Registry of built-in actions.
 var actions = map[string]ActionFunc{
 	"keep_lines":      keepLines,
@@ -30,7 +35,7 @@ var actions = map[string]ActionFunc{
 	"state_machine":   stateMachine,
 	"aggregate":       aggregate,
 	"format_template": formatTemplate,
-	"compact_path":    compactPath,
+	ActionCompactPath: compactPath,
 	"replace":         replace,
 	"match_output":    matchOutput,
 	"on_empty":        onEmpty,


### PR DESCRIPTION
Implements option (3) from #115: a `compact_path = false` key on `FilterOverride`,
so the stage can be dropped without discarding the rest of the pipeline.

**This is the escape hatch, not the fix.** It does nothing for users who never
read #115 — the 28 bundled filters still compact by default, and a path that
`ENOENT`s is still the out-of-the-box behavior for `rg`, `tsc`, `gcc`, `eslint`
and the rest. Option (1) (dropping the stage from path-bearing filters) is the
change that actually repairs the default, and it stays available on top of this
one; the two compose rather than compete. I picked (3) because it is small,
additive, and cannot regress anyone's savings — not because it is sufficient.
Marked `Refs #115` rather than `Fixes` for that reason: merging this should not
close the issue.

Happy to follow with the YAML-only (1) if you want it, or to drop this entirely
if you'd rather go straight there.

## What changed

```toml
[filters.override.rg]
compact_path = false     # paths stay as ripgrep printed them
head = 200               # but keep the other savings
```

- `FilterOverride.CompactPath` is a `*bool`. The zero value of `bool` cannot
  distinguish "explicitly false" from "absent", and only the former may remove
  the stage. `true` and absent both leave the pipeline untouched.
- **`compact_path` is deliberately the exception to `applyOverride`'s append
  behavior.** Every other key names a stage that carries parameters, so appending
  a missing one is meaningful. `compact_path` takes none — appending it to a
  filter that never declared it would silently *add* compaction where there was
  none, which is the opposite of what the key is for. It is therefore only ever
  removed.
- The action name is now the exported constant `filter.ActionCompactPath`, used
  both as the registry key in `actions.go` and by `applyOverride`'s filter. Before
  this, engine and registry agreed only by duplicated string literal, so a rename
  touching one would have turned the override into a silent no-op.

## Tests

Six new tests. Five are structural (removal, composition with a `head` override
in the same call, `true`/absent both preserving the stage, never-appended) and one
is behavioral — `TestApplyOverrideCompactPathFalseKeepsPathsIntact` runs the real
`ApplyPipeline` and asserts `internal/soak/report.go` survives intact, with a
control leg proving the stage is what corrupts it.

That behavioral test exists because the structural ones assert on the same literal
`applyOverride` filters on, so they would all pass a rename that desynced engine
from registry. I verified the set is not vacuous by replacing the guard with
`if false {` — three tests fail, including the behavioral one — then restoring.

`make test` and `go vet ./...` green. No new dependencies.

## Docs

New **Tuning a Filter** section in the README with the full override-key table.
That table also documents an existing behavior that was previously undescribed:
`head`, `tail`, `truncate_lines`, `keep_lines` and `remove_lines` are *appended*
when the filter does not already declare them, while `compact_path` and
`stream_mode` are not.

One thing I left alone, flagging rather than fixing: project-mode `LoadMerged`
replaces an entire `[filters.override.<name>]` block rather than merging
field-by-field, so `head` in user config plus `compact_path` in project config
loses the `head`. That predates this PR, and documenting it properly means
introducing `.snip.toml` / project mode in the README, which it currently does not
cover at all. Separate change if you want it.

---

**Disclosure:** this PR was written by an AI agent (Claude Code). Tests were
executed and mutation-checked on this branch, and the diff was reviewed against
`master` @ `560990f` before filing. A human reviewed it before submission. If it's
unwanted, close it and I won't re-file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
