### PR TITLE
fix(filters): stop git filters answering a different question than the one asked

### DIFF
--- a/filters/git-diff.yaml
+++ b/filters/git-diff.yaml
@@ -1,26 +1,139 @@
 name: "git-diff"
-version: 1
-description: "Condensed git diff with stat summary"
+version: 2
+description: "git diff reduced to a diffstat; the patch body is not produced"
 
 match:
   command: "git"
   subcommand: "diff"
-  exclude_flags: ["--stat", "--name-only", "--name-status"]
+  # An explicit request for a patch must produce a patch, so the filter opts out
+  # entirely rather than injecting --stat alongside it (issue #124). Skipping
+  # only the injection was not enough: git emits both, and the head cap then ate
+  # the patch under a message about files.
+  exclude_flags:
+    ["--stat", "--shortstat", "--numstat", "--name-only", "--name-status",
+     "-p", "--patch", "-U", "--unified"]
 
 inject:
-  args: ["--stat"]
+  # --stat-count caps the file list inside git, so git's own accurate
+  # "N files changed, ..." summary line always survives the cap (issue #125).
+  args: ["--stat", "--stat-count=30"]
   skip_if_present: ["--stat", "--name-only", "--name-status"]
 
 pipeline:
+  - action: "strip_ansi"
   - action: "keep_lines"
     pattern: "\\S"
   - action: "truncate_lines"
     max: 100
     ellipsis: "..."
+  # Backstop only: git already caps the list at 30 files, so the output is at
+  # most 32 lines (30 file lines + git's " ..." marker + git's summary line).
+  # Keep n above 32, or git's summary line is cut and the only file count left
+  # in the output is a wrong one (issue #125).
   - action: "head"
-    n: 30
-    overflow_msg: "... and more files"
+    n: 40
+    overflow_msg: "... more lines (truncated by snip)"
+  # No "{{.count}} files changed" header: count was the number of lines reaching
+  # the template, i.e. files + 1 for git's summary line, and pinned at the head
+  # cap + 1 past it (issue #125). git's own summary is already correct and gets
+  # the singular right. The header names the substitution instead, since a
+  # diffstat answers a different question than the one asked (issue #124).
   - action: "format_template"
-    template: "{{.count}} files changed:\n{{.lines}}"
+    template: "diffstat only, patch not produced. Full patch: git diff -p\n{{.lines}}"
 
 on_error: "passthrough"
+
+tests:
+  - name: "git's own summary is kept and snip invents no file count"
+    input: |
+      a.txt | 2 +-
+      b.txt | 2 +-
+      c.txt | 2 +-
+      3 files changed, 3 insertions(+), 3 deletions(-)
+    expected: |
+      diffstat only, patch not produced. Full patch: git diff -p
+      a.txt | 2 +-
+      b.txt | 2 +-
+      c.txt | 2 +-
+      3 files changed, 3 insertions(+), 3 deletions(-)
+
+  - name: "single-file diff keeps git's singular wording"
+    input: |
+      a.txt | 2 +-
+      1 file changed, 1 insertion(+), 1 deletion(-)
+    expected: |
+      diffstat only, patch not produced. Full patch: git diff -p
+      a.txt | 2 +-
+      1 file changed, 1 insertion(+), 1 deletion(-)
+
+  # 32 lines: the shape --stat-count=30 produces past the cap. This is the test
+  # that catches anyone lowering head n back under 32, which is exactly what
+  # makes git's true total disappear.
+  - name: "capped diff keeps git's overflow marker and its true total"
+    input: |
+      f01.txt | 2 +-
+      f02.txt | 2 +-
+      f03.txt | 2 +-
+      f04.txt | 2 +-
+      f05.txt | 2 +-
+      f06.txt | 2 +-
+      f07.txt | 2 +-
+      f08.txt | 2 +-
+      f09.txt | 2 +-
+      f10.txt | 2 +-
+      f11.txt | 2 +-
+      f12.txt | 2 +-
+      f13.txt | 2 +-
+      f14.txt | 2 +-
+      f15.txt | 2 +-
+      f16.txt | 2 +-
+      f17.txt | 2 +-
+      f18.txt | 2 +-
+      f19.txt | 2 +-
+      f20.txt | 2 +-
+      f21.txt | 2 +-
+      f22.txt | 2 +-
+      f23.txt | 2 +-
+      f24.txt | 2 +-
+      f25.txt | 2 +-
+      f26.txt | 2 +-
+      f27.txt | 2 +-
+      f28.txt | 2 +-
+      f29.txt | 2 +-
+      f30.txt | 2 +-
+      ...
+      40 files changed, 40 insertions(+), 40 deletions(-)
+    expected: |
+      diffstat only, patch not produced. Full patch: git diff -p
+      f01.txt | 2 +-
+      f02.txt | 2 +-
+      f03.txt | 2 +-
+      f04.txt | 2 +-
+      f05.txt | 2 +-
+      f06.txt | 2 +-
+      f07.txt | 2 +-
+      f08.txt | 2 +-
+      f09.txt | 2 +-
+      f10.txt | 2 +-
+      f11.txt | 2 +-
+      f12.txt | 2 +-
+      f13.txt | 2 +-
+      f14.txt | 2 +-
+      f15.txt | 2 +-
+      f16.txt | 2 +-
+      f17.txt | 2 +-
+      f18.txt | 2 +-
+      f19.txt | 2 +-
+      f20.txt | 2 +-
+      f21.txt | 2 +-
+      f22.txt | 2 +-
+      f23.txt | 2 +-
+      f24.txt | 2 +-
+      f25.txt | 2 +-
+      f26.txt | 2 +-
+      f27.txt | 2 +-
+      f28.txt | 2 +-
+      f29.txt | 2 +-
+      f30.txt | 2 +-
+      ...
+      40 files changed, 40 insertions(+), 40 deletions(-)

--- a/filters/git-log.yaml
+++ b/filters/git-log.yaml
@@ -1,18 +1,30 @@
 name: "git-log"
-version: 1
+version: 2
 description: "Condense git log to hash + message + author + date"
 
 match:
   command: "git"
   subcommand: "log"
-  exclude_flags: ["--format", "--pretty", "--graph", "--oneline"]
+  # A request for a patch or a stat asks a different question than "what are the
+  # recent commits", and the template would then count output lines as commits
+  # (issue #125). Opt out entirely for those.
+  exclude_flags:
+    ["--format", "--pretty", "--graph", "--oneline",
+     "-p", "--patch", "--stat", "--numstat", "--name-only", "--name-status"]
 
 inject:
-  args: ["--pretty=format:%h %s (%ar) <%an>", "--no-merges"]
+  # No --no-merges: it hid merge commits unconditionally, so on a PR-merge
+  # history the most recent commit was absent while the header still claimed a
+  # complete list. It saved nothing measurable, since -n already bounds the
+  # output (issue #124).
+  args: ["--pretty=format:%h %s (%ar) <%an>"]
   defaults:
     "-n": "10"
-  skip_if_present:
-    ["--merges", "--format", "--pretty", "--oneline", "-n", "--max-count"]
+  # -n / --max-count are handled by defaults, which leaves a user-supplied value
+  # alone. Listing them here disabled the whole injection instead, so `git log
+  # -n 3` fell back to raw multi-line git output under a header counting lines
+  # rather than commits (issue #125).
+  skip_if_present: ["--format", "--pretty", "--oneline"]
 
 pipeline:
   - action: "keep_lines"
@@ -20,7 +32,21 @@ pipeline:
   - action: "truncate_lines"
     max: 80
     ellipsis: "..."
+  # Safe here, unlike git-diff: the injected --pretty emits exactly one line per
+  # commit, there is no summary line, and no cap runs before the template.
   - action: "format_template"
     template: "{{.count}} commits:\n{{.lines}}"
 
 on_error: "passthrough"
+
+tests:
+  - name: "merge commits are kept and the count matches what is shown"
+    input: |
+      25b7589 Merge pull request #131 from user/pin (16 minutes ago) <Edouard>
+      eb5fc8c refactor(engine): extract resultFrom (41 minutes ago) <Edouard>
+      0b337a9 fix(filter): truncate_bytes respects its cap (42 minutes ago) <Edouard>
+    expected: |
+      3 commits:
+      25b7589 Merge pull request #131 from user/pin (16 minutes ago) <Edouard>
+      eb5fc8c refactor(engine): extract resultFrom (41 minutes ago) <Edouard>
+      0b337a9 fix(filter): truncate_bytes respects its cap (42 minutes ago) <Edouard>

--- a/filters/git-show.yaml
+++ b/filters/git-show.yaml
@@ -1,22 +1,57 @@
 name: "git-show"
-version: 1
-description: "Condensed git show: commit header and diffstat"
+version: 2
+description: "git show reduced to commit header and diffstat; the patch body is not produced"
 
 match:
   command: "git"
   subcommand: "show"
-  exclude_flags: ["--stat", "--format", "--pretty", "--name-only", "--name-status"]
+  # An explicit request for a patch must produce a patch (issue #124). -p and
+  # --patch were in skip_if_present, which stopped the injection but not the
+  # head cap: git produced the patch and snip then kept 4 of 196 patch lines
+  # under a message about files.
+  exclude_flags:
+    ["--stat", "--format", "--pretty", "--name-only", "--name-status",
+     "-p", "--patch", "-U", "--unified"]
 
 inject:
-  args: ["--stat"]
-  skip_if_present: ["--stat", "--format", "--pretty", "--name-only", "--name-status", "-p", "--patch"]
+  # --stat-count caps the file list inside git, so git's own accurate
+  # "N files changed, ..." summary line always survives the cap (issue #125).
+  args: ["--stat", "--stat-count=30"]
+  skip_if_present: ["--stat", "--format", "--pretty", "--name-only", "--name-status"]
 
 pipeline:
   - action: "strip_ansi"
   - action: "keep_lines"
     pattern: "\\S"
+  # Above the 32 lines --stat-count=30 can produce plus the commit header, so
+  # git's own "N files changed, ..." total is never the line that gets cut.
   - action: "head"
-    n: 30
-    overflow_msg: "... more files changed"
+    n: 45
+    overflow_msg: "... more lines (truncated by snip)"
+  # Name the substitution: a diffstat answers a different question than the one
+  # asked, and unlike a cap there is no marker that can express content which
+  # was never produced (issue #124).
+  - action: "format_template"
+    template: "diffstat only, patch not produced. Full patch: git show -p <rev>\n{{.lines}}"
 
 on_error: "passthrough"
+
+tests:
+  - name: "commit header and diffstat are kept and labelled as a substitution"
+    input: |
+      commit eb5fc8c97545f66f319143470651703aaee53991
+      Author: Repro <r@example.com>
+      Date:   Sun Jul 26 08:38:02 2026 +0400
+
+          refactor(engine): extract resultFrom
+
+       internal/engine/executor.go | 52 +++++++++++++++-----------
+       1 file changed, 32 insertions(+), 20 deletions(-)
+    expected: |
+      diffstat only, patch not produced. Full patch: git show -p <rev>
+      commit eb5fc8c97545f66f319143470651703aaee53991
+      Author: Repro <r@example.com>
+      Date:   Sun Jul 26 08:38:02 2026 +0400
+          refactor(engine): extract resultFrom
+       internal/engine/executor.go | 52 +++++++++++++++-----------
+       1 file changed, 32 insertions(+), 20 deletions(-)


### PR DESCRIPTION
Closes #124, closes #125. Both reproduce on master; all numbers below were measured with snip's own estimator on this repository, clean `HOME`.

## `git-log`: `--no-merges` removed

The clearest of the three. On a PR-merge history the most recent commit is a merge, so the default `git log` view hid HEAD while the header still read `10 commits:` and the count matched what was displayed. An agent asked "what changed recently" got the wrong most-recent commit with no signal.

It bought nothing: **205 tokens with it and 205 without**, because `-n 10` already bounds the output. It only changed which ten commits appear.

Its `skip_if_present` also listed `-n` and `--max-count`, and `skip_if_present` is all-or-nothing, so `git log -n 3` disabled the `--pretty` injection too and fell back to raw multi-line git output under a header counting *lines* as commits. `defaults` already leaves a user-supplied `-n` alone, so those two entries are gone.

## `git-diff` / `git-show`: the diffstat stays, but it is now labelled and escapable

`--stat` is a large and defensible saving, 21124 tokens down to 356 on `git diff HEAD~10`, and I am keeping it. What was wrong is that the output answered a different question than the one asked and nothing said so. Unlike a cap there is no marker that can express content that was never produced, so:

- **An explicit request for a patch opts the filter out entirely.** `-p`, `--patch`, `-U` and `--unified` move from `skip_if_present` to `exclude_flags`. `-p` was already skipping the injection, but that was not enough: git emits the patch anyway and `head: 30` then kept 4 of 196 patch lines under a message about *files*. Measured after the change: `git diff -p HEAD~1` returns all 401 patch lines, identical to raw.
- **The template names the substitution**: `diffstat only, patch not produced. Full patch: git diff -p`.

## `git-diff`: the fabricated file count is gone

`{{.count}}` is the number of lines reaching the template. `git diff --stat` appends a summary line, so the header was always files + 1: a 3-file diff printed `4 files changed:` directly above git's own ` 3 files changed, ...`.

Past the cap it is not off by one but arbitrary. `head: 30` keeps 30 lines and appends its overflow marker, so the header is pinned at `31 files changed:` for **any** diff over 30 files, off by 169 at 200 files. And the same cap cut git's accurate summary line, so past 30 files the output contained no true count at all, only a false one.

Fixed by dropping the header and injecting `--stat-count=30`, so git caps the file list itself and its own summary line always survives:

```
$ snip run -- git diff        # 40 changed files
diffstat only, patch not produced. Full patch: git diff -p
 f01.txt | 2 +-
 ...
 ...
 40 files changed, 40 insertions(+), 40 deletions(-)
```

`head` stays as a backstop at `n: 40`, above the 32 lines `--stat-count=30` can produce, and the inline test for the capped case is written out to all 30 file lines precisely so that lowering it back under 32 fails.

`git-log` keeps its `{{.count}}`: the injected `--pretty` emits exactly one line per commit, there is no summary line, and no cap runs before the template. `-p`, `--stat`, `--numstat`, `--name-only` and `--name-status` are added to its `exclude_flags` so that stays true.

## Cost

| command | raw | v0.23.0 | this PR |
|---|---:|---:|---:|
| `git diff HEAD~10` | 21,124 | 342 | 356 |
| `git show <sha>` | 2,831 | 404 | 420 |
| `git log` | 30,662 | 205 | 205 |

Between 0 and 0.5 percentage points of compression. For comparison, v0.23.0 accepted 3.6 points to remove `compact_path` from 28 filters, for the same reason: an answer the agent cannot trust costs a tool round-trip, which is worth more than the tokens saved.

## Tests

Inline `tests:` blocks added to all three filters, which had none. `snip verify`: 132 filters, 19 tested, 42 tests, 42 passed, 0 failed. Full CI green locally (build, vet, `test -race`, `-tags lite`, `golangci-lint` 0 issues).

Versions bumped 1 -> 2 on all three, since the version is user-visible in the summary line.
