### PR TITLE
fix(engine): flag output dropped by the bounded drain

### DIFF
--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -13,7 +13,10 @@ import (
 // drainGrace bounds how long Execute keeps reading output after the command
 // itself has exited. Descendants it left running inherit the pipe write ends,
 // so an unbounded drain waits for the longest-lived of them.
-const drainGrace = 100 * time.Millisecond
+//
+// A var rather than a const so tests can shrink it and force the boundary
+// deterministically instead of waiting out the real window.
+var drainGrace = 100 * time.Millisecond
 
 // syncBuffer collects one captured stream. Access is guarded because Execute
 // may read the buffer while its reader goroutine is still blocked: a descendant
@@ -43,6 +46,10 @@ type Result struct {
 	Stderr   string
 	ExitCode int
 	Duration time.Duration
+	// Truncated reports that the drain grace period expired with the pipes
+	// still open, so Stdout and Stderr hold only what had been read by then.
+	// Without it, a partial capture is indistinguishable from a full one.
+	Truncated bool
 }
 
 // shellBuiltins lists commands that are shell built-ins and cannot be
@@ -170,18 +177,26 @@ func Execute(command string, args []string) (*Result, error) {
 	// still holds the write ends, so the readers would block for that process's
 	// lifetime. Give them a grace period to drain what is already buffered, then
 	// close the read ends and take whatever they captured.
+	//
+	// Giving up here means output may still have been in flight, so record that
+	// the capture is partial. The flag is written on this goroutine only, before
+	// the Result is built: the reader goroutines never touch it, so no lock is
+	// needed for it (unlike the buffers they are still writing to).
+	truncated := false
 	select {
 	case <-drained:
 	case <-time.After(drainGrace):
+		truncated = true
 		_ = stdoutR.Close()
 		_ = stderrR.Close()
 	}
 
 	return &Result{
-		Stdout:   stdoutBuf.String(),
-		Stderr:   stderrBuf.String(),
-		ExitCode: exitCode,
-		Duration: time.Since(start),
+		Stdout:    stdoutBuf.String(),
+		Stderr:    stderrBuf.String(),
+		ExitCode:  exitCode,
+		Duration:  time.Since(start),
+		Truncated: truncated,
 	}, waitErr
 }
 

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -183,6 +183,48 @@ func TestExecuteDoesNotWaitForBackgroundDescendants(t *testing.T) {
 	}
 }
 
+// shrinkDrainGrace lowers the drain grace period for the duration of a test so
+// the truncation boundary can be forced without a multi-second wait.
+func shrinkDrainGrace(t *testing.T, d time.Duration) {
+	t.Helper()
+	old := drainGrace
+	drainGrace = d
+	t.Cleanup(func() { drainGrace = old })
+}
+
+// Dropping the late output is the intended trade-off, but the caller must be
+// able to tell that it happened: unflagged truncation is indistinguishable from
+// complete output.
+func TestExecuteFlagsTruncatedWhenDrainGraceExpires(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skip on windows")
+	}
+	shrinkDrainGrace(t, 50*time.Millisecond)
+
+	result, err := Execute("sh", []string{"-c", "(sleep 1; echo LATE) & echo early"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := strings.TrimSpace(result.Stdout); got != "early" {
+		t.Fatalf("stdout = %q, want %q", got, "early")
+	}
+	if !result.Truncated {
+		t.Error("Result.Truncated = false, want true: the drain gave up with output still pending")
+	}
+}
+
+// The flag must stay off for the overwhelmingly common case, or every command
+// would carry a truncation warning.
+func TestExecuteDoesNotFlagTruncatedForCompleteOutput(t *testing.T) {
+	result, err := Execute("echo", []string{"hello"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Truncated {
+		t.Error("Result.Truncated = true, want false: the command's output was fully drained")
+	}
+}
+
 // Output well past the pipe buffer makes the command block on write until the
 // reader drains. Nothing may be truncated, and neither side may deadlock.
 func TestExecuteLargeOutput(t *testing.T) {

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -192,6 +192,14 @@ func (p *Pipeline) Run(command string, args []string) int {
 		}
 	}
 
+	// The drain gave up while a process still held the pipe. Announce it in the
+	// filtered output, the same contract head/tail/truncate_* follow when they
+	// drop lines: the LLM reads stdout, and staying silent would let it treat a
+	// possibly partial capture as the whole story.
+	if result.Truncated {
+		filtered = appendTruncationMarker(filtered)
+	}
+
 	// Tee: save raw output if needed
 	hint := tee.MaybeSave(pipelineInput, result.ExitCode, command, p.TeeConfig)
 
@@ -334,6 +342,26 @@ func (p *Pipeline) Passthrough(command string, args []string) int {
 // rather than sending nothing to the LLM (issue #85).
 func shouldRestoreRaw(filtered, raw string) bool {
 	return strings.TrimSpace(filtered) == "" && strings.TrimSpace(raw) != ""
+}
+
+// truncatedMarker announces that the engine stopped reading with the pipe still
+// held open. It uses the same bracketed [snip: ...] shape as the summary line,
+// since it is the engine speaking rather than a filter action.
+//
+// It says "may be incomplete" rather than "truncated" because the two cases are
+// indistinguishable from inside Execute: a descendant that inherited stdout and
+// went on writing loses output, while one that merely stays alive without
+// writing loses nothing. Both expire the grace period. Claiming loss in the
+// second case would push the agent into re-running a command that in fact
+// returned everything.
+const truncatedMarker = "[snip: output may be incomplete -- a background process held the pipe open]"
+
+// appendTruncationMarker adds truncatedMarker as the last line of out.
+func appendTruncationMarker(out string) string {
+	if out != "" && !strings.HasSuffix(out, "\n") {
+		out += "\n"
+	}
+	return out + truncatedMarker + "\n"
 }
 
 func (p *Pipeline) summaryEnabled() bool {

--- a/internal/engine/pipeline_test.go
+++ b/internal/engine/pipeline_test.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/edouard-claude/snip/internal/config"
 	"github.com/edouard-claude/snip/internal/filter"
@@ -632,5 +633,90 @@ func TestPipelineRunFallsBackWhenCommandNeverRan(t *testing.T) {
 		if !strings.Contains(buf.String(), want) {
 			t.Errorf("stderr missing %q, got %q", want, buf.String())
 		}
+	}
+}
+
+// captureStdout runs fn with os.Stdout redirected to a pipe and returns what
+// was written. NOTE: not safe under t.Parallel() since os.Stdout is global.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	fn()
+
+	os.Stdout = old
+	_ = w.Close()
+	out := <-done
+	_ = r.Close()
+	return out
+}
+
+// shPassthroughFilter matches "sh" and keeps every line, so the filtered output
+// is the raw output plus whatever the engine adds.
+func shPassthroughFilter() filter.Filter {
+	return filter.Filter{
+		Name:    "sh-passthrough",
+		Version: 1,
+		Match:   filter.Match{Command: "sh"},
+		OnError: "passthrough",
+		Pipeline: filter.Pipeline{
+			{ActionName: "keep_lines", Params: map[string]any{"pattern": `.`}},
+		},
+	}
+}
+
+// A background descendant holding the pipe makes the engine drop output. The
+// LLM reading the filtered result is the consumer that matters, so the loss is
+// announced in that result rather than only on stderr.
+func TestPipelineRunMarksOutputDroppedByDrainGrace(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skip on windows")
+	}
+	shrinkDrainGrace(t, 50*time.Millisecond)
+
+	p := &Pipeline{Registry: filter.NewRegistry([]filter.Filter{shPassthroughFilter()})}
+	out := captureStdout(t, func() {
+		p.Run("sh", []string{"-c", "(sleep 1; echo LATE) & echo early"})
+	})
+
+	if !strings.Contains(out, "early") {
+		t.Errorf("stdout lost the command's own output, got %q", out)
+	}
+	if strings.Contains(out, "LATE") {
+		t.Fatalf("premise broken: the late write was not dropped, got %q", out)
+	}
+	if !strings.Contains(out, truncatedMarker) {
+		t.Errorf("stdout missing the truncation marker, got %q", out)
+	}
+}
+
+// A command whose output drains completely must not carry the marker, or every
+// invocation would warn about a loss that did not happen.
+func TestPipelineRunDoesNotMarkCompleteOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skip on windows")
+	}
+
+	p := &Pipeline{Registry: filter.NewRegistry([]filter.Filter{shPassthroughFilter()})}
+	out := captureStdout(t, func() {
+		p.Run("sh", []string{"-c", "echo complete"})
+	})
+
+	if !strings.Contains(out, "complete") {
+		t.Fatalf("premise broken: missing command output, got %q", out)
+	}
+	if strings.Contains(out, truncatedMarker) {
+		t.Errorf("stdout carries the truncation marker for complete output: %q", out)
 	}
 }


### PR DESCRIPTION
Follow-up to #123, which bounded how long `Execute` keeps reading after the command exits. That fixed a real hang, but when the grace period expires the capture is returned as if it were complete: `Result` had no flag, nothing reached stderr even under `-v`, and the truncated bytes are what `tee.MaybeSave` persists, so `snip tee` could not recover the rest either.

Issue #120's own suggested fix said "give the readers a short grace window and then stop, **marking the result truncated**". The window shipped; the marking did not. #121 established the project convention in the same batch: every action that drops output announces it. This makes the engine honour the same contract.

## Changes

- `Result.Truncated`, set in the `case <-time.After(drainGrace)` branch. Written on `Execute`'s own goroutine before the `Result` is built, so unlike the capture buffers it needs no lock. Clean under `-race`.
- `Pipeline.Run` appends a marker line to the filtered output. Chose stdout over stderr because the LLM is the consumer that matters and an agent may never read stderr, matching how `head`/`tail`/`truncate_*` announce themselves.
- `drainGrace` becomes a `var` so tests can shrink it and force the boundary deterministically instead of waiting out 100ms. Value unchanged.

## On the wording

The marker says "output may be incomplete", not "output truncated", and that is deliberate. From inside `Execute` the two cases are indistinguishable: a descendant that inherited stdout and goes on writing loses output, while one that merely stays alive without writing loses nothing. Both expire the grace period.

```
$ snip run -- make late      # late: @(sleep 3; echo LATE) & echo early
early
[snip: output may be incomplete -- a background process held the pipe open]

$ snip run -- make server    # server: @(sleep 3) & echo "listening on :8080"
listening on :8080
[snip: output may be incomplete -- a background process held the pipe open]

$ snip run -- make quick     # quick: @echo all-good
all-good
```

The second case loses nothing. Claiming truncation there would push the agent into re-running a command that in fact returned everything, which is the distrust loop #85 exists to avoid. "May be incomplete" is true in both, and shorter.

## Tests

One pinning that a background descendant's late output is dropped and flagged, one that a normal command is not flagged, both at engine and pipeline level. Reverting `truncated = true` fails both `TestExecuteFlagsTruncatedWhenDrainGraceExpires` and `TestPipelineRunMarksOutputDroppedByDrainGrace`; disabling the `pipeline.go` append fails the latter.

Full CI green locally: build, vet, `test -race`, `-tags lite`, `golangci-lint` (0 issues), `snip verify` 37/37.

## Not fixed here

`tee.MaybeSave` still receives the truncated bytes and writes them with no marker, so `snip tee` hands back a partial file that reads as complete. Those bytes are genuinely gone by then; making the tee file say so is a separate change.
