### PR TITLE
fix(filters): keep the route table in rails-routes

### DIFF
--- a/filters/rails-routes.yaml
+++ b/filters/rails-routes.yaml
@@ -1,5 +1,5 @@
 name: "rails-routes"
-version: 1
+version: 2
 description: "Summarized rails routes with count and truncation"
 
 match:
@@ -12,12 +12,80 @@ pipeline:
     pattern: "\\S"
   - action: "remove_lines"
     pattern: "^\\s*Prefix"
+  # append keeps the route table: without it, aggregate replaces the lines it counts
   - action: "aggregate"
     patterns:
       routes: "(GET|POST|PUT|PATCH|DELETE)"
+    append: true
+  # the count is carried by .stats, so drop the summary line aggregate appended
+  - action: "remove_lines"
+    pattern: "^routes: \\d+$"
+  # head announces its own truncation with "+N more lines"
   - action: "head"
     n: 15
   - action: "format_template"
-    template: "{{with .stats}}{{.routes}} routes total{{end}} (showing first 15):\n{{.lines}}"
+    template: "{{with .stats}}{{if .routes}}{{.routes}} routes:{{else}}no routes{{end}}{{end}}\n{{.lines}}"
 
 on_error: "passthrough"
+
+tests:
+  - name: "route table survives the count summary"
+    input: |
+      Prefix Verb   URI Pattern                Controller#Action
+        root GET    /                          home#index
+       users GET    /users(.:format)           users#index
+             POST   /users(.:format)           users#create
+        user GET    /users/:id(.:format)       users#show
+             PATCH  /users/:id(.:format)       users#update
+             DELETE /users/:id(.:format)       users#destroy
+    expected: |
+      6 routes:
+        root GET    /                          home#index
+       users GET    /users(.:format)           users#index
+             POST   /users(.:format)           users#create
+        user GET    /users/:id(.:format)       users#show
+             PATCH  /users/:id(.:format)       users#update
+             DELETE /users/:id(.:format)       users#destroy
+  - name: "more than 15 routes are capped and the overflow is announced"
+    input: |
+      Prefix Verb   URI Pattern                Controller#Action
+        root GET    /                          home#index
+       users GET    /users(.:format)           users#index
+             POST   /users(.:format)           users#create
+        user GET    /users/:id(.:format)       users#show
+             PATCH  /users/:id(.:format)       users#update
+             DELETE /users/:id(.:format)       users#destroy
+       posts GET    /posts(.:format)           posts#index
+             POST   /posts(.:format)           posts#create
+        post GET    /posts/:id(.:format)       posts#show
+             PATCH  /posts/:id(.:format)       posts#update
+             DELETE /posts/:id(.:format)       posts#destroy
+        tags GET    /tags(.:format)            tags#index
+             POST   /tags(.:format)            tags#create
+         tag GET    /tags/:id(.:format)        tags#show
+             PATCH  /tags/:id(.:format)        tags#update
+             DELETE /tags/:id(.:format)        tags#destroy
+      health GET    /health(.:format)          health#show
+    expected: |
+      17 routes:
+        root GET    /                          home#index
+       users GET    /users(.:format)           users#index
+             POST   /users(.:format)           users#create
+        user GET    /users/:id(.:format)       users#show
+             PATCH  /users/:id(.:format)       users#update
+             DELETE /users/:id(.:format)       users#destroy
+       posts GET    /posts(.:format)           posts#index
+             POST   /posts(.:format)           posts#create
+        post GET    /posts/:id(.:format)       posts#show
+             PATCH  /posts/:id(.:format)       posts#update
+             DELETE /posts/:id(.:format)       posts#destroy
+        tags GET    /tags(.:format)            tags#index
+             POST   /tags(.:format)            tags#create
+         tag GET    /tags/:id(.:format)        tags#show
+             PATCH  /tags/:id(.:format)        tags#update
+      +2 more lines
+  - name: "header only means no routes"
+    input: |
+      Prefix Verb URI Pattern Controller#Action
+    expected: |
+      no routes

--- a/internal/filter/actions_integration_test.go
+++ b/internal/filter/actions_integration_test.go
@@ -331,10 +331,22 @@ func TestRailsRoutesFilterIntegration(t *testing.T) {
 		t.Errorf("filtered (%d) not shorter than input (%d)", len(filtered), len(fixture))
 	}
 
-	// Should contain routes total summary
-	if !strings.Contains(filtered, "routes total") {
-		t.Error("filtered output missing 'routes total'")
+	// Should contain the route count summary
+	if !strings.Contains(filtered, " routes:") {
+		t.Errorf("filtered output missing route count header: %q", filtered)
 	}
+
+	// The route table itself must survive the aggregate stage (issue #134)
+	if !strings.Contains(filtered, "users#index") {
+		t.Errorf("filtered output missing the route table: %q", filtered)
+	}
+
+	// Not asserted here: that the aggregate summary line does not leak into the
+	// payload. This fixture has more routes than the head cap, so the appended
+	// "routes: N" line is dropped by head whether or not the remove_lines stage
+	// exists, and the assertion would pass either way. The filter's own inline
+	// tests use a fixture under the cap and do pin it: deleting that stage fails
+	// all three of them.
 
 	// Calculate and log token savings
 	inputTokens := utils.EstimateTokens(fixture)


### PR DESCRIPTION
Closes #134.

`rails routes` announced a route count and then showed no routes at all:

```
$ snip run -- rails routes      # v0.23.1
3 routes total (showing first 15):
routes: 3

$ snip run -- rails routes      # this PR
3 routes:
     root GET    /                 home#index
    users GET    /users            users#index
 new_user GET    /users/new        users#new
```

`aggregate` **replaces** the lines it counted unless `append: true` is set, so by the time `format_template` ran, `{{.lines}}` was the aggregate's own `routes: 3` summary and the route table was gone. Worse than a wrong number next to correct content: a correct number instead of the content, under a header claiming to show the first 15.

## Changes

- `append: true` on the aggregate stage, so the routes survive.
- a `remove_lines` on `^routes: \d+$` right after it, dropping the summary line aggregate appends. Without it the summary would be rendered again by the template and would occupy one of `head`'s 15 slots as if it were a route. The count itself is unaffected: `aggregate` writes it to `Metadata["stats"]`, which the template reads as `.stats` regardless of what happened to the lines.
- honest header. `(showing first 15)` was false with fewer than 15 routes and silent about truncation above 15. It is now `N routes:`, or `no routes` when there are none, and `head` announces its own truncation with `+N more lines`.

## Tests

Inline `tests:` block added, which this filter did not have: a normal table, a 17-route table exercising the cap and its overflow marker, and a header-only input. Written first against the unfixed pipeline, where all three failed.

Non-vacuous, verified by mutation: deleting the `remove_lines` stage fails all three (`rails-routes FAIL (0/3 passed)`).

The Go integration test gains an assertion that the route table survives. It deliberately does **not** assert that the summary line stays out of the payload: its fixture has more routes than the head cap, so the appended line is dropped either way and the assertion would pass with the fix reverted. That is left to the inline tests, with a comment saying so.

`snip verify`: 132 filters, 20 tested, 45 tests, 45 passed, 0 failed. Full CI green locally (build, vet, `test -race`, `-tags lite`, `golangci-lint` 0 issues).

## Same defect elsewhere, not fixed here

`filters/rails-migrate.yaml` has the identical shape and is confirmed broken live: it prints `2 migrations executed:` followed by `migrated: 2` instead of the migration names. The cure is the same shape but not the same single line, so it belongs on its own branch. Filing it separately.

`filters/cargo-test.yaml` also ends in a non-append `aggregate` feeding a bare `{{.lines}}`, which destroys the `state_machine` failure block on a failing run. Different enough to need its own analysis.
