### PR TITLE
refactor(engine): extract resultFrom so the wait-error branch is testable

### DIFF
--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -158,20 +158,7 @@ func Execute(command string, args []string) (*Result, error) {
 		close(drained)
 	}()
 
-	exitCode := 0
-	var waitErr error
-	err = cmd.Wait()
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			exitCode = exitErr.ExitCode()
-		} else {
-			// The command ran to completion; only the wait bookkeeping failed.
-			// Report the error, but still return the Result so the caller does
-			// not re-run a command whose side effects have already happened.
-			// The exit status went missing with the bookkeeping, so it stays 0.
-			waitErr = fmt.Errorf("wait command: %w", err)
-		}
-	}
+	waitErr := cmd.Wait()
 
 	// The command itself has exited. Anything it left running in the background
 	// still holds the write ends, so the readers would block for that process's
@@ -191,13 +178,36 @@ func Execute(command string, args []string) (*Result, error) {
 		_ = stderrR.Close()
 	}
 
-	return &Result{
-		Stdout:    stdoutBuf.String(),
-		Stderr:    stderrBuf.String(),
-		ExitCode:  exitCode,
-		Duration:  time.Since(start),
-		Truncated: truncated,
-	}, waitErr
+	result, err := resultFrom(waitErr, stdoutBuf.String(), stderrBuf.String(), time.Since(start))
+	// Set here rather than inside resultFrom: whether the drain ran out of time
+	// is a property of the capture, not of how cmd.Wait ended, and resultFrom
+	// stays a pure function of the wait outcome.
+	result.Truncated = truncated
+	return result, err
+}
+
+// resultFrom turns the error of cmd.Wait plus the captured streams into the
+// pair Execute returns. It is a separate function because its middle branch is
+// unreachable from a test through a real command: the Go runtime owns SIGCHLD
+// and os/exec exposes no seam on the wait syscall.
+//
+// Every branch returns a non-nil *Result. The command has started by the time
+// this is called, so "never ran" (the nil *Result) is not one of the cases.
+func resultFrom(waitErr error, stdout, stderr string, d time.Duration) (*Result, error) {
+	result := &Result{Stdout: stdout, Stderr: stderr, Duration: d}
+	if waitErr == nil {
+		return result, nil
+	}
+	if exitErr, ok := waitErr.(*exec.ExitError); ok {
+		// The command failed, which is not an error of Execute.
+		result.ExitCode = exitErr.ExitCode()
+		return result, nil
+	}
+	// The command ran to completion; only the wait bookkeeping failed. Report
+	// the error, but still return the Result so the caller does not re-run a
+	// command whose side effects have already happened. The exit status went
+	// missing with the bookkeeping, so it stays 0.
+	return result, fmt.Errorf("wait command: %w", waitErr)
 }
 
 // Passthrough runs a command with inherited stdio (no capture).

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -1,6 +1,8 @@
 package engine
 
 import (
+	"errors"
+	"os/exec"
 	"runtime"
 	"strings"
 	"testing"
@@ -85,6 +87,83 @@ func TestExecuteNilResultOnlyWhenNeverStarted(t *testing.T) {
 	if strings.TrimSpace(result.Stdout) != "out" || strings.TrimSpace(result.Stderr) != "err" {
 		t.Errorf("output not captured: stdout=%q stderr=%q", result.Stdout, result.Stderr)
 	}
+}
+
+// resultFrom holds the whole post-wait decision of Execute. Its non-ExitError
+// branch is the one issue #119 is about, and no real command can reach it: the
+// Go runtime owns SIGCHLD and os/exec offers no seam on the wait syscall. So it
+// is exercised here directly, on the helper.
+func TestResultFrom(t *testing.T) {
+	const (
+		stdout = "captured out\n"
+		stderr = "captured err\n"
+	)
+	const dur = 7 * time.Millisecond
+
+	t.Run("wait bookkeeping failed", func(t *testing.T) {
+		boom := errors.New("boom")
+
+		result, err := resultFrom(boom, stdout, stderr, dur)
+
+		if err == nil {
+			t.Fatal("a non-ExitError from wait must be reported")
+		}
+		if !errors.Is(err, boom) {
+			t.Errorf("error must wrap the wait error, got %v", err)
+		}
+		if result == nil {
+			t.Fatal("result must be non-nil: the command ran and re-running it would repeat its side effects")
+		}
+		if result.Stdout != stdout || result.Stderr != stderr {
+			t.Errorf("captured output lost: stdout=%q stderr=%q", result.Stdout, result.Stderr)
+		}
+		if result.Duration != dur {
+			t.Errorf("duration = %v, want %v", result.Duration, dur)
+		}
+	})
+
+	t.Run("exit error", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("skip on windows")
+		}
+		waitErr := exec.Command("sh", "-c", "exit 3").Run()
+		var exitErr *exec.ExitError
+		if !errors.As(waitErr, &exitErr) {
+			t.Fatalf("setup: want *exec.ExitError, got %T (%v)", waitErr, waitErr)
+		}
+
+		result, err := resultFrom(waitErr, stdout, stderr, dur)
+
+		if err != nil {
+			t.Fatalf("a failing command is not an error of Execute, got %v", err)
+		}
+		if result == nil {
+			t.Fatal("result must be non-nil")
+		}
+		if result.ExitCode != 3 {
+			t.Errorf("exit code = %d, want 3", result.ExitCode)
+		}
+		if result.Stdout != stdout || result.Stderr != stderr {
+			t.Errorf("captured output lost: stdout=%q stderr=%q", result.Stdout, result.Stderr)
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		result, err := resultFrom(nil, stdout, stderr, dur)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result == nil {
+			t.Fatal("result must be non-nil")
+		}
+		if result.ExitCode != 0 {
+			t.Errorf("exit code = %d, want 0", result.ExitCode)
+		}
+		if result.Stdout != stdout || result.Stderr != stderr {
+			t.Errorf("captured output lost: stdout=%q stderr=%q", result.Stdout, result.Stderr)
+		}
+	})
 }
 
 func TestPassthrough(t *testing.T) {

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -32,6 +32,19 @@ type Pipeline struct {
 	// TrackUnfiltered records no-filter passthrough commands for coverage
 	// analysis (issue #96). Off keeps the passthrough path free of extra work.
 	TrackUnfiltered bool
+	// execute runs the command. nil means Execute, which is what production
+	// always uses. It exists so tests can return a Result together with an
+	// error — the "the command ran, only its bookkeeping failed" case that no
+	// real command can be made to produce.
+	execute func(command string, args []string) (*Result, error)
+}
+
+// runCommand executes the command through the pipeline's executor.
+func (p *Pipeline) runCommand(command string, args []string) (*Result, error) {
+	if p.execute != nil {
+		return p.execute(command, args)
+	}
+	return Execute(command, args)
 }
 
 // Run executes a command through the full pipeline.
@@ -117,7 +130,7 @@ func (p *Pipeline) Run(command string, args []string) int {
 	timed := tracking.Start(p.Tracker)
 
 	// Execute command
-	result, err := Execute(command, finalArgs)
+	result, err := p.runCommand(command, finalArgs)
 	if result == nil {
 		// The command never ran, so fall back to passthrough. A non-nil result
 		// with a non-nil err means it did run, and re-running it here would

--- a/internal/engine/pipeline_test.go
+++ b/internal/engine/pipeline_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"runtime"
@@ -718,5 +719,70 @@ func TestPipelineRunDoesNotMarkCompleteOutput(t *testing.T) {
 	}
 	if strings.Contains(out, truncatedMarker) {
 		t.Errorf("stdout carries the truncation marker for complete output: %q", out)
+	}
+}
+
+// The counterpart of TestPipelineRunFallsBackWhenCommandNeverRan: a non-nil
+// Result alongside a non-nil error means the command did run, so Run must use
+// that Result instead of re-running the command and repeating its side effects
+// (issue #119). No real command produces that pair, hence the execute seam.
+func TestPipelineRunDoesNotFallBackWhenCommandRan(t *testing.T) {
+	// A command that cannot be executed: should Run wrongly fall back, the
+	// Passthrough attempt is loud and its exit code differs from the Result's.
+	const missing = "nonexistent-command-xyz"
+	f := filter.Filter{
+		Name:    "ran-tool",
+		Version: 1,
+		Match:   filter.Match{Command: missing},
+		Pipeline: filter.Pipeline{
+			{ActionName: "keep_lines", Params: map[string]any{"pattern": `kept`}},
+		},
+	}
+	executed := 0
+	p := &Pipeline{
+		Registry: filter.NewRegistry([]filter.Filter{f}),
+		Verbose:  1,
+		execute: func(string, []string) (*Result, error) {
+			executed++
+			return &Result{Stdout: "kept line\ndropped line\n"}, errors.New("wait command: boom")
+		},
+	}
+
+	// NOTE: not safe under t.Parallel() since os.Stdout/os.Stderr are global.
+	outR, outW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	errR, errW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldStdout, oldStderr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = outW, errW
+	t.Cleanup(func() { os.Stdout, os.Stderr = oldStdout, oldStderr })
+
+	code := p.Run(missing, nil)
+
+	_ = outW.Close()
+	_ = errW.Close()
+	var outBuf, errBuf bytes.Buffer
+	_, _ = io.Copy(&outBuf, outR)
+	_, _ = io.Copy(&errBuf, errR)
+	os.Stdout, os.Stderr = oldStdout, oldStderr
+
+	if executed != 1 {
+		t.Errorf("command executed %d times, want exactly 1", executed)
+	}
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0 from the Result", code)
+	}
+	if !strings.Contains(outBuf.String(), "kept line") || strings.Contains(outBuf.String(), "dropped line") {
+		t.Errorf("captured output was not filtered and printed, got %q", outBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "exit status unknown") {
+		t.Errorf("stderr must report the lost exit status, got %q", errBuf.String())
+	}
+	if strings.Contains(errBuf.String(), "passthrough") {
+		t.Errorf("Run fell back to passthrough for a command that already ran, stderr: %q", errBuf.String())
 	}
 }


### PR DESCRIPTION
Follow-up to #122, which stopped `Pipeline.Run` re-executing a command whose `cmd.Wait` bookkeeping failed (#119). The production change was correct, but neither test it shipped fails when the fix is reverted:

- restoring `executor.go` to its pre-#122 form leaves `TestExecuteNilResultOnlyWhenNeverStarted` passing;
- reverting `pipeline.go`'s `if result == nil` to `if err != nil` leaves `TestPipelineRunFallsBackWhenCommandNeverRan` passing.

Both only reach the two branches that are identical before and after: command-not-found, and a normal `*exec.ExitError`. The branch the fix is about was entered by no test, so a future refactor could reintroduce the double execution with the suite green.

There is no clean in-process way to make `cmd.Wait` return a non-`ExitError`. #122 documented why, and I confirmed the ECHILD route does not reproduce: a probe running under `/bin/sh -c "trap '' CHLD; exec ./probe"` returns normally, because the Go runtime installs its own SIGCHLD handler and overrides the inherited disposition.

## Change

Extract the decision into `resultFrom(waitErr, stdout, stderr, duration)`, a pure function of the wait outcome, and have `Execute` call it. Nothing else in `Execute` moves: #123 and #129 just reshaped that function and that work is untouched. `Result.Truncated` is set by `Execute` after the call rather than passed in, so `resultFrom` stays a function of `cmd.Wait` alone.

Then test it directly: a plain `errors.New` must yield a non-nil `Result` carrying the captured output plus a non-nil error; an `*exec.ExitError` must yield its code with a nil error; `nil` must yield code 0 and no error. Plus a caller-side test that `Run` does not fall back to `Passthrough` when `Execute` returns a non-nil `Result` together with a non-nil error, which needs a small unexported seam on `Pipeline` since no real command produces that pair.

Non-vacuousness checked per hunk: changing `resultFrom`'s non-`ExitError` branch back to `return nil, err` fails `TestResultFrom/wait_bookkeeping_failed`, and reverting the caller predicate fails the new pipeline test.

Full CI green locally: build, vet, `test -race`, `-tags lite`, `golangci-lint` (0 issues).

## Not fixed here

`Execute` still reports `ExitCode` 0 when the bookkeeping fails, which flows into `tee.MaybeSave` and makes tee's default failures-only mode skip saving raw output for exactly the run whose status is unknown. That is a behaviour decision, not a test gap, so it stays out of this PR.
