### PR TITLE
fix(filter): make truncate_bytes respect its own byte cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,12 @@ dir = "~/.config/snip/filters"
 [filters.enable]
 # git-diff = false       # disable a specific built-in filter
 
+[filters.global]
+# max_output_bytes = 65536  # hard cap on the bytes any filter emits (0 = unlimited).
+                            # Applied last, cutting on a UTF-8 rune boundary and
+                            # appending a "... truncated at N bytes" marker that is
+                            # counted inside the cap.
+
 [tee]
 enabled = true
 mode = "failures"    # "failures" | "always" | "never"

--- a/SKILL.md
+++ b/SKILL.md
@@ -55,7 +55,7 @@ on_error: "passthrough"          # What to do if the pipeline fails: "passthroug
 - `defaults` only apply if their flag key is not already present in the user's args.
 - If any flag in `skip_if_present` is found, the entire inject block is skipped.
 
-## The 16 Pipeline Actions
+## The 17 Pipeline Actions
 
 ### Line Filtering
 
@@ -72,6 +72,7 @@ on_error: "passthrough"          # What to do if the pipeline fails: "passthroug
 | Action | Params | Description |
 |--------|--------|-------------|
 | `truncate_lines` | `max` (int, default 80), `ellipsis` (string, default "...") | Truncate long lines |
+| `truncate_bytes` | `max` (int, 0=disabled), `overflow_msg` (string, default "... truncated at {max} bytes") | Cap the whole output at `max` bytes, cutting on a UTF-8 rune boundary. The marker is paid for out of `max`, and is dropped when it alone would not fit |
 | `strip_ansi` | (none) | Remove ANSI escape codes |
 | `compact_path` | (none) | Strips a leading `src/`/`lib/`/`internal/`/`pkg/`/`vendor/` segment. The result may not resolve from the cwd, and carries no marker saying so — no bundled filter uses it. Display-only paths only. |
 

--- a/internal/filter/actions.go
+++ b/internal/filter/actions.go
@@ -152,17 +152,30 @@ func truncateBytes(input ActionResult, params map[string]any) (ActionResult, err
 	if len(joined) <= max {
 		return input, nil
 	}
-	// Back off to a UTF-8 rune boundary so we never emit a partial rune.
-	cut := max
-	for cut > 0 && !utf8.RuneStart(joined[cut]) {
-		cut--
-	}
 	msg := getStr(params, "overflow_msg")
 	if msg == "" {
 		msg = fmt.Sprintf("... truncated at %d bytes", max)
 	}
+	// The marker is paid for out of the budget: max is a hard cap on the bytes
+	// we emit, so reserve len(msg) plus the newline that joins it before cutting.
+	budget := max - len(msg) - 1
+	if budget <= 0 {
+		// The marker alone does not fit; emitting it would blow the cap, so
+		// drop it and spend the whole budget on content.
+		budget = max
+		msg = ""
+	}
+	// Back off to a UTF-8 rune boundary so we never emit a partial rune.
+	cut := budget
+	for cut > 0 && !utf8.RuneStart(joined[cut]) {
+		cut--
+	}
 	// Split allocates a fresh slice, so the append never aliases input.Lines.
-	input.Lines = append(strings.Split(joined[:cut], "\n"), msg)
+	out := strings.Split(joined[:cut], "\n")
+	if msg != "" {
+		out = append(out, msg)
+	}
+	input.Lines = out
 	return input, nil
 }
 

--- a/internal/filter/actions_test.go
+++ b/internal/filter/actions_test.go
@@ -108,14 +108,16 @@ func TestTruncateBytesEmoji(t *testing.T) {
 }
 
 func TestTruncateBytesMarker(t *testing.T) {
-	original := []string{"aaaaaaaaaa", "bbbbbbbbbb"}
+	const max = 70
+	original := []string{strings.Repeat("a", 40), strings.Repeat("b", 40)}
 	input := ActionResult{Lines: original, Metadata: nil}
-	res, err := truncateBytes(input, map[string]any{"max": 5})
+	res, err := truncateBytes(input, map[string]any{"max": max})
 	if err != nil {
 		t.Fatal(err)
 	}
-	// The kept bytes come first, the marker last.
-	want := []string{"aaaaa", "... truncated at 5 bytes"}
+	// The kept bytes come first, the marker last, and the marker is paid for
+	// out of the budget: 44 kept bytes + "\n" + 25 marker bytes = 70.
+	want := []string{strings.Repeat("a", 40), strings.Repeat("b", 3), "... truncated at 70 bytes"}
 	if len(res.Lines) != len(want) {
 		t.Fatalf("got %v, want %v", res.Lines, want)
 	}
@@ -124,20 +126,49 @@ func TestTruncateBytesMarker(t *testing.T) {
 			t.Errorf("line %d = %q, want %q", i, res.Lines[i], want[i])
 		}
 	}
+	if got := len(strings.Join(res.Lines, "\n")); got > max {
+		t.Errorf("output is %d bytes, over the %d-byte cap", got, max)
+	}
 	// Appending the marker must not write into the caller's backing array.
-	if original[1] != "bbbbbbbbbb" {
+	if original[1] != strings.Repeat("b", 40) {
 		t.Errorf("input slice mutated: %v", original)
 	}
 }
 
 func TestTruncateBytesCustomOverflowMsg(t *testing.T) {
+	const max = 20
 	input := lines("aaaaaaaaaa", "bbbbbbbbbb")
-	res, err := truncateBytes(input, map[string]any{"max": 5, "overflow_msg": "[cut]"})
+	res, err := truncateBytes(input, map[string]any{"max": max, "overflow_msg": "[cut]"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if res.Lines[len(res.Lines)-1] != "[cut]" {
 		t.Errorf("custom overflow msg: %v", res.Lines)
+	}
+	if got := len(strings.Join(res.Lines, "\n")); got > max {
+		t.Errorf("output is %d bytes, over the %d-byte cap", got, max)
+	}
+}
+
+func TestTruncateBytesRespectsCap(t *testing.T) {
+	// Multi-byte input so rune-boundary back-off is exercised at every cap.
+	input := lines(
+		strings.Repeat("héllo wörld ", 20),
+		strings.Repeat("🎉 café ", 20),
+		strings.Repeat("naïve ", 20),
+	)
+	for _, max := range []int{1, 2, 3, 7, 24, 25, 26, 40, 100, 512, 4096} {
+		res, err := truncateBytes(input, map[string]any{"max": max})
+		if err != nil {
+			t.Fatalf("max=%d: %v", max, err)
+		}
+		out := strings.Join(res.Lines, "\n")
+		if len(out) > max {
+			t.Errorf("max=%d: output is %d bytes, over the cap: %q", max, len(out), out)
+		}
+		if !utf8.ValidString(out) {
+			t.Errorf("max=%d: output is not valid UTF-8: %q", max, out)
+		}
 	}
 }
 


### PR DESCRIPTION
Follow-up to #121, which gave `truncate_bytes` an overflow marker but appended it after cutting at `max`. The emitted text was `cut` bytes + `\n` + `len(msg)`, i.e. 25 to 28 bytes past the declared cap with the default message.

Measured on master: a 4099-byte input with `max=4096` comes back as 4124 bytes joined, 28 over the cap and 25 bytes *more* than doing nothing at all. `max=70` emitted 96.

The sibling action does the opposite: `truncateLines` computes `ellipsisLen`, bumps `max` when the ellipsis alone would not fit, and cuts at `max-ellipsisLen`, so it never exceeds `max`. `head` may add a line past `n` because `n` counts lines and the marker is metadata, but `max_output_bytes` is a byte budget whose whole purpose is bounding how much text reaches the model, and `truncate_bytes` is its only enforcement point (`applyGlobalLimit`).

## Fix

Build `msg` first, reserve `len(msg)` plus the joining newline out of the budget, then back off from there to a UTF-8 rune boundary. When the marker alone would not fit, drop it and spend the whole budget on content rather than blow the cap. Preserves the existing early return when the input already fits, and the guarantee that the append never aliases the caller's backing array (`TestTruncateBytesMarker` pins that).

Invariant now holds by construction: `cut + 1 + len(msg) <= max`.

## Docs

`truncate_bytes` had no row in SKILL.md at all despite gaining an `overflow_msg` param in #121, and `filters.global.max_output_bytes`, its only route to a user, was undocumented in the README. Issue #118 flagged that second point. Both added, and the SKILL.md section heading count corrected to match.

## Tests

Updated the #121 tests that encoded the old sizes, plus one asserting `len(strings.Join(res.Lines, "\n")) <= max` across several caps including pathologically small ones, with a multi-byte input. Reverting the production hunk fails all three.

Full CI green locally: build, vet, `test -race`, `-tags lite`, `golangci-lint` (0 issues), `snip verify` 37/37.
