### PR TITLE
fix(codex): rewrite PreToolUse commands via updatedInput

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ snip integrates with every major AI coding assistant. One binary, universal comp
 | **Cursor** | `snip init --agent cursor` | beforeShellExecution hook (native) |
 | **GitHub Copilot** | `snip init --agent copilot` | .github/copilot-instructions.md |
 | **Gemini CLI** | `snip init --agent gemini` | GEMINI.md prompt injection |
-| **Codex (OpenAI)** | `snip init --agent codex` | AGENTS.md prompt injection |
+| **Codex (OpenAI)** | `snip init --agent codex` | PreToolUse hook (native) |
 | **Pi (pi.dev)** | `snip init --agent pi` | PreToolUse hook (via [pi-hooks](https://github.com/hsingjui/pi-hooks)) |
 | **Grok Build (xAI)** | `snip init --agent grok` | PreToolUse hook (deny + re-run suggestion) |
 | **Windsurf** | `snip init --agent windsurf` | .windsurfrules prompt injection |
@@ -208,7 +208,7 @@ snip init --agent pi --uninstall   # remove the hook
 snip init --agent grok
 ```
 
-This writes `~/.grok/hooks/snip.json` with a `PreToolUse` hook matching the shell tool. Grok Build hooks cannot rewrite commands in place (the hook contract is allow/deny only), so snip denies matched commands with a re-run suggestion (`"…/snip" run -- <command>`), the same pattern as Codex. Non-matching commands pass through untouched, and the hook is fail-open: if snip breaks, commands simply run unfiltered.
+This writes `~/.grok/hooks/snip.json` with a `PreToolUse` hook matching the shell tool. Grok Build hooks cannot rewrite commands in place (the hook contract is allow/deny only), so snip denies matched commands with a re-run suggestion (`"…/snip" run -- <command>`). Non-matching commands pass through untouched, and the hook is fail-open: if snip breaks, commands simply run unfiltered.
 
 Prefer prompt injection instead? Grok Build reads `AGENTS.md` natively:
 
@@ -219,12 +219,33 @@ snip init --agent grok --uninstall     # remove the hook
 
 `AGENTS.md` is shared with Codex, so `--uninstall` never deletes it; it prints a reminder instead.
 
-### Copilot / Gemini / Codex / Windsurf / Cline / Kilo Code / Antigravity
+### Codex
+
+```bash
+snip init --agent codex
+```
+
+This patches `~/.codex/hooks.json` with a native `PreToolUse` hook. Supported shell commands are transparently rewritten through snip with Codex's `updatedInput` contract, so the model runs commands normally and sees only the filtered output.
+
+For safety, mixed commands containing unsupported segments, pipelines with uninspected tails, and command substitutions pass through unchanged so Codex keeps its native permission flow.
+
+Use `snip proxy -- <command>` when full unfiltered output is required.
+
+```bash
+snip init --agent codex --uninstall
+```
+
+For older Codex releases without `PreToolUse` input rewriting, use the legacy project-scoped prompt integration:
+
+```bash
+snip init --agent codex --mode prompt
+```
+
+### Copilot / Gemini / Windsurf / Cline / Kilo Code / Antigravity
 
 ```bash
 snip init --agent copilot      # creates .github/copilot-instructions.md
 snip init --agent gemini       # creates GEMINI.md
-snip init --agent codex        # creates AGENTS.md
 snip init --agent windsurf     # creates .windsurfrules
 snip init --agent cline        # creates .clinerules
 snip init --agent kilocode     # creates .kilocode/rules/snip-rules.md

--- a/internal/hook/codex.go
+++ b/internal/hook/codex.go
@@ -12,13 +12,15 @@ import (
 // codexAgent is the value written to hookaudit.Event.Agent for Codex events.
 const codexAgent = "codex"
 
-// RunCodex reads a Codex PreToolUse JSON payload from r, determines if the
-// command matches a snip filter, and writes a deny-with-suggestion response
-// telling Codex (and the user) to re-run the command through snip.
+// RunCodex reads a Codex PreToolUse JSON payload from r, determines whether the
+// command can be safely rewritten through snip, and writes the updated tool
+// input to w. If no safe rewrite is available, nothing is written and Codex
+// executes the original command through its normal permission flow.
 //
-// Codex's PreToolUse hook cannot rewrite the command in place — only "deny"
-// with a free-form reason is honored. See openai/codex#18491. When that
-// limitation is lifted, this function can return updatedInput like Run does.
+// Codex only accepts updatedInput together with permissionDecision "allow".
+// Therefore this handler rewrites a command only when every runnable segment is
+// recognized by snip. Mixed or unverifiable commands pass through unchanged so
+// an unknown segment can never bypass Codex's native approval rules.
 //
 // Always returns nil; the caller must exit 0 (graceful degradation).
 func RunCodex(r io.Reader, w io.Writer, commands []string, prefixes []TransparentPrefix, snipBin string) error {
@@ -46,22 +48,28 @@ func RunCodex(r io.Reader, w io.Writer, commands []string, prefixes []Transparen
 		return nil
 	}
 
+	// Command substitutions and carriage returns contain executable content that
+	// cannot be safely attested by the segment rewriter. Preserve Codex's native
+	// permission flow by leaving them untouched.
+	if HasUnverifiableConstruct(ti.Command) {
+		return nil
+	}
+
 	cmdSet := make(map[string]struct{}, len(commands))
 	for _, c := range commands {
 		cmdSet[c] = struct{}{}
 	}
 
-	sug := suggestSnipRerun(ti.Command, cmdSet, prefixes, snipBin)
-	if sug.alreadySnip {
-		return nil
-	}
-	if sug.command == "" {
+	res := RewriteCommand(ti.Command, cmdSet, prefixes, snipBin)
+	if !res.Changed || !res.AllKnown {
 		if audit {
+			base := firstBase(ti.Command)
+			_, matched := cmdSet[base]
 			hookaudit.Append(hookaudit.Event{
 				Timestamp: time.Now().UTC(),
 				Command:   ti.Command,
-				Base:      sug.base,
-				Matched:   false,
+				Base:      base,
+				Matched:   matched,
 				Rewritten: false,
 				Agent:     codexAgent,
 			})
@@ -69,13 +77,19 @@ func RunCodex(r io.Reader, w io.Writer, commands []string, prefixes []Transparen
 		return nil
 	}
 
-	reason := fmt.Sprintf("snip can filter this command. Re-run as: %s", sug.command)
+	// Preserve every original tool_input field and replace only the command.
+	var originalInput map[string]any
+	if err := json.Unmarshal(input.ToolInput, &originalInput); err != nil {
+		return nil
+	}
+	originalInput["command"] = res.Command
 
 	output := map[string]any{
 		"hookSpecificOutput": map[string]any{
 			"hookEventName":            "PreToolUse",
-			"permissionDecision":       "deny",
-			"permissionDecisionReason": reason,
+			"permissionDecision":       "allow",
+			"permissionDecisionReason": "snip auto-rewrite",
+			"updatedInput":             originalInput,
 		},
 	}
 
@@ -83,9 +97,9 @@ func RunCodex(r io.Reader, w io.Writer, commands []string, prefixes []Transparen
 		hookaudit.Append(hookaudit.Event{
 			Timestamp: time.Now().UTC(),
 			Command:   ti.Command,
-			Base:      sug.base,
+			Base:      firstBase(ti.Command),
 			Matched:   true,
-			Rewritten: false,
+			Rewritten: true,
 			Agent:     codexAgent,
 		})
 	}

--- a/internal/hook/codex_test.go
+++ b/internal/hook/codex_test.go
@@ -7,8 +7,9 @@ import (
 	"testing"
 )
 
-func extractDenyReason(t *testing.T, output string) string {
+func extractCodexRewrite(t *testing.T, output string) (map[string]any, map[string]any) {
 	t.Helper()
+
 	var result map[string]any
 	if err := json.Unmarshal([]byte(output), &result); err != nil {
 		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, output)
@@ -20,20 +21,17 @@ func extractDenyReason(t *testing.T, output string) string {
 	if hookOut["hookEventName"] != "PreToolUse" {
 		t.Errorf("hookEventName = %v, want PreToolUse", hookOut["hookEventName"])
 	}
-	if hookOut["permissionDecision"] != "deny" {
-		t.Errorf("permissionDecision = %v, want deny", hookOut["permissionDecision"])
+	if hookOut["permissionDecision"] != "allow" {
+		t.Errorf("permissionDecision = %v, want allow", hookOut["permissionDecision"])
 	}
-	if _, ok := hookOut["updatedInput"]; ok {
-		t.Errorf("updatedInput must not be set in Codex response (Codex ignores it): %s", output)
+	updated, ok := hookOut["updatedInput"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing updatedInput: %s", output)
 	}
-	reason, _ := hookOut["permissionDecisionReason"].(string)
-	if reason == "" {
-		t.Fatalf("permissionDecisionReason is empty")
-	}
-	return reason
+	return hookOut, updated
 }
 
-func TestRunCodexDeniesSupportedCommand(t *testing.T) {
+func TestRunCodexRewritesSupportedCommand(t *testing.T) {
 	commands := []string{"git", "go"}
 	snipBin := "/usr/local/bin/snip"
 
@@ -43,13 +41,39 @@ func TestRunCodexDeniesSupportedCommand(t *testing.T) {
 		t.Fatalf("RunCodex: %v", err)
 	}
 	if out.Len() == 0 {
-		t.Fatal("expected deny output for supported command, got empty")
+		t.Fatal("expected rewrite output for supported command, got empty")
 	}
 
-	reason := extractDenyReason(t, out.String())
-	wantSuggestion := `"/usr/local/bin/snip" run -- git log -10`
-	if !strings.Contains(reason, wantSuggestion) {
-		t.Errorf("reason = %q, want it to contain %q", reason, wantSuggestion)
+	_, updated := extractCodexRewrite(t, out.String())
+	want := `"/usr/local/bin/snip" run -- git log -10`
+	if updated["command"] != want {
+		t.Errorf("command = %q, want %q", updated["command"], want)
+	}
+}
+
+func TestRunCodexPreservesOtherToolInputFields(t *testing.T) {
+	commands := []string{"git"}
+	payload := map[string]any{
+		"tool_name": "Bash",
+		"tool_input": map[string]any{
+			"command":     "git status",
+			"timeout_ms":  30000,
+			"description": "inspect worktree",
+		},
+	}
+	data, _ := json.Marshal(payload)
+
+	var out bytes.Buffer
+	if err := RunCodex(strings.NewReader(string(data)), &out, commands, nil, "/usr/local/bin/snip"); err != nil {
+		t.Fatalf("RunCodex: %v", err)
+	}
+
+	_, updated := extractCodexRewrite(t, out.String())
+	if updated["timeout_ms"] != float64(30000) {
+		t.Errorf("timeout_ms = %v, want 30000", updated["timeout_ms"])
+	}
+	if updated["description"] != "inspect worktree" {
+		t.Errorf("description = %v, want inspect worktree", updated["description"])
 	}
 }
 
@@ -57,13 +81,27 @@ func TestRunCodexUnsupportedPassthrough(t *testing.T) {
 	commands := []string{"git", "go"}
 	snipBin := "/usr/local/bin/snip"
 
-	input := makePayload("Bash", "ls -la")
+	input := makePayload("Bash", "custom-tool inspect")
 	var out bytes.Buffer
 	if err := RunCodex(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
 		t.Fatalf("RunCodex: %v", err)
 	}
 	if out.Len() != 0 {
 		t.Errorf("expected no output for unsupported command, got: %s", out.String())
+	}
+}
+
+func TestRunCodexProxyBypassPassthrough(t *testing.T) {
+	commands := []string{"git"}
+	snipBin := "/usr/local/bin/snip"
+
+	input := makePayload("Bash", "snip proxy -- git status")
+	var out bytes.Buffer
+	if err := RunCodex(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
+		t.Fatalf("RunCodex: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("snip proxy bypass must pass through unchanged, got: %s", out.String())
 	}
 }
 
@@ -82,7 +120,7 @@ func TestRunCodexAlreadyRewritten(t *testing.T) {
 	}
 }
 
-func TestRunCodexMultiSegmentSuggestionIncludesTail(t *testing.T) {
+func TestRunCodexRewritesAllKnownSegments(t *testing.T) {
 	commands := []string{"git"}
 	snipBin := "/usr/local/bin/snip"
 
@@ -92,10 +130,38 @@ func TestRunCodexMultiSegmentSuggestionIncludesTail(t *testing.T) {
 		t.Fatalf("RunCodex: %v", err)
 	}
 
-	reason := extractDenyReason(t, out.String())
-	wantSuggestion := `"/usr/local/bin/snip" run -- git add . && git commit -m 'fix'`
-	if !strings.Contains(reason, wantSuggestion) {
-		t.Errorf("reason = %q, want it to contain %q", reason, wantSuggestion)
+	_, updated := extractCodexRewrite(t, out.String())
+	want := `"/usr/local/bin/snip" run -- git add . && "/usr/local/bin/snip" run -- git commit -m 'fix'`
+	if updated["command"] != want {
+		t.Errorf("command = %q, want %q", updated["command"], want)
+	}
+}
+
+func TestRunCodexMixedCommandPassthrough(t *testing.T) {
+	commands := []string{"git"}
+	snipBin := "/usr/local/bin/snip"
+
+	input := makePayload("Bash", "git status && custom-tool deploy")
+	var out bytes.Buffer
+	if err := RunCodex(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
+		t.Fatalf("RunCodex: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("mixed command must keep Codex permission flow, got: %s", out.String())
+	}
+}
+
+func TestRunCodexPipelinePassthrough(t *testing.T) {
+	commands := []string{"git"}
+	snipBin := "/usr/local/bin/snip"
+
+	input := makePayload("Bash", "git log --oneline | custom-filter")
+	var out bytes.Buffer
+	if err := RunCodex(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
+		t.Fatalf("RunCodex: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("pipeline with uninspected tail must pass through, got: %s", out.String())
 	}
 }
 
@@ -109,10 +175,24 @@ func TestRunCodexEnvVarPrefix(t *testing.T) {
 		t.Fatalf("RunCodex: %v", err)
 	}
 
-	reason := extractDenyReason(t, out.String())
-	wantSuggestion := `CGO_ENABLED=0 "/usr/local/bin/snip" run -- go test ./...`
-	if !strings.Contains(reason, wantSuggestion) {
-		t.Errorf("reason = %q, want it to contain %q", reason, wantSuggestion)
+	_, updated := extractCodexRewrite(t, out.String())
+	want := `CGO_ENABLED=0 "/usr/local/bin/snip" run -- go test ./...`
+	if updated["command"] != want {
+		t.Errorf("command = %q, want %q", updated["command"], want)
+	}
+}
+
+func TestRunCodexUnverifiableCommandPassthrough(t *testing.T) {
+	commands := []string{"git"}
+	snipBin := "/usr/local/bin/snip"
+
+	input := makePayload("Bash", "git status && $(custom-tool)")
+	var out bytes.Buffer
+	if err := RunCodex(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
+		t.Fatalf("RunCodex: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("unverifiable command must pass through, got: %s", out.String())
 	}
 }
 

--- a/internal/initcmd/codex.go
+++ b/internal/initcmd/codex.go
@@ -1,6 +1,7 @@
 package initcmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -60,10 +61,9 @@ func initCodex(snipBin, home, filterDir string) error {
 	fmt.Printf("  config: %s ([features].codex_hooks=true)\n", configPath)
 	fmt.Println()
 	fmt.Println("note: Codex hooks require a recent Codex CLI release that supports")
-	fmt.Println("      the [features].codex_hooks flag. Codex denies matched commands")
-	fmt.Println("      with a re-run suggestion (transparent rewrite is tracked upstream:")
-	fmt.Println("      https://github.com/openai/codex/issues/18491). For older Codex")
-	fmt.Println("      releases use:  snip init --agent codex --mode prompt")
+	fmt.Println("      PreToolUse updatedInput. Supported commands are transparently")
+	fmt.Println("      rewritten through snip. For older Codex releases use:")
+	fmt.Println("      snip init --agent codex --mode prompt")
 	if res.backupWritten {
 		fmt.Printf("      original config.toml backed up to %s.bak (comments are not\n", configPath)
 		fmt.Println("      preserved by the TOML round-trip)")
@@ -341,8 +341,9 @@ func readJSONMap(path string) (map[string]any, os.FileMode, error) {
 	_ = os.WriteFile(path+".bak", data, mode)
 
 	m := make(map[string]any)
-	if len(data) > 0 {
-		if err := json.Unmarshal(data, &m); err != nil {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) > 0 {
+		if err := json.Unmarshal(trimmed, &m); err != nil {
 			return nil, mode, fmt.Errorf("parse %s: %w", filepath.Base(path), err)
 		}
 	}

--- a/internal/initcmd/codex_test.go
+++ b/internal/initcmd/codex_test.go
@@ -43,6 +43,37 @@ func TestPatchCodexHooksNew(t *testing.T) {
 	}
 }
 
+func TestPatchCodexHooksWhitespaceOnlyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.json")
+	if err := os.WriteFile(path, []byte(" \n\t"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	hookCommand := "/usr/local/bin/snip hook codex"
+	if err := patchCodexHooks(path, hookCommand); err != nil {
+		t.Fatalf("patch whitespace-only hooks.json: %v", err)
+	}
+
+	cfg := readSettings(t, path)
+	hooks, ok := cfg["hooks"].(map[string]any)
+	if !ok {
+		t.Fatal("hooks not found")
+	}
+	preToolUse, ok := hooks["PreToolUse"].([]any)
+	if !ok || len(preToolUse) != 1 {
+		t.Fatalf("PreToolUse = %#v, want one entry", hooks["PreToolUse"])
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("mode = %o, want 600", got)
+	}
+}
+
 func TestPatchCodexHooksIdempotent(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "hooks.json")


### PR DESCRIPTION
  ## Summary

  - Rewrites supported Codex Bash commands through `snip run` using the
    `PreToolUse` `updatedInput` contract.
  - Preserves the original `tool_input` fields and leaves mixed, unsupported, and
    unverifiable commands untouched so Codex keeps its native permission flow.
  - Updates `snip init --agent codex` messaging and the README for the native
    transparent-rewrite flow.

  ## Test plan

  - [x] `make test`
  - [x] `make test-race`
  - [x] `make lint`
  - [x] `make build`, `make build-lite`, `make build-windows`
  - [x] Real `codex exec` smoke test: verified `git status --short --branch` is
    rewritten through the built `snip` binary and exits successfully.