### PR TITLE
fix(engine): do not re-run a command whose wait bookkeeping failed

### DIFF
--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -64,6 +64,11 @@ func makeCommand(command string, args []string) *exec.Cmd {
 }
 
 // Execute runs a command, capturing stdout and stderr concurrently via goroutines.
+//
+// A nil *Result means the command never ran. When the returned *Result is
+// non-nil the command did run, even if err is also non-nil: err then reports a
+// failure in the wait bookkeeping rather than in the command itself. Callers
+// must decide whether re-running is safe from the *Result rather than from err.
 func Execute(command string, args []string) (*Result, error) {
 	start := time.Now()
 
@@ -101,12 +106,17 @@ func Execute(command string, args []string) (*Result, error) {
 	wg.Wait()
 
 	exitCode := 0
+	var waitErr error
 	err = cmd.Wait()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			exitCode = exitErr.ExitCode()
 		} else {
-			return nil, fmt.Errorf("wait command: %w", err)
+			// The command ran to completion; only the wait bookkeeping failed.
+			// Report the error, but still return the Result so the caller does
+			// not re-run a command whose side effects have already happened.
+			// The exit status went missing with the bookkeeping, so it stays 0.
+			waitErr = fmt.Errorf("wait command: %w", err)
 		}
 	}
 
@@ -115,7 +125,7 @@ func Execute(command string, args []string) (*Result, error) {
 		Stderr:   stderrBuf.String(),
 		ExitCode: exitCode,
 		Duration: time.Since(start),
-	}, nil
+	}, waitErr
 }
 
 // Passthrough runs a command with inherited stdio (no capture).

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -55,6 +55,37 @@ func TestExecuteNotFound(t *testing.T) {
 	}
 }
 
+// A nil *Result is how Execute signals "the command never ran". An error does
+// not carry that meaning, since it can also mean the command ran to completion
+// and only the wait bookkeeping failed. Callers decide from the Result whether
+// re-running is safe, so this invariant has to hold.
+func TestExecuteNilResultOnlyWhenNeverStarted(t *testing.T) {
+	result, err := Execute("nonexistent-command-xyz", nil)
+	if err == nil {
+		t.Fatal("expected error for nonexistent command")
+	}
+	if result != nil {
+		t.Errorf("result must be nil when the command never started, got %+v", result)
+	}
+
+	if runtime.GOOS == "windows" {
+		t.Skip("skip on windows")
+	}
+	result, err = Execute("sh", []string{"-c", "echo out; echo err >&2; exit 3"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("result must be non-nil for a command that ran")
+	}
+	if result.ExitCode != 3 {
+		t.Errorf("exit code = %d, want 3", result.ExitCode)
+	}
+	if strings.TrimSpace(result.Stdout) != "out" || strings.TrimSpace(result.Stderr) != "err" {
+		t.Errorf("output not captured: stdout=%q stderr=%q", result.Stdout, result.Stderr)
+	}
+}
+
 func TestPassthrough(t *testing.T) {
 	code, err := Passthrough("echo", []string{"test"})
 	if err != nil {

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -118,13 +118,24 @@ func (p *Pipeline) Run(command string, args []string) int {
 
 	// Execute command
 	result, err := Execute(command, finalArgs)
-	if err != nil {
-		// Execution failed entirely — fallback to passthrough
+	if result == nil {
+		// The command never ran, so fall back to passthrough. A non-nil result
+		// with a non-nil err means it did run, and re-running it here would
+		// repeat its side effects.
 		if p.Verbose > 0 {
 			fmt.Fprintf(os.Stderr, "snip: execute error: %v\n", err)
 		}
-		code, _ := Passthrough(command, fullArgs)
+		code, perr := Passthrough(command, fullArgs)
+		if perr != nil && p.Verbose > 0 {
+			fmt.Fprintf(os.Stderr, "snip: passthrough error: %v\n", perr)
+		}
 		return code
+	}
+	if err != nil {
+		// The command ran, so its output below is good, but its exit status was
+		// lost with the bookkeeping and is reported as 0. Say so unconditionally
+		// rather than let a command of unknown status look like a success.
+		fmt.Fprintf(os.Stderr, "snip: %v (exit status unknown, reporting 0)\n", err)
 	}
 
 	// Build pipeline input from selected streams

--- a/internal/engine/pipeline_test.go
+++ b/internal/engine/pipeline_test.go
@@ -586,3 +586,51 @@ func TestApplyOverrideNilParamsDoesNotPanic(t *testing.T) {
 		t.Errorf("keep_lines pattern = %v, want error|warn", f.Pipeline[1].Params["pattern"])
 	}
 }
+
+// Run falls back to Passthrough only on a nil *Result, the one case where
+// re-running the command is safe. The filter matches so Run reaches Execute,
+// and the command does not exist so Execute returns nil. Run must fall back
+// rather than dereference the nil Result.
+func TestPipelineRunFallsBackWhenCommandNeverRan(t *testing.T) {
+	const missing = "nonexistent-command-xyz"
+	f := filter.Filter{
+		Name:    "missing-tool",
+		Version: 1,
+		Match:   filter.Match{Command: missing},
+		OnError: "passthrough",
+		Pipeline: filter.Pipeline{
+			{ActionName: "keep_lines", Params: map[string]any{"pattern": `.`}},
+		},
+	}
+	p := &Pipeline{
+		Registry: filter.NewRegistry([]filter.Filter{f}),
+		Verbose:  1,
+	}
+
+	// NOTE: not safe under t.Parallel() since os.Stderr is global.
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = oldStderr })
+
+	code := p.Run(missing, nil)
+
+	_ = w.Close()
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	os.Stderr = oldStderr
+
+	if code != 1 {
+		t.Errorf("exit code = %d, want 1 from the passthrough fallback", code)
+	}
+	// Both errors are reported under -v: the one that triggered the fallback and
+	// the fallback's own.
+	for _, want := range []string{"execute error", "passthrough error"} {
+		if !strings.Contains(buf.String(), want) {
+			t.Errorf("stderr missing %q, got %q", want, buf.String())
+		}
+	}
+}


### PR DESCRIPTION
Fixes #119.

`Execute` returned `nil, err` when `cmd.Wait` gave back something other than an `*exec.ExitError`. By that point the command has started, run to completion and had its output fully read, so the error describes a failure in the wait bookkeeping rather than in the command. `ECHILD` is the realistic trigger: `SIGCHLD` set to `SIG_IGN` is inherited across `exec`, and the child is then reaped by the kernel before `wait4` runs.

`pipeline.go` read any error as "nothing ran" and re-ran the whole command through `Passthrough`. snip wraps every command an agent issues, so the second run could be a push, a publish or a migration.

## The fix

`Execute` now returns the captured `Result` alongside the error, and the caller falls back only when the result is nil, which is the case exactly when the command never started. That invariant is now stated in `Execute`'s doc comment, since it is the whole contract the caller depends on.

Two smaller things came out of it:

- The fallback's own error was discarded. It is now reported under `-v`.
- When the bookkeeping fails, the exit status is gone and is reported as 0. That warning is unconditional rather than verbose-gated, so a command of unknown status does not quietly read as a success.

## The untested branch

The non-`ExitError` branch has no test. I found no clean way to trigger it in-process:

- `signal.Ignore(syscall.SIGCHLD)` does not set the kernel disposition to `SIG_IGN`, because the Go runtime installs its own handler and tracks the ignore in userspace.
- There is no injection seam. Neither `StdoutPipe` nor `os.Pipe` creates the `os/exec` copy goroutines whose errors `Wait` would surface, so a failing writer cannot be substituted.
- Adding a package-level `var execute = ...` seam to make it mockable seemed like too much surgery for a fix this size.

What is tested is the invariant the fix rests on. `TestExecuteNilResultOnlyWhenNeverStarted` pins that a nil `Result` means the command never started and that a command which did run always comes back non-nil with its output and status. `TestPipelineRunFallsBackWhenCommandNeverRan` covers the caller: a filter matches so `Run` reaches `Execute`, the binary does not exist so `Execute` returns nil, and `Run` falls back rather than dereferencing it.

## Merges cleanly alongside the other two

This is one of three separate PRs for #118, #119 and #120. #120 also touches `Execute`, in disjoint hunks. All three were test-merged in every ordering, and each of the six orders produces an identical tree, so they can land in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
