### PR TITLE
fix(filter): mark dropped output in tail and truncate_bytes

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -64,7 +64,7 @@ on_error: "passthrough"          # What to do if the pipeline fails: "passthroug
 | `keep_lines` | `pattern` (regex) | Keep only lines matching the pattern |
 | `remove_lines` | `pattern` (regex) | Remove lines matching the pattern |
 | `head` | `n` (int, default 10), `overflow_msg` (string, default "+{remaining} more lines") | Keep first N lines |
-| `tail` | `n` (int, default 10) | Keep last N lines |
+| `tail` | `n` (int, default 10), `overflow_msg` (string, default "+{dropped} earlier lines") | Keep last N lines |
 | `dedup` | `normalize` ([]string of regexes to strip before comparing), `top` (int, 0=all) | Deduplicate lines, output "text (xN)" for repeats |
 
 ### Line Transformation

--- a/internal/filter/actions.go
+++ b/internal/filter/actions.go
@@ -157,7 +157,12 @@ func truncateBytes(input ActionResult, params map[string]any) (ActionResult, err
 	for cut > 0 && !utf8.RuneStart(joined[cut]) {
 		cut--
 	}
-	input.Lines = strings.Split(joined[:cut], "\n")
+	msg := getStr(params, "overflow_msg")
+	if msg == "" {
+		msg = fmt.Sprintf("... truncated at %d bytes", max)
+	}
+	// Split allocates a fresh slice, so the append never aliases input.Lines.
+	input.Lines = append(strings.Split(joined[:cut], "\n"), msg)
 	return input, nil
 }
 
@@ -190,9 +195,14 @@ func tail(input ActionResult, params map[string]any) (ActionResult, error) {
 	if len(input.Lines) <= n {
 		return input, nil
 	}
-	start := len(input.Lines) - n
-	out := make([]string, n)
-	copy(out, input.Lines[start:])
+	dropped := len(input.Lines) - n
+	msg := getStr(params, "overflow_msg")
+	if msg == "" {
+		msg = fmt.Sprintf("+%d earlier lines", dropped)
+	}
+	out := make([]string, 0, n+1)
+	out = append(out, msg)
+	out = append(out, input.Lines[dropped:]...)
 	return ActionResult{Lines: out, Metadata: input.Metadata}, nil
 }
 

--- a/internal/filter/actions_test.go
+++ b/internal/filter/actions_test.go
@@ -75,8 +75,8 @@ func TestTruncateBytesUTF8Boundary(t *testing.T) {
 	if !utf8.ValidString(out) {
 		t.Errorf("truncated output is not valid UTF-8: %q (% x)", out, out)
 	}
-	if out != "h" {
-		t.Errorf("got %q, want %q", out, "h")
+	if res.Lines[0] != "h" {
+		t.Errorf("got %q, want %q", res.Lines[0], "h")
 	}
 }
 
@@ -102,8 +102,42 @@ func TestTruncateBytesEmoji(t *testing.T) {
 	if !utf8.ValidString(out) {
 		t.Errorf("truncated output is not valid UTF-8: %q (% x)", out, out)
 	}
-	if out != "ab" {
-		t.Errorf("got %q, want %q", out, "ab")
+	if res.Lines[0] != "ab" {
+		t.Errorf("got %q, want %q", res.Lines[0], "ab")
+	}
+}
+
+func TestTruncateBytesMarker(t *testing.T) {
+	original := []string{"aaaaaaaaaa", "bbbbbbbbbb"}
+	input := ActionResult{Lines: original, Metadata: nil}
+	res, err := truncateBytes(input, map[string]any{"max": 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The kept bytes come first, the marker last.
+	want := []string{"aaaaa", "... truncated at 5 bytes"}
+	if len(res.Lines) != len(want) {
+		t.Fatalf("got %v, want %v", res.Lines, want)
+	}
+	for i := range want {
+		if res.Lines[i] != want[i] {
+			t.Errorf("line %d = %q, want %q", i, res.Lines[i], want[i])
+		}
+	}
+	// Appending the marker must not write into the caller's backing array.
+	if original[1] != "bbbbbbbbbb" {
+		t.Errorf("input slice mutated: %v", original)
+	}
+}
+
+func TestTruncateBytesCustomOverflowMsg(t *testing.T) {
+	input := lines("aaaaaaaaaa", "bbbbbbbbbb")
+	res, err := truncateBytes(input, map[string]any{"max": 5, "overflow_msg": "[cut]"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Lines[len(res.Lines)-1] != "[cut]" {
+		t.Errorf("custom overflow msg: %v", res.Lines)
 	}
 }
 
@@ -150,11 +184,37 @@ func TestTail(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(res.Lines) != 2 {
-		t.Errorf("got %d lines, want 2", len(res.Lines))
+	// overflow message + 2 lines
+	if len(res.Lines) != 3 {
+		t.Errorf("got %d lines, want 3", len(res.Lines))
 	}
-	if res.Lines[0] != "4" || res.Lines[1] != "5" {
+	if !strings.Contains(res.Lines[0], "+3 earlier") {
+		t.Errorf("overflow msg: %q", res.Lines[0])
+	}
+	if res.Lines[1] != "4" || res.Lines[2] != "5" {
 		t.Errorf("got %v", res.Lines)
+	}
+}
+
+func TestTailNoOverflow(t *testing.T) {
+	input := lines("1", "2", "3")
+	res, err := tail(input, map[string]any{"n": 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Lines) != 3 {
+		t.Errorf("got %d lines, want 3", len(res.Lines))
+	}
+}
+
+func TestTailCustomOverflowMsg(t *testing.T) {
+	input := lines("1", "2", "3", "4", "5")
+	res, err := tail(input, map[string]any{"n": 2, "overflow_msg": "[...]"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Lines[0] != "[...]" {
+		t.Errorf("custom overflow msg: %q", res.Lines[0])
 	}
 }
 


### PR DESCRIPTION
Fixes #118.

`head` and `truncate_lines` both announce what they removed. `tail` and `truncate_bytes` dropped content silently, so the consumer of the filtered text had no way to tell a partial result from a complete one. `truncate_bytes` is the worse of the two: it joins on `"\n"`, slices at a rune boundary, then re-splits, so the last element is a fragment that reads as a whole line.

`tail` now prepends `+N earlier lines` and `truncate_bytes` appends `... truncated at N bytes`. Both accept an `overflow_msg` param, reusing the name `head` already has.

## One deliberate deviation from the issue

The issue suggested letting a filter opt out of the marker by setting an empty `overflow_msg`. This PR does not do that. An empty value falls back to the default message, which is exactly how `head` behaves today. Making `tail` and `truncate_bytes` treat empty as "stay silent" would give the same param two different meanings across three actions. If silent truncation is worth supporting, a separate opt-out that also covers `head` seems like the better shape, and it is easy to add later.

## Blast radius

No bundled filter uses either action. They are reachable through the `max_output_bytes` global limit, the `tail` project override in `applyOverride`, and user-written filters, so nothing that ships changes shape. `snip verify` passes unchanged: 132 filters, 37 tests, 0 failed.

`SKILL.md` documented `overflow_msg` on the `head` row and listed only `n` for `tail`, so that row is updated to match.

## Tests

`TestTail` and the two UTF-8 boundary tests are updated for the new shape. New: `TestTruncateBytesMarker` (pins the kept bytes, the marker, and that appending the marker does not write into the caller's backing array), `TestTruncateBytesCustomOverflowMsg`, `TestTailNoOverflow`, `TestTailCustomOverflowMsg`.

## Merges cleanly alongside the other two

This is one of three separate PRs for #118, #119 and #120. All three were test-merged in every ordering, and each of the six orders produces an identical tree, so they can land in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
