### PR TITLE
fix(engine): bound output draining after the command exits

### DIFF
--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -3,11 +3,39 @@ package engine
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"sync"
 	"time"
 )
+
+// drainGrace bounds how long Execute keeps reading output after the command
+// itself has exited. Descendants it left running inherit the pipe write ends,
+// so an unbounded drain waits for the longest-lived of them.
+const drainGrace = 100 * time.Millisecond
+
+// syncBuffer collects one captured stream. Access is guarded because Execute
+// may read the buffer while its reader goroutine is still blocked: a descendant
+// of the command can hold the pipe's write end open long after the command
+// itself has exited, and closing the read end does not interrupt a blocked read
+// on every platform.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
 
 // Result holds the output of a command execution.
 type Result struct {
@@ -72,33 +100,51 @@ func Execute(command string, args []string) (*Result, error) {
 	// commands that don't read stdin (most filtered commands).
 	// Passthrough commands still get stdin via the Passthrough function.
 
-	stdoutPipe, err := cmd.StdoutPipe()
+	// Own the pipes rather than using cmd.StdoutPipe/StderrPipe, whose contract
+	// requires every read to finish before cmd.Wait. Bounding the drain means
+	// reaping the child first, which that contract does not allow.
+	stdoutR, stdoutW, err := os.Pipe()
 	if err != nil {
 		return nil, fmt.Errorf("stdout pipe: %w", err)
 	}
-	stderrPipe, err := cmd.StderrPipe()
+	defer func() { _ = stdoutR.Close() }()
+	stderrR, stderrW, err := os.Pipe()
 	if err != nil {
+		_ = stdoutW.Close()
 		return nil, fmt.Errorf("stderr pipe: %w", err)
 	}
+	defer func() { _ = stderrR.Close() }()
+	cmd.Stdout = stdoutW
+	cmd.Stderr = stderrW
 
 	if err := cmd.Start(); err != nil {
+		_ = stdoutW.Close()
+		_ = stderrW.Close()
 		return nil, fmt.Errorf("start command: %w", err)
 	}
+	// The child holds its own copies of the write ends now. Drop ours, or the
+	// readers below would never see EOF.
+	_ = stdoutW.Close()
+	_ = stderrW.Close()
 
-	var stdoutBuf, stderrBuf bytes.Buffer
+	var stdoutBuf, stderrBuf syncBuffer
 	var wg sync.WaitGroup
 	wg.Add(2)
 
 	go func() {
 		defer wg.Done()
-		_, _ = stdoutBuf.ReadFrom(stdoutPipe)
+		_, _ = io.Copy(&stdoutBuf, stdoutR)
 	}()
 	go func() {
 		defer wg.Done()
-		_, _ = stderrBuf.ReadFrom(stderrPipe)
+		_, _ = io.Copy(&stderrBuf, stderrR)
 	}()
 
-	wg.Wait()
+	drained := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(drained)
+	}()
 
 	exitCode := 0
 	err = cmd.Wait()
@@ -108,6 +154,17 @@ func Execute(command string, args []string) (*Result, error) {
 		} else {
 			return nil, fmt.Errorf("wait command: %w", err)
 		}
+	}
+
+	// The command itself has exited. Anything it left running in the background
+	// still holds the write ends, so the readers would block for that process's
+	// lifetime. Give them a grace period to drain what is already buffered, then
+	// close the read ends and take whatever they captured.
+	select {
+	case <-drained:
+	case <-time.After(drainGrace):
+		_ = stdoutR.Close()
+		_ = stderrR.Close()
 	}
 
 	return &Result{

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -4,6 +4,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestExecuteEcho(t *testing.T) {
@@ -123,5 +124,49 @@ func TestMakeCommandRegular(t *testing.T) {
 	// Should NOT wrap with sh
 	if len(cmd.Args) > 0 && cmd.Args[0] == "sh" {
 		t.Error("regular commands should not be wrapped with sh")
+	}
+}
+
+// A command that leaves a process running in the background hands that
+// descendant its copies of the pipe write ends, so the pipes only reach EOF
+// once the descendant exits too. Execute must not wait for it.
+//
+// The descendant writes well after the grace period, which pins both sides of
+// the trade-off: everything the command itself wrote is captured, and the late
+// write is dropped rather than waited for.
+func TestExecuteDoesNotWaitForBackgroundDescendants(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skip on windows")
+	}
+	started := time.Now()
+	result, err := Execute("sh", []string{"-c", "(sleep 5; echo late) & echo started"})
+	elapsed := time.Since(started)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := strings.TrimSpace(result.Stdout); got != "started" {
+		t.Errorf("stdout = %q, want %q", got, "started")
+	}
+	if elapsed > 3*time.Second {
+		t.Errorf("Execute blocked for %s on a background descendant", elapsed)
+	}
+}
+
+// Output well past the pipe buffer makes the command block on write until the
+// reader drains. Nothing may be truncated, and neither side may deadlock.
+func TestExecuteLargeOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skip on windows")
+	}
+	const want = 200000
+	result, err := Execute("sh", []string{"-c", "seq 1 200000"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := strings.Count(result.Stdout, "\n"); got != want {
+		t.Errorf("captured %d lines, want %d", got, want)
+	}
+	if got := strings.TrimSpace(result.Stdout); !strings.HasSuffix(got, "\n200000") {
+		t.Errorf("output truncated, ends with %q", got[max(0, len(got)-20):])
 	}
 }


### PR DESCRIPTION
Fixes #120.

`Execute` drained both pipes to EOF before reaping the child. EOF arrives when the last holder of the write end closes it, which is not the moment the command exits: any process the command leaves running in the background inherits those descriptors and keeps them open. With no timeout anywhere in `Execute`, snip blocked for the lifetime of that descendant, and blocked silently, since output is buffered until EOF.

```
$ cat Makefile
hang:
	@sleep 8 & echo started

$ time make -f Makefile hang
real  0m0.024s
$ time snip run -- make -f Makefile hang
real  0m8.045s
```

`make`, `npm` and `docker` recipes that background a watcher or a dev server hit this routinely.

## The fix

The command is reaped first, and the readers then get a 100ms grace period to drain what is already buffered before the read ends are closed. Same reproducer after the change: **0.158s**.

That reordering requires owning the pipes. `cmd.StdoutPipe` documents that reads must finish before `cmd.Wait`, which is the opposite of what a bounded drain needs, so capture moves to `os.Pipe` with `cmd.Stdout`/`cmd.Stderr` set to the write ends.

## Trade-off

Whatever the descendant writes after the grace period is dropped. That is the price of the timeout; the alternative is blocking until the descendant exits. Everything the command itself wrote is still captured: the readers run for its whole lifetime, so at most a pipe buffer's worth of its output is still in flight when it exits, and that drains in microseconds.

`TestExecuteDoesNotWaitForBackgroundDescendants` pins both sides: the descendant sleeps 5s and then writes, `started` comes back in full, and the call returns immediately.

## The mutex

Once the grace period expires, a reader goroutine may still be blocked on a pipe whose read end was just closed. Closing does not interrupt a blocked read on every platform, and the go.mod floor is 1.25.8, so I did not want to rely on Windows pipe pollability here. The capture buffers are therefore mutex-guarded, and `Execute` never waits on the readers after the timeout. Worst case one goroutine outlives the call, which beats either racing on the buffer or hanging the process.

## Tests

`TestExecuteDoesNotWaitForBackgroundDescendants` covers the hang. `TestExecuteLargeOutput` covers the other direction: 200k lines is well past the pipe buffer, so the command blocks on write until the reader drains, and nothing may be truncated or deadlock. Existing executor and pipeline tests pass unchanged, `-race` included.

## Merges cleanly alongside the other two

This is one of three separate PRs for #118, #119 and #120. #119 also touches `Execute`, in disjoint hunks. All three were test-merged in every ordering, and each of the six orders produces an identical tree, so they can land in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
