### PR TITLE
fix(filters): drop compact_path from all 28 bundled filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,10 +388,16 @@ Run `snip discover` to see which of your commands already have filters.
 | `state_machine` | Multi-state line processing |
 | `aggregate` | Count pattern matches |
 | `format_template` | Go template formatting |
-| `compact_path` | Shorten file paths |
+| `compact_path` | Shorten file paths (see caveat below) |
 | `replace` | Regex find and replace |
 | `match_output` | Conditional short-circuit (return message if pattern matches) |
 | `on_empty` | Return message if output is empty |
+
+> **`compact_path` emits paths that may not resolve.** It strips a leading
+> `src/`, `lib/`, `internal/`, `pkg/` or `vendor/` segment unconditionally and
+> with no marker, so `internal/soak/report.go` becomes `soak/report.go` — which
+> `ENOENT`s from the directory the command ran in. No bundled filter uses it.
+> Reach for it only when the path is display-only and will never be opened.
 
 ### Custom Filters
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -73,7 +73,7 @@ on_error: "passthrough"          # What to do if the pipeline fails: "passthroug
 |--------|--------|-------------|
 | `truncate_lines` | `max` (int, default 80), `ellipsis` (string, default "...") | Truncate long lines |
 | `strip_ansi` | (none) | Remove ANSI escape codes |
-| `compact_path` | (none) | Remove directory prefixes from file paths |
+| `compact_path` | (none) | Strips a leading `src/`/`lib/`/`internal/`/`pkg/`/`vendor/` segment. The result may not resolve from the cwd, and carries no marker saying so — no bundled filter uses it. Display-only paths only. |
 
 ### Extraction & Grouping
 

--- a/filters/basedpyright.yaml
+++ b/filters/basedpyright.yaml
@@ -1,5 +1,5 @@
 name: "basedpyright"
-version: 1
+version: 2
 description: "Condensed basedpyright output: type errors"
 
 match:
@@ -16,7 +16,6 @@ pipeline:
     pattern: "^\\s*$"
   - action: "keep_lines"
     pattern: "(error|warning|information|\\d+ errors?|\\d+ warnings?|\\d+ information)"
-  - action: "compact_path"
   - action: "truncate_lines"
     max: 120
   - action: "head"

--- a/filters/biome.yaml
+++ b/filters/biome.yaml
@@ -1,5 +1,5 @@
 name: "biome"
-version: 1
+version: 2
 description: "Condensed biome output: lint/format diagnostics"
 
 match:
@@ -16,7 +16,6 @@ pipeline:
     pattern: "^(\\s*$|\\s+\\d+ \\|)"
   - action: "keep_lines"
     pattern: "(error|warning|Fixed|Checked|diagnostics|invalid|\\u2716|\\u2714)"
-  - action: "compact_path"
   - action: "truncate_lines"
     max: 120
   - action: "head"

--- a/filters/dotnet-build.yaml
+++ b/filters/dotnet-build.yaml
@@ -1,5 +1,5 @@
 name: "dotnet-build"
-version: 1
+version: 2
 description: "Condensed dotnet build: errors and build result"
 
 match:
@@ -16,7 +16,6 @@ pipeline:
     pattern: "^\\s*(Determining|Restored|Nothing to do|\\s*$)"
   - action: "keep_lines"
     pattern: "(error |warning |Build succeeded|Build FAILED|\\d+ Error|\\d+ Warning|Time Elapsed)"
-  - action: "compact_path"
   - action: "truncate_lines"
     max: 120
   - action: "head"

--- a/filters/dotnet-format.yaml
+++ b/filters/dotnet-format.yaml
@@ -1,5 +1,5 @@
 name: "dotnet-format"
-version: 1
+version: 2
 description: "Condensed dotnet format: formatting issues"
 
 match:
@@ -14,7 +14,6 @@ pipeline:
   - action: "strip_ansi"
   - action: "remove_lines"
     pattern: "^\\s*$"
-  - action: "compact_path"
   - action: "truncate_lines"
     max: 120
   - action: "head"

--- a/filters/eslint.yaml
+++ b/filters/eslint.yaml
@@ -1,5 +1,5 @@
 name: "eslint"
-version: 3
+version: 4
 description: "Condensed eslint output: file errors and summary"
 
 match:
@@ -21,8 +21,6 @@ pipeline:
   # Keep file paths (start with /), error/warning lines (indented line:col), and summary
   - action: "keep_lines"
     pattern: "(^/|^\\s+\\d+:\\d+|problems?|\\d+ errors?|\\d+ warnings?)"
-  # Compact paths in file header lines
-  - action: "compact_path"
   - action: "truncate_lines"
     max: 120
   - action: "head"

--- a/filters/find.yaml
+++ b/filters/find.yaml
@@ -1,12 +1,11 @@
 name: "find"
-version: 1
-description: "Condensed find output: compacts paths and truncates"
+version: 2
+description: "Condensed find output: truncates long paths and limits results"
 
 match:
   command: "find"
 
 pipeline:
-  - action: "compact_path"
   - action: "truncate_lines"
     max: 100
   - action: "head"

--- a/filters/g++.yaml
+++ b/filters/g++.yaml
@@ -1,5 +1,5 @@
 name: "g++"
-version: 1
+version: 2
 description: "Condensed g++ output: errors and warnings"
 
 match:
@@ -14,7 +14,6 @@ pipeline:
   - action: "strip_ansi"
   - action: "keep_lines"
     pattern: "(error:|warning:|note:|fatal error|undefined reference|linker|ld:|In function)"
-  - action: "compact_path"
   - action: "truncate_lines"
     max: 120
   - action: "head"

--- a/filters/gcc.yaml
+++ b/filters/gcc.yaml
@@ -1,5 +1,5 @@
 name: "gcc"
-version: 1
+version: 2
 description: "Condensed gcc/g++ output: errors and warnings"
 
 match:
@@ -14,7 +14,6 @@ pipeline:
   - action: "strip_ansi"
   - action: "keep_lines"
     pattern: "(error:|warning:|note:|fatal error|undefined reference|linker|ld:|In function)"
-  - action: "compact_path"
   - action: "truncate_lines"
     max: 120
   - action: "head"

--- a/filters/go-vet.yaml
+++ b/filters/go-vet.yaml
@@ -1,5 +1,5 @@
 name: "go-vet"
-version: 1
+version: 2
 description: "Condensed go vet: issues by file"
 
 match:
@@ -14,7 +14,6 @@ pipeline:
   - action: "strip_ansi"
   - action: "remove_lines"
     pattern: "^#\\s"
-  - action: "compact_path"
   - action: "truncate_lines"
     max: 120
   - action: "head"

--- a/filters/golangci-lint.yaml
+++ b/filters/golangci-lint.yaml
@@ -1,5 +1,5 @@
 name: "golangci-lint"
-version: 1
+version: 2
 description: "Condensed golangci-lint: issues grouped by file"
 
 match:
@@ -13,7 +13,6 @@ pipeline:
   - action: "strip_ansi"
   - action: "remove_lines"
     pattern: "^(level=|WARN|INFO|DEBUG)"
-  - action: "compact_path"
   - action: "truncate_lines"
     max: 120
   - action: "head"

--- a/filters/grep.yaml
+++ b/filters/grep.yaml
@@ -1,13 +1,12 @@
 name: "grep"
-version: 1
-description: "Condensed grep output: compacts paths and limits results"
+version: 2
+description: "Condensed grep output: limits results"
 
 match:
   command: "grep"
 
 pipeline:
   - action: "strip_ansi"
-  - action: "compact_path"
   - action: "truncate_lines"
     max: 120
   - action: "head"

--- a/filters/ls.yaml
+++ b/filters/ls.yaml
@@ -1,5 +1,5 @@
 name: "ls"
-version: 2
+version: 3
 description: "Compact ls output: reformats long listings to date+name+size, removes noise, extension summary"
 
 match:
@@ -19,7 +19,6 @@ pipeline:
   - action: "replace"
     pattern: "^\\S+\\s+\\d+\\s+.*\\s(\\d\\S*)\\s+(\\S+\\s+\\S+\\s+[\\d:]{4,5})\\s+(.+)$"
     replacement: "$2  $3  $1"
-  - action: "compact_path"
   - action: "truncate_lines"
     max: 120
   - action: "head"

--- a/filters/markdownlint-cli2.yaml
+++ b/filters/markdownlint-cli2.yaml
@@ -1,5 +1,5 @@
 name: "markdownlint-cli2"
-version: 1
+version: 2
 description: "Condensed markdownlint-cli2 output: issues by file"
 
 match:
@@ -11,7 +11,6 @@ streams:
 
 pipeline:
   - action: "strip_ansi"
-  - action: "compact_path"
   - action: "remove_lines"
     pattern: "^markdownlint-cli2 v"
   - action: "remove_lines"

--- a/filters/markdownlint.yaml
+++ b/filters/markdownlint.yaml
@@ -1,5 +1,5 @@
 name: "markdownlint"
-version: 1
+version: 2
 description: "Condensed markdownlint output: issues by file"
 
 match:
@@ -11,7 +11,6 @@ streams:
 
 pipeline:
   - action: "strip_ansi"
-  - action: "compact_path"
   - action: "truncate_lines"
     max: 120
   - action: "head"

--- a/filters/mix-compile.yaml
+++ b/filters/mix-compile.yaml
@@ -1,5 +1,5 @@
 name: "mix-compile"
-version: 1
+version: 2
 description: "Condensed mix compile output: errors and warnings"
 
 match:
@@ -16,7 +16,6 @@ pipeline:
     pattern: "(^Compiling \\d+ file|^Generated |^\\s*$)"
   - action: "keep_lines"
     pattern: "(error|warning|\\*\\* )"
-  - action: "compact_path"
   - action: "truncate_lines"
     max: 120
   - action: "head"

--- a/filters/mix-format.yaml
+++ b/filters/mix-format.yaml
@@ -1,5 +1,5 @@
 name: "mix-format"
-version: 1
+version: 2
 description: "Condensed mix format output"
 
 match:
@@ -14,7 +14,6 @@ pipeline:
   - action: "strip_ansi"
   - action: "remove_lines"
     pattern: "^\\s*$"
-  - action: "compact_path"
   - action: "truncate_lines"
     max: 120
   - action: "head"

--- a/filters/mypy.yaml
+++ b/filters/mypy.yaml
@@ -1,5 +1,5 @@
 name: "mypy"
-version: 1
+version: 2
 description: "Condensed mypy output: type errors by file"
 
 match:
@@ -13,7 +13,6 @@ pipeline:
   - action: "strip_ansi"
   - action: "remove_lines"
     pattern: "^\\s*$"
-  - action: "compact_path"
   - action: "truncate_lines"
     max: 120
   - action: "head"

--- a/filters/oxlint.yaml
+++ b/filters/oxlint.yaml
@@ -1,5 +1,5 @@
 name: "oxlint"
-version: 1
+version: 2
 description: "Condensed oxlint output: lint issues"
 
 match:
@@ -16,7 +16,6 @@ pipeline:
     pattern: "(^\\s*\\d+ \\||^\\s*$)"
   - action: "keep_lines"
     pattern: "(error|warning|help:|\\d+ problems?|\\d+ errors?|\\d+ warnings?|\\u2716|\\u00d7)"
-  - action: "compact_path"
   - action: "truncate_lines"
     max: 120
   - action: "head"

--- a/filters/prettier.yaml
+++ b/filters/prettier.yaml
@@ -1,5 +1,5 @@
 name: "prettier"
-version: 1
+version: 2
 description: "Condensed prettier output: formatting issues"
 
 match:
@@ -13,7 +13,6 @@ pipeline:
   - action: "strip_ansi"
   - action: "remove_lines"
     pattern: "^\\s*$"
-  - action: "compact_path"
   - action: "truncate_lines"
     max: 120
   - action: "head"

--- a/filters/pytest.yaml
+++ b/filters/pytest.yaml
@@ -1,5 +1,5 @@
 name: "pytest"
-version: 3
+version: 4
 description: "Condensed pytest output: failures with locations and summary line"
 
 match:
@@ -35,8 +35,6 @@ pipeline:
   - action: "replace"
     pattern: "^=+ | =+$"
     replacement: ""
-  # Shorten paths
-  - action: "compact_path"
   - action: "truncate_lines"
     max: 120
   - action: "head"

--- a/filters/rg.yaml
+++ b/filters/rg.yaml
@@ -1,13 +1,12 @@
 name: "rg"
-version: 1
-description: "Condensed ripgrep output: compacts paths and limits results"
+version: 2
+description: "Condensed ripgrep output: limits results"
 
 match:
   command: "rg"
 
 pipeline:
   - action: "strip_ansi"
-  - action: "compact_path"
   - action: "truncate_lines"
     max: 120
   - action: "head"

--- a/filters/rubocop.yaml
+++ b/filters/rubocop.yaml
@@ -1,5 +1,5 @@
 name: "rubocop"
-version: 1
+version: 2
 description: "Condensed rubocop output: offenses by file"
 
 match:
@@ -16,7 +16,6 @@ pipeline:
     pattern: "(^Inspecting|^\\.+$|^\\s*$)"
   - action: "keep_lines"
     pattern: "(^[A-Z]:|offenses? detected|no offenses|files? inspected|error|warning|convention)"
-  - action: "compact_path"
   - action: "truncate_lines"
     max: 120
   - action: "head"

--- a/filters/ruff.yaml
+++ b/filters/ruff.yaml
@@ -1,5 +1,5 @@
 name: "ruff"
-version: 1
+version: 2
 description: "Condensed ruff output: lint issues by file"
 
 match:
@@ -13,7 +13,6 @@ pipeline:
   - action: "strip_ansi"
   - action: "remove_lines"
     pattern: "^\\s*$"
-  - action: "compact_path"
   - action: "truncate_lines"
     max: 120
   - action: "head"

--- a/filters/shellcheck.yaml
+++ b/filters/shellcheck.yaml
@@ -1,5 +1,5 @@
 name: "shellcheck"
-version: 1
+version: 2
 description: "Condensed shellcheck output: warnings by file"
 
 match:
@@ -16,7 +16,6 @@ pipeline:
     pattern: "(^\\s*\\^--|^\\s*$)"
   - action: "keep_lines"
     pattern: "(^In |SC\\d+|error|warning|note|info|^\\s+\\d+)"
-  - action: "compact_path"
   - action: "truncate_lines"
     max: 120
   - action: "head"

--- a/filters/swift-build.yaml
+++ b/filters/swift-build.yaml
@@ -1,5 +1,5 @@
 name: "swift-build"
-version: 1
+version: 2
 description: "Condensed swift build output: errors and warnings"
 
 match:
@@ -16,7 +16,6 @@ pipeline:
     pattern: "(^Compiling |^Linking |^Build complete|^Fetching |^\\s*$)"
   - action: "keep_lines"
     pattern: "(error:|warning:|Build complete|Build FAILED|note:|compile error)"
-  - action: "compact_path"
   - action: "truncate_lines"
     max: 120
   - action: "head"

--- a/filters/tsc.yaml
+++ b/filters/tsc.yaml
@@ -1,5 +1,5 @@
 name: "tsc"
-version: 3
+version: 4
 description: "Condensed tsc output: type errors and summary"
 
 match:
@@ -24,7 +24,6 @@ pipeline:
   # Keep error lines and summary
   - action: "keep_lines"
     pattern: "(error TS\\d+|warning TS\\d+|Found \\d+ error)"
-  - action: "compact_path"
   - action: "truncate_lines"
     max: 120
   - action: "head"
@@ -55,8 +54,8 @@ tests:
 
       Found 2 errors in 2 files.
     expected: |
-      index.ts:3:1 - error TS2304: Cannot find name 'foo'.
-      utils.ts:10:5 - error TS2322: Type 'string' is not assignable to type 'number'.
+      src/index.ts:3:1 - error TS2304: Cannot find name 'foo'.
+      src/utils.ts:10:5 - error TS2322: Type 'string' is not assignable to type 'number'.
       Found 2 errors in 2 files.
   - name: "classic format errors"
     input: |
@@ -64,6 +63,6 @@ tests:
       src/utils.ts(10,5): error TS2322: Type 'string' is not assignable to type 'number'.
       Found 2 errors in 2 files.
     expected: |
-      index.ts(3,1): error TS2304: Cannot find name 'foo'.
-      utils.ts(10,5): error TS2322: Type 'string' is not assignable to type 'number'.
+      src/index.ts(3,1): error TS2304: Cannot find name 'foo'.
+      src/utils.ts(10,5): error TS2322: Type 'string' is not assignable to type 'number'.
       Found 2 errors in 2 files.

--- a/filters/ty.yaml
+++ b/filters/ty.yaml
@@ -1,5 +1,5 @@
 name: "ty"
-version: 1
+version: 2
 description: "Condensed ty (Python type checker) output"
 
 match:
@@ -13,7 +13,6 @@ pipeline:
   - action: "strip_ansi"
   - action: "remove_lines"
     pattern: "^\\s*$"
-  - action: "compact_path"
   - action: "truncate_lines"
     max: 120
   - action: "head"

--- a/filters/yamllint.yaml
+++ b/filters/yamllint.yaml
@@ -1,5 +1,5 @@
 name: "yamllint"
-version: 1
+version: 2
 description: "Condensed yamllint output: issues by file"
 
 match:
@@ -11,7 +11,6 @@ streams:
 
 pipeline:
   - action: "strip_ansi"
-  - action: "compact_path"
   - action: "truncate_lines"
     max: 120
   - action: "head"

--- a/internal/engine/summary_test.go
+++ b/internal/engine/summary_test.go
@@ -23,10 +23,10 @@ func TestBuildSummaryLineInjectionOnly(t *testing.T) {
 func TestBuildSummaryLinePipelineOnly(t *testing.T) {
 	got := BuildSummaryLine(SummaryInfo{
 		FilterName:    "find",
-		FilterVersion: 1,
-		PipelineNames: []string{"compact_path", "head"},
+		FilterVersion: 2,
+		PipelineNames: []string{"truncate_lines", "head"},
 	})
-	want := "[snip: find v1 | compact_path>head]"
+	want := "[snip: find v2 | truncate_lines>head]"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}


### PR DESCRIPTION
This is option (1) from #115: drop `compact_path` from every bundled filter that declares it.

## Why

`compact_path` strips a leading `src/`, `lib/`, `internal/`, `pkg/` or `vendor/` segment unconditionally and emits no marker, so `internal/soak/report.go` comes out as `soak/report.go` — a path that `ENOENT`s from the directory the command ran in. A consumer cannot tell a compacted path from a real one.

Every filter that declared the stage is one whose output is a path a human or an agent is expected to open:

| group | filters |
|---|---|
| search | `rg`, `grep`, `find`, `ls` |
| diagnostics | `gcc`, `g++`, `tsc`, `eslint`, `oxlint`, `biome`, `go-vet`, `golangci-lint`, `shellcheck`, `yamllint`, `markdownlint`, `markdownlint-cli2`, `mypy`, `basedpyright`, `ruff`, `ty`, `rubocop`, `pytest`, `swift-build`, `dotnet-build`, `mix-compile` |
| formatters | `prettier`, `dotnet-format`, `mix-format` |

For diagnostics the `file:line` **is** the actionable payload, so rewriting it to a nonexistent file breaks the read-error → open-file → fix loop, and any editor or CI integration that parses `file:line:col`.

## What it costs

Measured on `rg --files` over this repo with a clean `HOME` and the bundled filter: **83.0% saved before, 79.3% after** — 3.6 percentage points. `strip_ansi`, `truncate_lines` and `head` carry essentially all of the compression. Compaction was buying ~9 characters per line in exchange for a wrong answer.

## Safety of the removal

In every one of the 28 filters the stage sat *after* all `keep_lines`/`remove_lines` patterns and *before* `truncate_lines`/`head`, and no downstream pattern matches on a path — so removal changes nothing but the paths themselves.

`tsc`'s two inline tests asserted the **compacted** form as expected output; they encoded the defect as correct behavior and are updated to expect the real paths. The other four filters with inline tests (`eslint`, `ls`, `markdownlint-cli2`, `pytest`) use fixtures with no strippable leading prefix and were already unaffected. `snip verify` is green.

Filter `version:` bumped in each, since it is user-visible in the summary line (`internal/engine/pipeline.go:175`).

Two comments describing the removed stage (eslint's *"Compact paths in file header lines"*, pytest's *"Shorten paths"*) would otherwise have been left sitting above the following `truncate_lines`, mislabelling it; both are dropped. The `rg`, `grep` and `find` `description:` strings advertised path compaction and are corrected — `description` is not read by behavior code, but it is the first thing a filter author reads.

One Go test fixture went stale as a consequence: `TestBuildSummaryLinePipelineOnly` built its `SummaryInfo` from the `find` filter as it was (`v1`, `compact_path>head`). It's synthetic and passed regardless, but every other fixture in that file is drawn from a real filter, so it's retargeted at `find` as it now ships.

## What is kept

The `compact_path` action itself stays, for user filters that genuinely want display-only paths. The caveat is now documented in `README.md` and `SKILL.md`, including the fact that no bundled filter uses it.

## Relation to #116

#116 adds a per-filter `compact_path = false` config override. That is an escape hatch for a defect that shouldn't be on by default; this PR fixes the default. They don't conflict textually — the two touch disjoint Go files, and the `README.md` hunks are ~17 lines apart — and the override remains useful for user filters. If you'd rather take only one, take this one.

---

`make test`, `go vet ./...` and `snip verify` all pass.

Note: `CLAUDE.md` asks that filter changes be mirrored into the GitHub wiki. I don't have push access to `snip.wiki`, so that part is not done here.

Fixes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)
