### PR TITLE
fix(hook): stop rewriting block bodies and heredoc contents

### DIFF
--- a/internal/hook/blockscope.go
+++ b/internal/hook/blockscope.go
@@ -1,0 +1,221 @@
+package hook
+
+import "strings"
+
+// blockScope tracks how deep the segmenter currently sits inside a shell
+// compound command: a loop (for/while/until/select), a conditional (if/case), a
+// brace group, a function body or a subshell.
+//
+// The segmenter splits on top-level ';', '&&', '||', '&' and '\n', which means a
+// block body becomes an ordinary group. The #111 guard that keeps a producer raw
+// when its output feeds a pipe or a redirect only inspects the group it is in,
+// so `done | wc -l` and `done > out.txt` — which live in a different group from
+// the body — never protected the body. It was wrapped, and the consumer read
+// snip's compacted view instead of the real output (issue #133, bug A).
+//
+// The rule chosen here is deliberately one sentence: nothing inside a block is
+// ever rewritten. It is a counter over machinery that already exists, not a
+// shell parser, and every misdetection costs filtering rather than correctness —
+// an unmatched opener pins the depth above zero and the remainder is simply
+// passed through raw. Consumer propagation (resolving which block a trailing
+// pipe belongs to and rewriting the bodies that have no consumer) would recover
+// more savings, but its failure mode is wrong output, not lost savings, and this
+// hook path prefers the opposite trade (see the #127 process-substitution fix).
+type blockScope struct {
+	depth int
+}
+
+// inBlock reports whether the group being flushed sits inside a compound
+// command and must therefore be emitted verbatim.
+func (s *blockScope) inBlock() bool { return s.depth > 0 }
+
+// advance updates the depth from a group that has just been emitted.
+func (s *blockScope) advance(group string) {
+	// A block can open behind a pipe ("cat list | while read -r l"), so every
+	// top-level pipeline stage is a command position and must be classified.
+	rest := group
+	for {
+		head, tail := splitFirstPipe(rest)
+		s.classify(firstToken(head))
+		if tail == "" {
+			break
+		}
+		rest = tail[1:]
+	}
+
+	// Openers and closers with no reserved word of their own: a function header
+	// ("deploy() {") ends with a standalone '{', and a spaced one-line subshell
+	// ("( go build ./... )") ends with a standalone ')'. Both are skipped when
+	// the whole group is that single character, which firstToken already saw.
+	t := strings.TrimSpace(group)
+	if len(t) < 2 {
+		return
+	}
+	switch prev, last := t[len(t)-2], t[len(t)-1]; {
+	case last == '{' && (prev == ' ' || prev == '\t' || prev == ')'):
+		s.depth++
+	case last == ')' && (prev == ' ' || prev == '\t'):
+		s.close()
+	}
+}
+
+// classify applies one command-position token to the depth counter. Quoting is
+// not stripped, matching the shell: a quoted 'for' is not a reserved word.
+func (s *blockScope) classify(tok string) {
+	switch tok {
+	case "for", "while", "until", "if", "case", "select", "{", "(":
+		s.depth++
+	case "done", "fi", "esac", "}", ")":
+		s.close()
+	}
+}
+
+func (s *blockScope) close() {
+	if s.depth > 0 {
+		s.depth--
+	}
+}
+
+// firstToken returns the first word of a command position: leading blanks are
+// skipped, then bytes are read up to the first blank or shell operator. A lone
+// '(', ')', '{' or '}' is returned as a single-character token only when it
+// stands alone, so "(cd sub" and "arr=(a b)" are not read as subshell openers
+// and "mkdir -p x/{p,q}" is not read as a brace group.
+func firstToken(stage string) string {
+	i := 0
+	for i < len(stage) && (stage[i] == ' ' || stage[i] == '\t' || stage[i] == '\n') {
+		i++
+	}
+	if i >= len(stage) {
+		return ""
+	}
+	if c := stage[i]; c == '(' || c == ')' || c == '{' || c == '}' {
+		if i+1 >= len(stage) || isTokenBreak(stage[i+1]) {
+			return stage[i : i+1]
+		}
+	}
+	start := i
+	for i < len(stage) && !isTokenBreak(stage[i]) {
+		i++
+	}
+	return stage[start:i]
+}
+
+func isTokenBreak(c byte) bool {
+	switch c {
+	case ' ', '\t', '\n', ';', '&', '|', '<', '>':
+		return true
+	}
+	return false
+}
+
+// heredocDelim is a pending heredoc body waiting for its terminator line.
+type heredocDelim struct {
+	delim     string
+	stripTabs bool // <<- form: leading tabs are stripped before comparing
+}
+
+// parseHeredocDelim reads a heredoc delimiter starting at i, which is the index
+// just past "<<". It returns the delimiter, the index just past it, and whether
+// this really is a heredoc.
+//
+// The delimiter is unquoted the way the shell does ('EOF', "EOF" and \EOF all
+// name EOF), because the terminator line is compared against the unquoted form.
+// An all-digit delimiter is rejected: it never occurs in practice and it is what
+// a bare arithmetic command such as "((x = 1 << 2))" would produce, where arming
+// a heredoc would swallow the rest of the command and silently disable filtering
+// (issue #133).
+func parseHeredocDelim(cmd string, i int) (heredocDelim, int, bool) {
+	var d heredocDelim
+	if i < len(cmd) && cmd[i] == '-' {
+		d.stripTabs = true
+		i++
+	}
+	for i < len(cmd) && (cmd[i] == ' ' || cmd[i] == '\t') {
+		i++
+	}
+
+	var sb strings.Builder
+	digitsOnly := true
+scan:
+	for i < len(cmd) {
+		switch ch := cmd[i]; ch {
+		case '\'', '"':
+			i++
+			for i < len(cmd) && cmd[i] != ch {
+				if cmd[i] < '0' || cmd[i] > '9' {
+					digitsOnly = false
+				}
+				sb.WriteByte(cmd[i])
+				i++
+			}
+			if i < len(cmd) {
+				i++
+			}
+		case '\\':
+			if i+1 >= len(cmd) {
+				break scan
+			}
+			if cmd[i+1] < '0' || cmd[i+1] > '9' {
+				digitsOnly = false
+			}
+			sb.WriteByte(cmd[i+1])
+			i += 2
+		case ' ', '\t', '\n', ';', '&', '|', '<', '>', '(', ')':
+			break scan
+		default:
+			if ch < '0' || ch > '9' {
+				digitsOnly = false
+			}
+			sb.WriteByte(ch)
+			i++
+		}
+	}
+
+	d.delim = sb.String()
+	if d.delim == "" || digitsOnly {
+		return heredocDelim{}, i, false
+	}
+	return d, i, true
+}
+
+// drainHeredocs returns the index just past the bodies of every pending heredoc,
+// starting at the first byte of the line following the operator. Each body runs
+// up to and including a line equal to its delimiter (leading tabs stripped first
+// for the <<- form; bash requires an exact match otherwise). A delimiter that
+// never appears consumes the rest of the command, which fails safe: the tail is
+// emitted verbatim instead of being rewritten.
+func drainHeredocs(cmd string, start int, delims []heredocDelim) int {
+	pos := start
+	for _, d := range delims {
+		for pos < len(cmd) {
+			line := cmd[pos:]
+			next := len(cmd)
+			if nl := strings.IndexByte(line, '\n'); nl >= 0 {
+				line = line[:nl]
+				next = pos + nl + 1
+			}
+			pos = next
+			if d.stripTabs {
+				line = strings.TrimLeft(line, "\t")
+			}
+			if line == d.delim {
+				break
+			}
+		}
+	}
+	return pos
+}
+
+// isWordStart reports whether the byte at i begins a shell word, used to decide
+// whether an unquoted '#' opens a comment.
+func isWordStart(cmd string, i int) bool {
+	if i == 0 {
+		return true
+	}
+	switch cmd[i-1] {
+	case ' ', '\t', '\n', ';', '&', '|', '(':
+		return true
+	}
+	return false
+}

--- a/internal/hook/blockscope.go
+++ b/internal/hook/blockscope.go
@@ -2,9 +2,30 @@ package hook
 
 import "strings"
 
-// blockScope tracks how deep the segmenter currently sits inside a shell
-// compound command: a loop (for/while/until/select), a conditional (if/case), a
-// brace group, a function body or a subshell.
+// blockKind is what opened an entry on blockScope's stack. The kind matters
+// because the same byte closes different things: ')' ends a subshell, but on a
+// case-arm pattern line ("  a )") it ends the pattern and the case block stays
+// open. Tracking only a depth cannot tell those apart, and reading "  a )" as a
+// subshell close pops the case back to top level and re-wraps the arm body —
+// the exact corruption issue #133 reports.
+type blockKind uint8
+
+const (
+	// blockParen is an unquoted '(' that does not open a subshell: an array
+	// assignment ("arr=(a b)"), an arithmetic command ("((x = 1))"), an extglob
+	// pattern. It is pushed only so its matching ')' is consumed and cannot be
+	// mistaken for the close of an enclosing subshell. It is not a block, so it
+	// never suppresses rewriting.
+	blockParen blockKind = iota
+	blockSubshell
+	blockBrace // { ... } group or function body
+	blockLoop  // for / while / until / select ... done
+	blockCond  // if ... fi
+	blockCase  // case ... esac
+)
+
+// blockScope tracks which shell compound commands the segmenter currently sits
+// inside: a loop, a conditional, a brace group, a function body or a subshell.
 //
 // The segmenter splits on top-level ';', '&&', '||', '&' and '\n', which means a
 // block body becomes an ordinary group. The #111 guard that keeps a producer raw
@@ -13,100 +34,219 @@ import "strings"
 // the body — never protected the body. It was wrapped, and the consumer read
 // snip's compacted view instead of the real output (issue #133, bug A).
 //
-// The rule chosen here is deliberately one sentence: nothing inside a block is
-// ever rewritten. It is a counter over machinery that already exists, not a
-// shell parser, and every misdetection costs filtering rather than correctness —
-// an unmatched opener pins the depth above zero and the remainder is simply
-// passed through raw. Consumer propagation (resolving which block a trailing
-// pipe belongs to and rewriting the bodies that have no consumer) would recover
-// more savings, but its failure mode is wrong output, not lost savings, and this
-// hook path prefers the opposite trade (see the #127 process-substitution fix).
+// The rule is one sentence: nothing inside a block is ever rewritten. It is a
+// stack over machinery that already exists, not a shell parser, and every
+// misdetection costs filtering rather than correctness — an unmatched opener
+// pins the scope open and the remainder is simply passed through raw. Consumer
+// propagation (resolving which block a trailing pipe belongs to and rewriting
+// the bodies that have no consumer) would recover more savings, but its failure
+// mode is wrong output, not lost savings, and this hook path prefers the
+// opposite trade (see the #127 process-substitution fix).
 type blockScope struct {
-	depth int
+	stack []blockKind
+	// blocks is the number of stack entries that are not blockParen, i.e. how
+	// many real compound commands are open.
+	blocks int
 }
 
 // inBlock reports whether the group being flushed sits inside a compound
 // command and must therefore be emitted verbatim.
-func (s *blockScope) inBlock() bool { return s.depth > 0 }
+func (s *blockScope) inBlock() bool { return s.blocks > 0 }
 
-// advance updates the depth from a group that has just been emitted.
-func (s *blockScope) advance(group string) {
-	// A block can open behind a pipe ("cat list | while read -r l"), so every
-	// top-level pipeline stage is a command position and must be classified.
-	rest := group
-	for {
-		head, tail := splitFirstPipe(rest)
-		s.classify(firstToken(head))
-		if tail == "" {
-			break
-		}
-		rest = tail[1:]
+func (s *blockScope) push(k blockKind) {
+	s.stack = append(s.stack, k)
+	if k != blockParen {
+		s.blocks++
 	}
+}
 
-	// Openers and closers with no reserved word of their own: a function header
-	// ("deploy() {") ends with a standalone '{', and a spaced one-line subshell
-	// ("( go build ./... )") ends with a standalone ')'. Both are skipped when
-	// the whole group is that single character, which firstToken already saw.
-	t := strings.TrimSpace(group)
-	if len(t) < 2 {
+func (s *blockScope) pop() {
+	n := len(s.stack)
+	if n == 0 {
 		return
 	}
-	switch prev, last := t[len(t)-2], t[len(t)-1]; {
-	case last == '{' && (prev == ' ' || prev == '\t' || prev == ')'):
-		s.depth++
-	case last == ')' && (prev == ' ' || prev == '\t'):
-		s.close()
+	if s.stack[n-1] != blockParen {
+		s.blocks--
 	}
+	s.stack = s.stack[:n-1]
 }
 
-// classify applies one command-position token to the depth counter. Quoting is
-// not stripped, matching the shell: a quoted 'for' is not a reserved word.
-func (s *blockScope) classify(tok string) {
-	switch tok {
-	case "for", "while", "until", "if", "case", "select", "{", "(":
-		s.depth++
-	case "done", "fi", "esac", "}", ")":
-		s.close()
+func (s *blockScope) top() (blockKind, bool) {
+	if n := len(s.stack); n > 0 {
+		return s.stack[n-1], true
 	}
+	return 0, false
 }
 
-func (s *blockScope) close() {
-	if s.depth > 0 {
-		s.depth--
+// closeKeyword applies a closing reserved word ("done", "fi", "esac", "}"). Any
+// unmatched blockParen entries above the block being closed are dropped first,
+// so a stray '(' cannot leave a block open forever.
+func (s *blockScope) closeKeyword() {
+	for len(s.stack) > 0 && s.stack[len(s.stack)-1] == blockParen {
+		s.stack = s.stack[:len(s.stack)-1]
 	}
+	s.pop()
 }
 
-// firstToken returns the first word of a command position: leading blanks are
-// skipped, then bytes are read up to the first blank or shell operator. A lone
-// '(', ')', '{' or '}' is returned as a single-character token only when it
-// stands alone, so "(cd sub" and "arr=(a b)" are not read as subshell openers
-// and "mkdir -p x/{p,q}" is not read as a brace group.
-func firstToken(stage string) string {
-	i := 0
-	for i < len(stage) && (stage[i] == ' ' || stage[i] == '\t' || stage[i] == '\n') {
-		i++
-	}
-	if i >= len(stage) {
-		return ""
-	}
-	if c := stage[i]; c == '(' || c == ')' || c == '{' || c == '}' {
-		if i+1 >= len(stage) || isTokenBreak(stage[i+1]) {
-			return stage[i : i+1]
+// advance updates the scope from a group that has just been emitted. It walks
+// the group byte by byte, honouring quotes, and keeps track of whether the next
+// word sits in command position — the only place a reserved word is reserved.
+//
+// The '(' and ')' bytes are handled where they occur rather than only at the end
+// of the group: a subshell closed before a trailing redirect or pipe
+// ("( cd sub && go build ./... ) > out.txt") must still close, otherwise the
+// scope stays open and every later top-level command silently loses filtering.
+func (s *blockScope) advance(group string) {
+	cmdPos := true
+	for i := 0; i < len(group); {
+		switch c := group[i]; c {
+		case ' ', '\t', '\n':
+			i++
+		case '\'', '"':
+			i = skipQuoted(group, i)
+			cmdPos = false
+		case ';', '|':
+			// A single '|' starts a new pipeline stage, which is a command
+			// position ("cat list | while read -r l" opens a loop). ';' is a
+			// group boundary and cannot reach here, but costs nothing to accept.
+			i++
+			cmdPos = true
+		case '&', '<', '>':
+			// Redirections only: "&&" and a bare "&" are group boundaries, so an
+			// '&' here belongs to a form like "2>&1".
+			i++
+			cmdPos = false
+		case '(':
+			i, cmdPos = s.openParen(group, i, cmdPos)
+		case ')':
+			i++
+			if k, ok := s.top(); ok && k == blockCase {
+				// End of a case-arm pattern ("  a )" or "  -v | --verbose )").
+				// The case block stays open, so the arm body stays unwrapped,
+				// and the arm's own body is a command position.
+				cmdPos = true
+				continue
+			} else if ok && (k == blockParen || k == blockSubshell) {
+				s.pop()
+			}
+			cmdPos = false
+		case '{':
+			// A brace group only when '{' stands alone as a word; "x/{p,q}" is
+			// brace expansion.
+			if cmdPos && (i+1 >= len(group) || isTokenBreak(group[i+1])) {
+				s.push(blockBrace)
+				i++
+				cmdPos = true
+				continue
+			}
+			i++
+			cmdPos = false
+		case '}':
+			if cmdPos {
+				if k, ok := s.top(); ok && k == blockBrace {
+					s.pop()
+				}
+			}
+			i++
+			cmdPos = false
+		default:
+			start := i
+			for i < len(group) && !isWordBreak(group[i]) {
+				i++
+			}
+			cmdPos = s.classify(group[start:i], cmdPos)
 		}
 	}
-	start := i
-	for i < len(stage) && !isTokenBreak(stage[i]) {
-		i++
-	}
-	return stage[start:i]
 }
 
+// openParen handles an unquoted '(' and returns the next index and the command
+// position that follows it.
+func (s *blockScope) openParen(group string, i int, cmdPos bool) (int, bool) {
+	// A subshell only when '(' stands alone as a word, so "(cd sub && go test
+	// ./...)" and "((x = 1))" are not read as subshell openers and keep being
+	// filtered exactly as on master.
+	if cmdPos && (i+1 >= len(group) || isTokenBreak(group[i+1])) {
+		s.push(blockSubshell)
+		return i + 1, true
+	}
+	// "name()" — a function header. The body's '{' that follows is in command
+	// position even though a word ("deploy") came before it.
+	j := i + 1
+	for j < len(group) && (group[j] == ' ' || group[j] == '\t') {
+		j++
+	}
+	if j < len(group) && group[j] == ')' {
+		return j + 1, true
+	}
+	s.push(blockParen)
+	return i + 1, false
+}
+
+// classify applies one word to the scope and returns whether the word after it
+// is still in command position. Quoting is not stripped, matching the shell: a
+// quoted 'for' is not a reserved word, and advance never reaches here for one.
+func (s *blockScope) classify(word string, cmdPos bool) bool {
+	if !cmdPos {
+		return false
+	}
+	switch word {
+	case "if":
+		s.push(blockCond)
+		return true // "if grep -q x f": a command follows
+	case "while", "until":
+		s.push(blockLoop)
+		return true
+	case "for", "select":
+		s.push(blockLoop)
+		return false // a variable name follows, not a command
+	case "case":
+		s.push(blockCase)
+		return false
+	case "done", "fi", "esac":
+		s.closeKeyword()
+		return false
+	case "then", "do", "else", "elif", "!", "time":
+		// Reserved words that introduce another command position, so a nested
+		// opener on the same line ("then if false") is still seen.
+		return true
+	}
+	return false
+}
+
+// skipQuoted returns the index just past the quoted region starting at i.
+func skipQuoted(s string, i int) int {
+	q := s[i]
+	for i++; i < len(s); i++ {
+		if s[i] == '\\' && q == '"' && i+1 < len(s) {
+			i++
+			continue
+		}
+		if s[i] == q {
+			return i + 1
+		}
+	}
+	return i
+}
+
+// isTokenBreak reports whether c ends a shell word. It excludes '(', ')', '{'
+// and '}' so that a lone one of those is only treated as an operator when it
+// stands alone: "((x" and "x/{p,q}" are single words.
 func isTokenBreak(c byte) bool {
 	switch c {
 	case ' ', '\t', '\n', ';', '&', '|', '<', '>':
 		return true
 	}
 	return false
+}
+
+// isWordBreak is isTokenBreak plus every byte advance handles itself, so the
+// default branch of its scan always consumes at least one byte.
+func isWordBreak(c byte) bool {
+	switch c {
+	case '(', ')', '{', '}', '\'', '"':
+		return true
+	}
+	return isTokenBreak(c)
 }
 
 // heredocDelim is a pending heredoc body waiting for its terminator line.
@@ -121,10 +261,6 @@ type heredocDelim struct {
 //
 // The delimiter is unquoted the way the shell does ('EOF', "EOF" and \EOF all
 // name EOF), because the terminator line is compared against the unquoted form.
-// An all-digit delimiter is rejected: it never occurs in practice and it is what
-// a bare arithmetic command such as "((x = 1 << 2))" would produce, where arming
-// a heredoc would swallow the rest of the command and silently disable filtering
-// (issue #133).
 func parseHeredocDelim(cmd string, i int) (heredocDelim, int, bool) {
 	var d heredocDelim
 	if i < len(cmd) && cmd[i] == '-' {
@@ -136,16 +272,12 @@ func parseHeredocDelim(cmd string, i int) (heredocDelim, int, bool) {
 	}
 
 	var sb strings.Builder
-	digitsOnly := true
 scan:
 	for i < len(cmd) {
 		switch ch := cmd[i]; ch {
 		case '\'', '"':
 			i++
 			for i < len(cmd) && cmd[i] != ch {
-				if cmd[i] < '0' || cmd[i] > '9' {
-					digitsOnly = false
-				}
 				sb.WriteByte(cmd[i])
 				i++
 			}
@@ -156,24 +288,18 @@ scan:
 			if i+1 >= len(cmd) {
 				break scan
 			}
-			if cmd[i+1] < '0' || cmd[i+1] > '9' {
-				digitsOnly = false
-			}
 			sb.WriteByte(cmd[i+1])
 			i += 2
 		case ' ', '\t', '\n', ';', '&', '|', '<', '>', '(', ')':
 			break scan
 		default:
-			if ch < '0' || ch > '9' {
-				digitsOnly = false
-			}
 			sb.WriteByte(ch)
 			i++
 		}
 	}
 
 	d.delim = sb.String()
-	if d.delim == "" || digitsOnly {
+	if d.delim == "" {
 		return heredocDelim{}, i, false
 	}
 	return d, i, true

--- a/internal/hook/blockscope.go
+++ b/internal/hook/blockscope.go
@@ -11,11 +11,12 @@ import "strings"
 type blockKind uint8
 
 const (
-	// blockParen is an unquoted '(' that does not open a subshell: an array
-	// assignment ("arr=(a b)"), an arithmetic command ("((x = 1))"), an extglob
-	// pattern. It is pushed only so its matching ')' is consumed and cannot be
-	// mistaken for the close of an enclosing subshell. It is not a block, so it
-	// never suppresses rewriting.
+	// blockParen is an unquoted '(' that does not open a subshell because it is
+	// not in command position: an array assignment ("arr=(a b)"), an extglob
+	// pattern ("@(a|b)"), or the inner parens of an arithmetic command
+	// ("((x = 1))"). It is pushed only so its matching ')' is consumed and
+	// cannot be mistaken for the close of an enclosing subshell. It is not a
+	// block, so it never suppresses rewriting.
 	blockParen blockKind = iota
 	blockSubshell
 	blockBrace // { ... } group or function body
@@ -34,19 +35,44 @@ const (
 // the body — never protected the body. It was wrapped, and the consumer read
 // snip's compacted view instead of the real output (issue #133, bug A).
 //
-// The rule is one sentence: nothing inside a block is ever rewritten. It is a
-// stack over machinery that already exists, not a shell parser, and every
-// misdetection costs filtering rather than correctness — an unmatched opener
-// pins the scope open and the remainder is simply passed through raw. Consumer
-// propagation (resolving which block a trailing pipe belongs to and rewriting
-// the bodies that have no consumer) would recover more savings, but its failure
-// mode is wrong output, not lost savings, and this hook path prefers the
-// opposite trade (see the #127 process-substitution fix).
+// The rule the code implements is: nothing inside a block it detects is ever
+// rewritten. It is a stack over machinery that already exists, not a shell
+// parser, so the honest contract is narrower than that sentence alone:
+//
+//   - What opens a block: the reserved words `if`, `while`, `until`, `for`,
+//     `select` and `case`; a '{' standing alone as a word in command position
+//     (which is how a function body opens, both `NAME() {` and `function NAME {`
+//     — the header only puts that '{' in command position); and a '(' in command
+//     position, whatever follows it (`((` is arithmetic and pushes no block).
+//     What closes one: `fi`, `done`, `esac`, a '}' in command position, and the
+//     ')' matching a '(' — recognised where it occurs, not only at the end of a
+//     group, and never on a case-arm pattern ("  a )"). Reserved words count
+//     only in command position and comments are skipped whole, so neither
+//     `echo done` nor `# done` closes anything.
+//   - A missed opener costs correctness, not just savings: the body is rewritten
+//     and a consumer of the block reads snip's compacted output. Every opener
+//     above is therefore matched on the shell's own rule (command position),
+//     never on a heuristic about what follows it.
+//   - A spurious opener, and any unmatched opener, costs filtering only: the
+//     scope stays open and the remainder of the command is passed through raw.
+//     `closeKeyword` bounds that to the enclosing block by dropping stray
+//     blockParen entries, so one malformed group cannot disable filtering for
+//     the whole message.
+//   - Not covered, by construction: line continuations (a trailing backslash is
+//     a group boundary here but not for the shell), and consumer propagation —
+//     deciding that a block's output has no consumer and rewriting its body
+//     anyway. The latter is why `(cd sub && go test ./...)` is no longer
+//     filtered: resolving which block a trailing pipe belongs to fails towards
+//     wrong output, and this hook path prefers the opposite trade (see the #127
+//     process-substitution fix).
 type blockScope struct {
 	stack []blockKind
 	// blocks is the number of stack entries that are not blockParen, i.e. how
 	// many real compound commands are open.
 	blocks int
+	// funcName is set between the `function` reserved word and the name that
+	// follows it, so the '{' after the name is still seen in command position.
+	funcName bool
 }
 
 // inBlock reports whether the group being flushed sits inside a compound
@@ -116,6 +142,19 @@ func (s *blockScope) advance(group string) {
 			// '&' here belongs to a form like "2>&1".
 			i++
 			cmdPos = false
+		case '#':
+			if !isWordStart(group, i) {
+				// Not a comment: '#' can follow a quoted region inside one word
+				// (`"x"#y`). The only way to land here is just past a closing
+				// quote, which already cleared cmdPos.
+				i++
+				continue
+			}
+			// A comment runs to the end of the line and holds no command, so no
+			// reserved word in it may open or close a block. The segmenter ends
+			// the group at that newline (a ';' inside a comment is not a
+			// boundary), so the comment always runs to the end of the group.
+			return
 		case '(':
 			i, cmdPos = s.openParen(group, i, cmdPos)
 		case ')':
@@ -162,15 +201,10 @@ func (s *blockScope) advance(group string) {
 // openParen handles an unquoted '(' and returns the next index and the command
 // position that follows it.
 func (s *blockScope) openParen(group string, i int, cmdPos bool) (int, bool) {
-	// A subshell only when '(' stands alone as a word, so "(cd sub && go test
-	// ./...)" and "((x = 1))" are not read as subshell openers and keep being
-	// filtered exactly as on master.
-	if cmdPos && (i+1 >= len(group) || isTokenBreak(group[i+1])) {
-		s.push(blockSubshell)
-		return i + 1, true
-	}
-	// "name()" — a function header. The body's '{' that follows is in command
-	// position even though a word ("deploy") came before it.
+	// "name()" / "function name ()" — a function header. The body's '{' that
+	// follows is in command position even though a word (the name) came before
+	// it. An empty "()" is never a subshell: the shell rejects "( )" as a syntax
+	// error, so this check is safe in command position too.
 	j := i + 1
 	for j < len(group) && (group[j] == ' ' || group[j] == '\t') {
 		j++
@@ -178,6 +212,26 @@ func (s *blockScope) openParen(group string, i int, cmdPos bool) (int, bool) {
 	if j < len(group) && group[j] == ')' {
 		return j + 1, true
 	}
+
+	if cmdPos {
+		// "((expr))" is an arithmetic command, not a subshell: the two parens
+		// are pushed as plain parens so the matching "))" consumes them without
+		// ever suppressing rewriting. Bash tells the two apart by adjacency, so
+		// "( (a) )" below is still nested subshells.
+		if i+1 < len(group) && group[i+1] == '(' {
+			s.push(blockParen)
+			s.push(blockParen)
+			return i + 2, false
+		}
+		// Every other '(' in command position opens a subshell, whatever
+		// follows it. Requiring '(' to stand alone as a word missed
+		// "(cd sub && go test ./...; echo x) | wc -l": the subshell spans three
+		// groups, the `go test` group has no consumer of its own, and it was
+		// wrapped while `wc -l` counted the whole subshell.
+		s.push(blockSubshell)
+		return i + 1, true
+	}
+
 	s.push(blockParen)
 	return i + 1, false
 }
@@ -189,7 +243,18 @@ func (s *blockScope) classify(word string, cmdPos bool) bool {
 	if !cmdPos {
 		return false
 	}
+	if s.funcName {
+		// The word after `function` is the name being defined, not a command.
+		// The body's '{' comes right after it and must be seen in command
+		// position, otherwise `function findall {` opens nothing and the body
+		// is rewritten (the ksh/bash spelling of `findall() {`).
+		s.funcName = false
+		return true
+	}
 	switch word {
+	case "function":
+		s.funcName = true
+		return true
 	case "if":
 		s.push(blockCond)
 		return true // "if grep -q x f": a command follows

--- a/internal/hook/blockscope.go
+++ b/internal/hook/blockscope.go
@@ -49,6 +49,17 @@ const (
 //     group, and never on a case-arm pattern ("  a )"). Reserved words count
 //     only in command position and comments are skipped whole, so neither
 //     `echo done` nor `# done` closes anything.
+//   - Command position is approximated, not decided the way the shell does, and
+//     four shapes are known to fool it. A case-arm pattern that is itself a
+//     reserved word (`case $s in done)`) is read as a command and closes the
+//     case. An extglob alternative does the same, because '|' is treated as a
+//     pipeline separator everywhere (`for f in @(data|done).txt`). `time -p`
+//     loses the opener that follows it, since only bare `time` is whitelisted.
+//     And a '#' written flush against a ')' is not seen as a comment, because
+//     isWordStart does not count ')' as a word boundary (`a)# done marker`).
+//     All four are pre-existing: they corrupt identically on master, which has
+//     no block tracking at all, so this file narrows the defect rather than
+//     introducing it. Tracked separately.
 //   - A missed opener costs correctness, not just savings: the body is rewritten
 //     and a consumer of the block reads snip's compacted output. Every opener
 //     above is therefore matched on the shell's own rule (command position),

--- a/internal/hook/blockscope_test.go
+++ b/internal/hook/blockscope_test.go
@@ -105,6 +105,56 @@ func TestRewriteBlockScope(t *testing.T) {
 			allKnown: false,
 		},
 		{
+			// Same arm spelled with a blank before the closing paren. A depth
+			// counter that reads a trailing spaced ')' as a subshell close pops
+			// the case back to top level here and re-wraps the arm body, which is
+			// the exact corruption #133 reports (raw 60 matches, rewritten 51).
+			// Only the KIND of the innermost open block tells the two apart.
+			name:     "case pattern spaced before paren",
+			cmd:      "case $x in\n  a )\n    grep reason f\n    ;;\nesac | wc -l",
+			want:     "case $x in\n  a )\n    grep reason f\n    ;;\nesac | wc -l",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			name:     "multi pattern case arm",
+			cmd:      "case $1 in\n  -v | --verbose )\n    go test ./...\n    grep x f\n    ;;\nesac > out.txt",
+			want:     "case $1 in\n  -v | --verbose )\n    go test ./...\n    grep x f\n    ;;\nesac > out.txt",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			// Several arms in a row: every pattern line closes nothing, so the
+			// case block stays open until `esac`.
+			name:     "several case arms stay inside the block",
+			cmd:      "case $1 in\n  a )\n    go test ./...\n    ;;\n  b)\n    grep x f\n    ;;\nesac | wc -l",
+			want:     "case $1 in\n  a )\n    go test ./...\n    ;;\n  b)\n    grep x f\n    ;;\nesac | wc -l",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			// A real subshell inside a case arm still closes on its own ')'.
+			name:     "subshell inside a case arm",
+			cmd:      "case $1 in\n  a )\n    ( go test ./... )\n    ;;\nesac | wc -l\ngo build ./...",
+			want:     "case $1 in\n  a )\n    ( go test ./... )\n    ;;\nesac | wc -l\n" + `"/usr/local/bin/snip" run -- go build ./...`,
+			changed:  true,
+			allKnown: false,
+		},
+		{
+			name:     "select loop body",
+			cmd:      "select f in a b\ndo\n  grep x $f\ndone | wc -l",
+			want:     "select f in a b\ndo\n  grep x $f\ndone | wc -l",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			name:     "until loop body",
+			cmd:      "until grep -q x f\ndo\n  go build ./...\n  grep y f\ndone > out.txt",
+			want:     "until grep -q x f\ndo\n  go build ./...\n  grep y f\ndone > out.txt",
+			changed:  false,
+			allKnown: false,
+		},
+		{
 			// Nested blocks must unwind back to top level.
 			name:     "nested blocks unwind",
 			cmd:      "for f in *\ndo\n  if true; then\n    grep x $f\n  fi\ndone | wc -l\ngo test ./...",
@@ -144,6 +194,92 @@ func TestRewriteBlockScope(t *testing.T) {
 			name:     "spaced one line subshell balanced",
 			cmd:      "( go build ./... )\ngo test ./...",
 			want:     "( go build ./... )\n" + `"/usr/local/bin/snip" run -- go test ./...`,
+			changed:  true,
+			allKnown: false,
+		},
+		{
+			// The close must be recognised where the ')' actually is, not only at
+			// the end of the group. A trailing redirect after the closer used to
+			// pin the depth above zero for the rest of the command, silently
+			// disabling filtering for every later top-level command.
+			name:     "subshell closed before a redirect",
+			cmd:      "( cd sub && go build ./... ) > out.txt\ngo test ./...",
+			want:     "( cd sub && go build ./... ) > out.txt\n" + `"/usr/local/bin/snip" run -- go test ./...`,
+			changed:  true,
+			allKnown: false,
+		},
+		{
+			name:     "subshell closed before a pipe",
+			cmd:      "( cd sub && go build ./... ) | tee log\ngo test ./...",
+			want:     "( cd sub && go build ./... ) | tee log\n" + `"/usr/local/bin/snip" run -- go test ./...`,
+			changed:  true,
+			allKnown: false,
+		},
+		{
+			name:     "subshell closed with no space before paren",
+			cmd:      "( go build ./...)\ngo test ./...",
+			want:     "( go build ./...)\n" + `"/usr/local/bin/snip" run -- go test ./...`,
+			changed:  true,
+			allKnown: false,
+		},
+		{
+			// Body groups of the subshell stay raw while it is open.
+			name:     "subshell body stays raw until the closer",
+			cmd:      "( cd sub && go build ./... ) > out.txt",
+			want:     "( cd sub && go build ./... ) > out.txt",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			// An array assignment inside a subshell must not close it: its ')'
+			// is matched by the '(' of the assignment, not by the subshell's.
+			name:     "array assignment inside a subshell does not close it",
+			cmd:      "(\n  arr=(a b)\n  go test ./...\n) | wc -l\ngo build ./...",
+			want:     "(\n  arr=(a b)\n  go test ./...\n) | wc -l\n" + `"/usr/local/bin/snip" run -- go build ./...`,
+			changed:  true,
+			allKnown: false,
+		},
+		{
+			// A quoted ')' is not a closer. Quotes must be skipped, not merely
+			// stepped over.
+			name:     "quoted paren inside a subshell does not close it",
+			cmd:      "(\n  grep -c ')' f\n  go test ./...\n) | wc -l\ngo build ./...",
+			want:     "(\n  grep -c ')' f\n  go test ./...\n) | wc -l\n" + `"/usr/local/bin/snip" run -- go build ./...`,
+			changed:  true,
+			allKnown: false,
+		},
+		{
+			// A closing keyword is only a keyword in command position: "echo
+			// done" inside a loop body must not close the loop.
+			name:     "closer keyword as an argument inside a block",
+			cmd:      "for f in *.go\ndo\n  echo done\n  go test $f\ndone | wc -l",
+			want:     "for f in *.go\ndo\n  echo done\n  go test $f\ndone | wc -l",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			// A redirect target is never a command, so it is never a keyword
+			// either — even when the file is named after one.
+			name:     "closer keyword as a redirect target inside a block",
+			cmd:      "for f in *.go\ndo\n  echo $f > done\n  go test $f\ndone | wc -l",
+			want:     "for f in *.go\ndo\n  echo $f > done\n  go test $f\ndone | wc -l",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			// "time" introduces another command position, so the loop behind it
+			// is still seen as an opener.
+			name:     "time before a loop still opens the block",
+			cmd:      "time for f in *.go; do echo $f; go test $f; done | wc -l",
+			want:     "time for f in *.go; do echo $f; go test $f; done | wc -l",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			// A function header spelled on its own line still opens its body.
+			name:     "function header then brace group",
+			cmd:      "deploy() {\n  go build ./...\n}\ngo test ./...",
+			want:     "deploy() {\n  go build ./...\n}\n" + `"/usr/local/bin/snip" run -- go test ./...`,
 			changed:  true,
 			allKnown: false,
 		},
@@ -230,6 +366,80 @@ func TestRewriteHeredoc(t *testing.T) {
 			cmd:      "ssh host <<EOF\nrm -rf /\nEOF",
 			want:     "ssh host <<EOF\nrm -rf /\nEOF",
 			changed:  false,
+			allKnown: false,
+		},
+		{
+			// Terminator matching must be pinned by what comes AFTER the heredoc:
+			// every way of breaking it degrades to "swallow the rest of the
+			// command", which is output-identical to the correct path unless a
+			// later command is asserted on. Quoted delimiter: the terminator line
+			// is the UNQUOTED word, so the quotes must be stripped when parsing.
+			name:     "quoted delimiter then command still filtered",
+			cmd:      "cat > Makefile <<'EOF'\ntest:\n\tgo test ./...\nEOF\ngo build ./...",
+			want:     "cat > Makefile <<'EOF'\ntest:\n\tgo test ./...\nEOF\n" + `"/usr/local/bin/snip" run -- go build ./...`,
+			changed:  true,
+			allKnown: false,
+		},
+		{
+			name:     "double quoted delimiter then command still filtered",
+			cmd:      "cat <<\"EOF\"\ngo test ./...\nEOF\ngo build ./...",
+			want:     "cat <<\"EOF\"\ngo test ./...\nEOF\n" + `"/usr/local/bin/snip" run -- go build ./...`,
+			changed:  true,
+			allKnown: false,
+		},
+		{
+			// Backslash-escaped delimiter: \EOF also names EOF.
+			name:     "escaped delimiter then command still filtered",
+			cmd:      "cat <<\\EOF\ngo test ./...\nEOF\ngo build ./...",
+			want:     "cat <<\\EOF\ngo test ./...\nEOF\n" + `"/usr/local/bin/snip" run -- go build ./...`,
+			changed:  true,
+			allKnown: false,
+		},
+		{
+			// <<- strips leading TABS from the terminator line before comparing.
+			name:     "tab stripped delimiter then command still filtered",
+			cmd:      "cat <<-EOF\n\tgo test ./...\n\tEOF\ngo build ./...",
+			want:     "cat <<-EOF\n\tgo test ./...\n\tEOF\n" + `"/usr/local/bin/snip" run -- go build ./...`,
+			changed:  true,
+			allKnown: false,
+		},
+		{
+			// Without <<-, an indented terminator is NOT a terminator: bash wants
+			// an exact match, so the rest of the command is part of the body.
+			name:     "indented terminator without dash does not terminate",
+			cmd:      "cat <<EOF\ngo test ./...\n\tEOF\ngo build ./...",
+			want:     "cat <<EOF\ngo test ./...\n\tEOF\ngo build ./...",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			// Two heredocs: the second body must start after the FIRST terminator,
+			// otherwise the trailing command is swallowed.
+			name:     "two heredocs then command still filtered",
+			cmd:      "cat <<A <<B\ngo build ./...\nA\ngo vet ./...\nB\ngo test ./...",
+			want:     "cat <<A <<B\ngo build ./...\nA\ngo vet ./...\nB\n" + `"/usr/local/bin/snip" run -- go test ./...`,
+			changed:  true,
+			allKnown: false,
+		},
+		{
+			// An arithmetic command and a heredoc on the same line: the "))"
+			// must end the arithmetic context so the '<<' that follows is read
+			// as a heredoc operator again.
+			name:     "heredoc after an arithmetic command on the same line",
+			cmd:      "((x = 1 << n)) && cat <<EOF\ngo test ./...\nEOF\ngo build ./...",
+			want:     "((x = 1 << n)) && cat <<EOF\ngo test ./...\nEOF\n" + `"/usr/local/bin/snip" run -- go build ./...`,
+			changed:  true,
+			allKnown: false,
+		},
+		{
+			// A '#' that is not at word start does not open a comment, so the
+			// heredoc here is armed and its body is not rewritten. If it were
+			// read as a comment the heredoc would be missed and `go test ./...`
+			// on the next line would be wrapped.
+			name:     "hash inside a word does not suppress the heredoc",
+			cmd:      "cat > notes#1.md <<EOF\ngo test ./...\nEOF\ngo build ./...",
+			want:     "cat > notes#1.md <<EOF\ngo test ./...\nEOF\n" + `"/usr/local/bin/snip" run -- go build ./...`,
+			changed:  true,
 			allKnown: false,
 		},
 		{
@@ -325,6 +535,29 @@ func TestRewriteNoFalsePositives(t *testing.T) {
 			name: "arithmetic shift is not a heredoc",
 			cmd:  "((x = 1 << 2))\ngo test ./...",
 			want: "((x = 1 << 2))\n" + w + "go test ./...",
+		},
+		{
+			// Same, with a variable right operand: the delimiter would be "n",
+			// which no all-digit guard can reject. Arithmetic is recognised by
+			// its "((" instead.
+			name: "arithmetic shift by a variable is not a heredoc",
+			cmd:  "((x = 1 << n))\ngo test ./...",
+			want: "((x = 1 << n))\n" + w + "go test ./...",
+		},
+		{
+			// The arithmetic suppression is scoped to its line: an unbalanced
+			// "((" must not disarm heredoc detection for the rest of the
+			// command, or a heredoc body further down would be rewritten.
+			name: "unbalanced arithmetic does not disarm later heredocs",
+			cmd:  "((x = 1 << n\ncat <<EOF\ngo vet ./...\nEOF\ngo test ./...",
+			want: "((x = 1 << n\ncat <<EOF\ngo vet ./...\nEOF\n" + w + "go test ./...",
+		},
+		{
+			// A bare "<<" has no delimiter and is not a heredoc: arming one
+			// would swallow every following command.
+			name: "bare shift operator is not a heredoc",
+			cmd:  "go build ./... <<\ngo test ./...",
+			want: w + "go build ./... <<\n" + w + "go test ./...",
 		},
 		{
 			// '<<' inside a comment is not a heredoc operator either.

--- a/internal/hook/blockscope_test.go
+++ b/internal/hook/blockscope_test.go
@@ -173,20 +173,46 @@ func TestRewriteBlockScope(t *testing.T) {
 			allKnown: false,
 		},
 		{
-			// One-line subshell: `(` is only an opener as a standalone word, so
-			// this keeps behaving exactly as on master (the trailing group is
-			// still guarded by the existing per-group #111 check).
-			name:     "one line subshell still filtered",
+			// A '(' in command position opens a subshell whatever follows it, so
+			// the body is raw even on one line. Wrapping it was safe only while
+			// the whole subshell fitted in ONE group: the previous rule read
+			// "(cd sub" as a non-opener and relied on the per-group #111 check,
+			// which the next case defeats with a single ';'. The cost is real —
+			// this shape is no longer filtered — and it is the price of never
+			// feeding a consumer snip's compacted output.
+			name:     "one line subshell stays raw",
 			cmd:      "(cd sub && go test ./...)",
-			want:     `(cd sub && "/usr/local/bin/snip" run -- go test ./...)`,
-			changed:  true,
+			want:     "(cd sub && go test ./...)",
+			changed:  false,
 			allKnown: false,
 		},
 		{
-			name:     "one line subshell piped stays raw",
-			cmd:      "(cd sub && go test ./...) | wc -l",
-			want:     "(cd sub && go test ./...) | wc -l",
+			// The gap the old "one line subshell piped stays raw" case hid: with
+			// a ';' inside the parens the subshell spans three groups, the
+			// `go test` group has no pipe of its own, and the per-group #111
+			// check cannot see the `| wc -l` that consumes the whole subshell.
+			// Raw prints 61 lines, the wrapped form printed 52.
+			name:     "one line subshell with an inner semicolon piped stays raw",
+			cmd:      "(cd sub && go test ./...; echo x) | wc -l",
+			want:     "(cd sub && go test ./...; echo x) | wc -l",
 			changed:  false,
+			allKnown: false,
+		},
+		{
+			name:     "one line subshell with an inner semicolon redirected stays raw",
+			cmd:      "(cd sub && grep -c x f; echo x) > out.txt",
+			want:     "(cd sub && grep -c x f; echo x) > out.txt",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			// The subshell closes where its ')' is, so a sibling command after it
+			// is filtered again: the blast radius is the subshell, not the rest
+			// of the message.
+			name:     "command after a one line subshell keeps filtering",
+			cmd:      "(cd sub && go build ./...; echo x) | wc -l\ngo test ./...",
+			want:     "(cd sub && go build ./...; echo x) | wc -l\n" + `"/usr/local/bin/snip" run -- go test ./...`,
+			changed:  true,
 			allKnown: false,
 		},
 		{
@@ -240,6 +266,25 @@ func TestRewriteBlockScope(t *testing.T) {
 			allKnown: false,
 		},
 		{
+			// Same for an arithmetic command: its "))" is matched by its own
+			// "((", so it must not close the subshell it sits in.
+			name:     "arithmetic command inside a subshell does not close it",
+			cmd:      "(\n  ((x = 1))\n  go test ./...\n) | wc -l\ngo build ./...",
+			want:     "(\n  ((x = 1))\n  go test ./...\n) | wc -l\n" + `"/usr/local/bin/snip" run -- go build ./...`,
+			changed:  true,
+			allKnown: false,
+		},
+		{
+			// Inside "((...))" the words are an arithmetic expression, not
+			// commands, so a variable named after a reserved word must not close
+			// the loop that a counting idiom like this lives in.
+			name:     "arithmetic on a variable named done does not close the loop",
+			cmd:      "for f in *.txt\ndo\n  ((done = done + 1))\n  grep MATCH $f\ndone | wc -l",
+			want:     "for f in *.txt\ndo\n  ((done = done + 1))\n  grep MATCH $f\ndone | wc -l",
+			changed:  false,
+			allKnown: false,
+		},
+		{
 			// A quoted ')' is not a closer. Quotes must be skipped, not merely
 			// stepped over.
 			name:     "quoted paren inside a subshell does not close it",
@@ -280,6 +325,147 @@ func TestRewriteBlockScope(t *testing.T) {
 			name:     "function header then brace group",
 			cmd:      "deploy() {\n  go build ./...\n}\ngo test ./...",
 			want:     "deploy() {\n  go build ./...\n}\n" + `"/usr/local/bin/snip" run -- go test ./...`,
+			changed:  true,
+			allKnown: false,
+		},
+		{
+			// The ksh/bash `function NAME {` spelling has no parentheses, so
+			// nothing before the '{' put it in command position and the body was
+			// rewritten: `findall | wc -l` then counted snip's capped output
+			// (51) instead of the 60 real matches.
+			name:     "function keyword without parens piped",
+			cmd:      "function findall {\n  grep MATCH data.txt\n}\nfindall | wc -l",
+			want:     "function findall {\n  grep MATCH data.txt\n}\nfindall | wc -l",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			name:     "function keyword without parens redirected",
+			cmd:      "function findall {\n  grep MATCH data.txt\n}\nfindall > out.txt",
+			want:     "function findall {\n  grep MATCH data.txt\n}\nfindall > out.txt",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			// Same on a single line, where the body is a group of its own.
+			name:     "function keyword without parens on one line",
+			cmd:      "function findall { grep MATCH f; }\nfindall | wc -l",
+			want:     "function findall { grep MATCH f; }\nfindall | wc -l",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			// The redundant `function NAME()` spelling keeps working, and the
+			// body still closes so the next command is filtered again.
+			name:     "function keyword with parens closes its body",
+			cmd:      "function deploy() {\n  go build ./...\n}\ngo test ./...",
+			want:     "function deploy() {\n  go build ./...\n}\n" + `"/usr/local/bin/snip" run -- go test ./...`,
+			changed:  true,
+			allKnown: false,
+		},
+		{
+			name:     "function keyword without parens closes its body",
+			cmd:      "function deploy {\n  go build ./...\n}\ngo test ./...",
+			want:     "function deploy {\n  go build ./...\n}\n" + `"/usr/local/bin/snip" run -- go test ./...`,
+			changed:  true,
+			allKnown: false,
+		},
+		{
+			// The `function` name must be consumed once and only once: a state
+			// that is never cleared would swallow the `for` below as if it were
+			// a function name, and the loop body would be rewritten.
+			name:     "loop after a function definition still opens",
+			cmd:      "function deploy {\n  go build ./...\n}\nfor f in *.txt\ndo\n  grep MATCH $f\ndone | wc -l",
+			want:     "function deploy {\n  go build ./...\n}\nfor f in *.txt\ndo\n  grep MATCH $f\ndone | wc -l",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			// A ';' inside a comment is not a group boundary, so the words after
+			// it are still comment text. Reading them as a new command position
+			// let `done` close the live loop and the rest of the body was
+			// rewritten: `wc -l` counted 51 instead of 60.
+			name:     "comment containing a semicolon and a closer",
+			cmd:      "for f in 1; do\n  : # count matches; done below\n  grep MATCH data.txt\ndone | wc -l",
+			want:     "for f in 1; do\n  : # count matches; done below\n  grep MATCH data.txt\ndone | wc -l",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			// Same for the other boundaries the splitter honours.
+			name:     "comment containing && and a closer",
+			cmd:      "for f in 1; do\n  : # check && done\n  grep MATCH data.txt\ndone | wc -l",
+			want:     "for f in 1; do\n  : # check && done\n  grep MATCH data.txt\ndone | wc -l",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			name:     "comment containing || and a closer",
+			cmd:      "for f in 1; do\n  : # check || esac fi done\n  grep MATCH data.txt\ndone | wc -l",
+			want:     "for f in 1; do\n  : # check || esac fi done\n  grep MATCH data.txt\ndone | wc -l",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			// A comment cannot open a block either, so the command after it is
+			// still filtered.
+			name:     "comment containing an opener does not open a block",
+			cmd:      "echo a # for f in *; do\ngo test ./...",
+			want:     "echo a # for f in *; do\n" + `"/usr/local/bin/snip" run -- go test ./...`,
+			changed:  true,
+			allKnown: false,
+		},
+		{
+			// A command spelled inside a comment never runs, so it is not
+			// rewritten either. This differs from master, which split the
+			// comment at the ';' and wrapped its tail — harmless there, but the
+			// same split is what corrupted the loop above.
+			name:     "command inside a comment is not rewritten",
+			cmd:      "echo a # go test ./...; go build ./...",
+			want:     "echo a # go test ./...; go build ./...",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			// A '#' glued to a closing quote stays inside the word, exactly as
+			// the shell reads it. Treating it as a comment would hide the
+			// `while` behind it and the loop body would be rewritten. This is
+			// the only shape that reaches the check: a '#' anywhere else in a
+			// word is swallowed by the word scan.
+			name:     "hash right after a quoted word is not a comment",
+			cmd:      "grep -c \"x\"#tag f | while read -r l\ndo\n  grep MATCH data.txt\ndone | wc -l",
+			want:     "grep -c \"x\"#tag f | while read -r l\ndo\n  grep MATCH data.txt\ndone | wc -l",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			// A block nested in a subshell: the word right after '(' is in
+			// command position, so `for` opens a loop of its own. If it did not,
+			// `done` would close the SUBSHELL instead and everything after it
+			// inside the parens would be rewritten while `wc -l` counts the lot.
+			name:     "loop nested in a one line subshell closes the loop not the subshell",
+			cmd:      "(for f in *.txt; do grep MATCH $f; done; grep MATCH data.txt; echo x) | wc -l",
+			want:     "(for f in *.txt; do grep MATCH $f; done; grep MATCH data.txt; echo x) | wc -l",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			// A '#' that is not at word start is ordinary text, so this is a
+			// real command and stays filtered.
+			name:     "hash inside a word is not a comment",
+			cmd:      "go test ./... > notes#1.md\ngo build ./...",
+			want:     "go test ./... > notes#1.md\n" + `"/usr/local/bin/snip" run -- go build ./...`,
+			changed:  true,
+			allKnown: true,
+		},
+		{
+			// Graceful degradation: a malformed command with an unmatched '(' is
+			// still handed to the hook, and its stray paren must not pin the
+			// loop open forever — the closing keyword drops it and filtering
+			// resumes after the block.
+			name:     "stray open paren inside a block does not survive its closer",
+			cmd:      "for f in *.go\ndo\n  echo a(b\ndone\ngo test ./...",
+			want:     "for f in *.go\ndo\n  echo a(b\ndone\n" + `"/usr/local/bin/snip" run -- go test ./...`,
 			changed:  true,
 			allKnown: false,
 		},
@@ -525,9 +711,22 @@ func TestRewriteNoFalsePositives(t *testing.T) {
 			want: "mkdir -p x/{p,q}\n" + w + "go test ./...",
 		},
 		{
+			// The '(' here is not in command position (the assignment word came
+			// first), so it opens no subshell and the next line keeps filtering.
 			name: "array assignment is not a subshell",
 			cmd:  "arr=(a b)\ngo test ./...",
 			want: "arr=(a b)\n" + w + "go test ./...",
+		},
+		{
+			name: "three element array assignment is not a subshell",
+			cmd:  "arr=(a b c)\ngo test ./...",
+			want: "arr=(a b c)\n" + w + "go test ./...",
+		},
+		{
+			// "((" in command position is an arithmetic command, not a subshell.
+			name: "arithmetic command is not a subshell",
+			cmd:  "((x = 1 + 2))\ngo test ./...",
+			want: "((x = 1 + 2))\n" + w + "go test ./...",
 		},
 		{
 			// A bare arithmetic command must not arm a phantom heredoc whose

--- a/internal/hook/blockscope_test.go
+++ b/internal/hook/blockscope_test.go
@@ -1,0 +1,350 @@
+package hook
+
+import "testing"
+
+// TestRewriteBlockScope pins issue #133 bug A: the segmenter splits on top-level
+// ';', '&&', '||', '&' and '\n' with no notion of block structure, so a loop or
+// conditional body becomes an ordinary group and gets wrapped. The #111 guard
+// (never wrap a producer whose output feeds a pipe or a redirect) only inspects
+// the group it is in, and `done | wc -l` / `done > out.txt` sit in a different
+// group from the body, so the body was wrapped and the consumer silently read
+// snip's compacted view instead of the real output.
+func TestRewriteBlockScope(t *testing.T) {
+	const bin = "/usr/local/bin/snip"
+	cmdSet := map[string]struct{}{"git": {}, "go": {}, "grep": {}, "wc": {}}
+
+	cases := []struct {
+		name     string
+		cmd      string
+		want     string
+		changed  bool
+		allKnown bool
+	}{
+		{
+			// Bug A, the reported form: the body must stay raw so `wc -l` counts
+			// the real matches (60), not the 50 that filters/grep.yaml caps at.
+			name:     "multiline loop piped to consumer",
+			cmd:      "for f in *.yaml\ndo\n  grep reason $f\ndone | wc -l",
+			want:     "for f in *.yaml\ndo\n  grep reason $f\ndone | wc -l",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			name:     "multiline loop redirected to file",
+			cmd:      "for f in *.yaml\ndo\n  grep reason $f\ndone > out.txt",
+			want:     "for f in *.yaml\ndo\n  grep reason $f\ndone > out.txt",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			// Bug A in its SINGLE-LINE form: a second body command exposes the
+			// body to rewriting, and the naive newline-armed guard misses it.
+			name:     "single line loop with two body commands piped",
+			cmd:      "for f in *.go; do echo $f; wc -l $f; done | sort -n",
+			want:     "for f in *.go; do echo $f; wc -l $f; done | sort -n",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			name:     "single line loop with two body commands redirected",
+			cmd:      "for f in *.yaml; do echo start; grep x $f; done > out.txt",
+			want:     "for f in *.yaml; do echo start; grep x $f; done > out.txt",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			// The closing keyword glued to its operator must still be recognised.
+			name:     "closer glued to pipe",
+			cmd:      "for f in *.go\ndo\n  grep x $f\ndone|wc -l",
+			want:     "for f in *.go\ndo\n  grep x $f\ndone|wc -l",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			// The block opener may sit behind a pipe stage: `|` is a command
+			// position too, so `while` still opens a block here.
+			name:     "opener behind a pipe stage",
+			cmd:      "cat list | while read -r l\ndo\n  grep x $l\n  go test $l\ndone | wc -l",
+			want:     "cat list | while read -r l\ndo\n  grep x $l\n  go test $l\ndone | wc -l",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			name:     "if then fi body",
+			cmd:      "if grep -q foo a.txt; then\n  go test ./...\n  grep x b.txt\nfi > out.txt",
+			want:     "if grep -q foo a.txt; then\n  go test ./...\n  grep x b.txt\nfi > out.txt",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			name:     "brace group redirected",
+			cmd:      "{ echo a\n  go test ./...\n} > out.txt",
+			want:     "{ echo a\n  go test ./...\n} > out.txt",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			name:     "multiline subshell piped",
+			cmd:      "(\n  go test ./...\n) | tee log",
+			want:     "(\n  go test ./...\n) | tee log",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			name:     "function body",
+			cmd:      "deploy() {\n  go build ./...\n  git status\n}",
+			want:     "deploy() {\n  go build ./...\n  git status\n}",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			name:     "case esac body",
+			cmd:      "case $1 in\n  a)\n    go test ./...\n    ;;\nesac | wc -l",
+			want:     "case $1 in\n  a)\n    go test ./...\n    ;;\nesac | wc -l",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			// Nested blocks must unwind back to top level.
+			name:     "nested blocks unwind",
+			cmd:      "for f in *\ndo\n  if true; then\n    grep x $f\n  fi\ndone | wc -l\ngo test ./...",
+			want:     "for f in *\ndo\n  if true; then\n    grep x $f\n  fi\ndone | wc -l\n" + `"/usr/local/bin/snip" run -- go test ./...`,
+			changed:  true,
+			allKnown: false,
+		},
+		{
+			// Blast radius is the block, not the whole command: a sibling
+			// top-level command keeps its filtering. This is what the rejected
+			// whole-command guard could not do.
+			name:     "sibling top level command keeps filtering",
+			cmd:      "go test ./...\nfor f in *.go\ndo\n  echo $f\n  grep x $f\ndone\ngit status",
+			want:     `"/usr/local/bin/snip" run -- go test ./...` + "\nfor f in *.go\ndo\n  echo $f\n  grep x $f\ndone\n" + `"/usr/local/bin/snip" run -- git status`,
+			changed:  true,
+			allKnown: false,
+		},
+		{
+			// One-line subshell: `(` is only an opener as a standalone word, so
+			// this keeps behaving exactly as on master (the trailing group is
+			// still guarded by the existing per-group #111 check).
+			name:     "one line subshell still filtered",
+			cmd:      "(cd sub && go test ./...)",
+			want:     `(cd sub && "/usr/local/bin/snip" run -- go test ./...)`,
+			changed:  true,
+			allKnown: false,
+		},
+		{
+			name:     "one line subshell piped stays raw",
+			cmd:      "(cd sub && go test ./...) | wc -l",
+			want:     "(cd sub && go test ./...) | wc -l",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			// Balanced spaced subshell: opens and closes within one group.
+			name:     "spaced one line subshell balanced",
+			cmd:      "( go build ./... )\ngo test ./...",
+			want:     "( go build ./... )\n" + `"/usr/local/bin/snip" run -- go test ./...`,
+			changed:  true,
+			allKnown: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := RewriteCommand(tc.cmd, cmdSet, nil, bin)
+			if res.Command != tc.want {
+				t.Errorf("Command = %q, want %q", res.Command, tc.want)
+			}
+			if res.Changed != tc.changed {
+				t.Errorf("Changed = %v, want %v", res.Changed, tc.changed)
+			}
+			if res.AllKnown != tc.allKnown {
+				t.Errorf("AllKnown = %v, want %v", res.AllKnown, tc.allKnown)
+			}
+		})
+	}
+}
+
+// TestRewriteHeredoc pins issue #133 bug B: heredoc bodies are literal text the
+// command writes, not commands to run. Rewriting them corrupts the file an agent
+// is writing (a Makefile, a CI config, a shell script).
+func TestRewriteHeredoc(t *testing.T) {
+	const bin = "/usr/local/bin/snip"
+	cmdSet := map[string]struct{}{"git": {}, "go": {}, "grep": {}, "ssh": {}}
+
+	cases := []struct {
+		name     string
+		cmd      string
+		want     string
+		changed  bool
+		allKnown bool
+	}{
+		{
+			name:     "body is literal text",
+			cmd:      "cat <<EOF\ngo test ./...\nEOF",
+			want:     "cat <<EOF\ngo test ./...\nEOF",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			name:     "quoted delimiter",
+			cmd:      "cat > Makefile <<'EOF'\ntest:\n\tgo test ./...\nEOF",
+			want:     "cat > Makefile <<'EOF'\ntest:\n\tgo test ./...\nEOF",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			name:     "tab stripped delimiter",
+			cmd:      "cat <<-EOF\n\tgo test ./...\n\tEOF",
+			want:     "cat <<-EOF\n\tgo test ./...\n\tEOF",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			name:     "two heredocs on one line",
+			cmd:      "cat <<A <<B\ngo build ./...\nA\ngo vet ./...\nB",
+			want:     "cat <<A <<B\ngo build ./...\nA\ngo vet ./...\nB",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			name:     "unterminated heredoc swallows the rest",
+			cmd:      "cat <<EOF\ngo test ./...\n",
+			want:     "cat <<EOF\ngo test ./...\n",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			// Commands after the terminator are ordinary commands again.
+			name:     "command after terminator still filtered",
+			cmd:      "cat <<EOF > f\ngo test ./...\nEOF\ngo build ./...",
+			want:     "cat <<EOF > f\ngo test ./...\nEOF\n" + `"/usr/local/bin/snip" run -- go build ./...`,
+			changed:  true,
+			allKnown: false,
+		},
+		{
+			// A heredoc-fed producer must not be wrapped: `snip run` never wires
+			// stdin to the child, so the wrapped form would read nothing. And an
+			// uninspected heredoc payload must never be auto-allowed (#88).
+			name:     "heredoc fed known producer left raw",
+			cmd:      "ssh host <<EOF\nrm -rf /\nEOF",
+			want:     "ssh host <<EOF\nrm -rf /\nEOF",
+			changed:  false,
+			allKnown: false,
+		},
+		{
+			// A here-string has no body: the next line is a real command, and the
+			// here-string group itself keeps the master behaviour (wrapped). That
+			// wrapping is unsound for a different, pre-existing reason — snip run
+			// does not forward stdin — but '<' is out of scope here, exactly as
+			// hasTopLevelRedirect documents.
+			name:     "here string is not a heredoc",
+			cmd:      "grep -c x <<<'go test'\ngo build ./...",
+			want:     `"/usr/local/bin/snip" run -- grep -c x <<<'go test'` + "\n" + `"/usr/local/bin/snip" run -- go build ./...`,
+			changed:  true,
+			allKnown: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := RewriteCommand(tc.cmd, cmdSet, nil, bin)
+			if res.Command != tc.want {
+				t.Errorf("Command = %q, want %q", res.Command, tc.want)
+			}
+			if res.Changed != tc.changed {
+				t.Errorf("Changed = %v, want %v", res.Changed, tc.changed)
+			}
+			if res.AllKnown != tc.allKnown {
+				t.Errorf("AllKnown = %v, want %v", res.AllKnown, tc.allKnown)
+			}
+		})
+	}
+}
+
+// TestRewriteNoFalsePositives is the regression set from issue #133: removing
+// unsound filtering is the goal, removing sound filtering is a regression. Every
+// command here must keep being rewritten exactly as it is on master. The naive
+// guard that was tried first broke the first two, because strings.Fields ignores
+// quoting and '<<' matched as a bare substring.
+func TestRewriteNoFalsePositives(t *testing.T) {
+	const bin = "/usr/local/bin/snip"
+	const w = `"/usr/local/bin/snip" run -- `
+	cmdSet := map[string]struct{}{"git": {}, "go": {}, "grep": {}, "make": {}}
+
+	cases := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{
+			// "do" appears as an ordinary argument, never in command position.
+			name: "keyword as argument",
+			cmd:  "go test ./...\necho nothing else to do",
+			want: w + "go test ./...\necho nothing else to do",
+		},
+		{
+			// '<<' inside single quotes is not a heredoc operator.
+			name: "quoted shift operator",
+			cmd:  "go build ./...\ngrep '<<' main.go",
+			want: w + "go build ./...\n" + w + "grep '<<' main.go",
+		},
+		{
+			name: "then as an argument",
+			cmd:  "make build\necho build ok then deploy",
+			want: w + "make build\necho build ok then deploy",
+		},
+		{
+			name: "plain multi line script",
+			cmd:  "go mod tidy\ngo build ./...\ngo vet ./...\ngo test ./...",
+			want: w + "go mod tidy\n" + w + "go build ./...\n" + w + "go vet ./...\n" + w + "go test ./...",
+		},
+		{
+			name: "keyword inside a grep pattern",
+			cmd:  "grep -rn 'for f in x; do echo; done' .",
+			want: w + "grep -rn 'for f in x; do echo; done' .",
+		},
+		{
+			name: "done as an argument",
+			cmd:  "grep done Makefile\ngo test ./...",
+			want: w + "grep done Makefile\n" + w + "go test ./...",
+		},
+		{
+			name: "brace expansion is not a block",
+			cmd:  "mkdir -p x/{p,q}\ngo test ./...",
+			want: "mkdir -p x/{p,q}\n" + w + "go test ./...",
+		},
+		{
+			name: "array assignment is not a subshell",
+			cmd:  "arr=(a b)\ngo test ./...",
+			want: "arr=(a b)\n" + w + "go test ./...",
+		},
+		{
+			// A bare arithmetic command must not arm a phantom heredoc whose
+			// delimiter never appears.
+			name: "arithmetic shift is not a heredoc",
+			cmd:  "((x = 1 << 2))\ngo test ./...",
+			want: "((x = 1 << 2))\n" + w + "go test ./...",
+		},
+		{
+			// '<<' inside a comment is not a heredoc operator either.
+			name: "shift operator in a comment",
+			cmd:  "go test ./... # see <<EOF\ngit status",
+			want: w + "go test ./... # see <<EOF\n" + w + "git status",
+		},
+		{
+			name: "stray closer at top level",
+			cmd:  "echo done\ngo test ./...",
+			want: "echo done\n" + w + "go test ./...",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := RewriteCommand(tc.cmd, cmdSet, nil, bin)
+			if res.Command != tc.want {
+				t.Errorf("Command = %q, want %q", res.Command, tc.want)
+			}
+		})
+	}
+}

--- a/internal/hook/rewrite.go
+++ b/internal/hook/rewrite.go
@@ -24,9 +24,10 @@ type RewriteResult struct {
 // rewrite so token savings are preserved across compound commands.
 //
 // cmd is split on top-level ';', '&&', '||', '&' and newline boundaries (quoted
-// regions are respected). Within each resulting group the head command is
-// wrapped only when its stdout is read directly by the LLM. A head whose output
-// feeds a downstream consumer — a pipe stage or a file redirection ('>') — is
+// regions and comments are respected: a comment runs to the end of its line and
+// the shell reads no operator inside it). Within each resulting group the head
+// command is wrapped only when its stdout is read directly by the LLM. A head
+// whose output feeds a consumer — a pipe stage or a file redirection ('>') — is
 // left raw, because snip's lossy compaction (path compaction, line truncation,
 // match caps, dedup, reformatting) would silently corrupt the exact count and
 // content that consumer depends on (issue #111).
@@ -35,8 +36,9 @@ type RewriteResult struct {
 // (issue #133):
 //
 //   - Groups inside a compound command (loop, conditional, brace group, function
-//     body, subshell), tracked by blockScope. The #111 guard is per-group, so it
-//     could not see that `done | wc -l` consumes the loop body sitting in an
+//     body, subshell), tracked by blockScope — see its doc comment for exactly
+//     which openers and closers are recognised. The #111 guard is per-group, so
+//     it could not see that `done | wc -l` consumes the loop body sitting in an
 //     earlier group; the body was wrapped and the count silently wrong.
 //   - Heredoc bodies, which are literal text the command writes, not commands to
 //     run. Rewriting them corrupted the Makefile or script an agent was writing.
@@ -90,11 +92,6 @@ func RewriteCommand(cmd string, cmdSet map[string]struct{}, prefixes []Transpare
 	var quote byte
 	// Heredoc bodies opened on the line being scanned, drained at its newline.
 	var pending []heredocDelim
-	// Set by an unquoted '#' at word start, cleared at the newline. It only
-	// suppresses heredoc detection: the shell would not treat a '<<' inside a
-	// comment as an operator. Group splitting is deliberately left alone, so
-	// this changes no existing rewrite.
-	inComment := false
 	// Nesting of unquoted "((" arithmetic, where '<<' is a left shift and not a
 	// heredoc operator. Arming a heredoc there would swallow the rest of the
 	// command and silently disable filtering for it (issue #133): "((x = 1 << n))"
@@ -126,7 +123,21 @@ func RewriteCommand(cmd string, cmdSet map[string]struct{}, prefixes []Transpare
 			i++
 		case '#':
 			if isWordStart(cmd, i) {
-				inComment = true
+				// A comment runs to the end of the line, so the shell reads no
+				// operator inside it: a ';', '&&', '||' or '|' there is not a
+				// group boundary and a '<<' there does not open a heredoc.
+				// Splitting on them handed blockScope a group that starts in
+				// command position but is really comment text, and a closing
+				// reserved word in the comment ("# count matches; done below")
+				// then closed a live block and the rest of its body was
+				// rewritten. Skipping to the newline leaves the comment inside
+				// its group; blockScope.advance skips it there in turn.
+				if nl := strings.IndexByte(cmd[i:], '\n'); nl >= 0 {
+					i += nl
+				} else {
+					i = len(cmd)
+				}
+				continue
 			}
 			i++
 		case '<':
@@ -137,7 +148,7 @@ func RewriteCommand(cmd string, cmdSet map[string]struct{}, prefixes []Transpare
 					i += 3
 					continue
 				}
-				if !inComment && arith == 0 {
+				if arith == 0 {
 					if d, next, ok := parseHeredocDelim(cmd, i+2); ok {
 						pending = append(pending, d)
 						heredocGroup = true
@@ -166,7 +177,6 @@ func RewriteCommand(cmd string, cmdSet map[string]struct{}, prefixes []Transpare
 			b.WriteByte('\n')
 			i++
 			groupStart = i
-			inComment = false
 			arith = 0
 			if len(pending) > 0 {
 				end := drainHeredocs(cmd, i, pending)

--- a/internal/hook/rewrite.go
+++ b/internal/hook/rewrite.go
@@ -31,6 +31,22 @@ type RewriteResult struct {
 // match caps, dedup, reformatting) would silently corrupt the exact count and
 // content that consumer depends on (issue #111).
 //
+// Two kinds of group are never runnable commands and are emitted verbatim
+// (issue #133):
+//
+//   - Groups inside a compound command (loop, conditional, brace group, function
+//     body, subshell), tracked by blockScope. The #111 guard is per-group, so it
+//     could not see that `done | wc -l` consumes the loop body sitting in an
+//     earlier group; the body was wrapped and the count silently wrong.
+//   - Heredoc bodies, which are literal text the command writes, not commands to
+//     run. Rewriting them corrupted the Makefile or script an agent was writing.
+//     The group carrying the '<<' operator is left raw too, because `snip run`
+//     never wires stdin to the child.
+//
+// Both also force AllKnown false: snip does not attest what it did not inspect
+// (issue #88). The scope is per-group, so a block or a heredoc never disables
+// filtering for unrelated top-level commands in the same message.
+//
 // The caller must reject commands containing unverifiable constructs
 // (HasUnverifiableConstruct) before calling this, so cmd here is free of command
 // substitution and carriage returns.
@@ -43,21 +59,43 @@ func RewriteCommand(cmd string, cmdSet map[string]struct{}, prefixes []Transpare
 	changed := false
 	allKnown := true
 
+	var scope blockScope
+	// Set while the group under construction carries a '<<' operator: its stdin
+	// comes from a heredoc body, which snip run cannot forward.
+	heredocGroup := false
+
 	flush := func(group string) {
-		out, headKnown, hasTail := rewriteGroup(group, cmdSet, prefixes, quotedBin, snipBin)
-		b.WriteString(out)
-		if out != group {
-			changed = true
+		if scope.inBlock() || heredocGroup {
+			b.WriteString(group)
+			if heredocGroup || strings.TrimSpace(group) != "" {
+				allKnown = false
+			}
+		} else {
+			out, headKnown, hasTail := rewriteGroup(group, cmdSet, prefixes, quotedBin, snipBin)
+			b.WriteString(out)
+			if out != group {
+				changed = true
+			}
+			// Empty/whitespace-only groups (e.g. a trailing ';') do not carry a
+			// command and never block auto-allow.
+			if strings.TrimSpace(group) != "" && (!headKnown || hasTail) {
+				allKnown = false
+			}
 		}
-		// Empty/whitespace-only groups (e.g. a trailing ';') do not carry a
-		// command and never block auto-allow.
-		if strings.TrimSpace(group) != "" && (!headKnown || hasTail) {
-			allKnown = false
-		}
+		scope.advance(group)
+		heredocGroup = false
 	}
 
 	groupStart := 0
 	var quote byte
+	// Heredoc bodies opened on the line being scanned, drained at its newline.
+	var pending []heredocDelim
+	// Set by an unquoted '#' at word start, cleared at the newline. It only
+	// suppresses heredoc detection: the shell would not treat a '<<' inside a
+	// comment as an operator. Group splitting is deliberately left alone, so
+	// this changes no existing rewrite.
+	inComment := false
+
 	for i := 0; i < len(cmd); {
 		ch := cmd[i]
 		if quote != 0 {
@@ -78,7 +116,43 @@ func RewriteCommand(cmd string, cmdSet map[string]struct{}, prefixes []Transpare
 		case '"':
 			quote = '"'
 			i++
-		case '\n', ';':
+		case '#':
+			if isWordStart(cmd, i) {
+				inComment = true
+			}
+			i++
+		case '<':
+			// "<<" opens a heredoc; "<<<" is a here-string, consumed whole so its
+			// operand is not read as a delimiter.
+			if i+1 < len(cmd) && cmd[i+1] == '<' {
+				if i+2 < len(cmd) && cmd[i+2] == '<' {
+					i += 3
+					continue
+				}
+				if !inComment {
+					if d, next, ok := parseHeredocDelim(cmd, i+2); ok {
+						pending = append(pending, d)
+						heredocGroup = true
+						i = next
+						continue
+					}
+				}
+			}
+			i++
+		case '\n':
+			flush(cmd[groupStart:i])
+			b.WriteByte('\n')
+			i++
+			groupStart = i
+			inComment = false
+			if len(pending) > 0 {
+				end := drainHeredocs(cmd, i, pending)
+				b.WriteString(cmd[i:end])
+				pending = pending[:0]
+				i = end
+				groupStart = i
+			}
+		case ';':
 			flush(cmd[groupStart:i])
 			b.WriteByte(ch)
 			i++

--- a/internal/hook/rewrite.go
+++ b/internal/hook/rewrite.go
@@ -95,6 +95,14 @@ func RewriteCommand(cmd string, cmdSet map[string]struct{}, prefixes []Transpare
 	// comment as an operator. Group splitting is deliberately left alone, so
 	// this changes no existing rewrite.
 	inComment := false
+	// Nesting of unquoted "((" arithmetic, where '<<' is a left shift and not a
+	// heredoc operator. Arming a heredoc there would swallow the rest of the
+	// command and silently disable filtering for it (issue #133): "((x = 1 << n))"
+	// would open a heredoc on delimiter "n". Command substitution is rejected
+	// upstream (HasUnverifiableConstruct), so "((" can only be an arithmetic
+	// command here. Reset at every newline so an unbalanced "((" cannot disarm
+	// heredoc detection for the rest of the command.
+	arith := 0
 
 	for i := 0; i < len(cmd); {
 		ch := cmd[i]
@@ -129,7 +137,7 @@ func RewriteCommand(cmd string, cmdSet map[string]struct{}, prefixes []Transpare
 					i += 3
 					continue
 				}
-				if !inComment {
+				if !inComment && arith == 0 {
 					if d, next, ok := parseHeredocDelim(cmd, i+2); ok {
 						pending = append(pending, d)
 						heredocGroup = true
@@ -139,12 +147,27 @@ func RewriteCommand(cmd string, cmdSet map[string]struct{}, prefixes []Transpare
 				}
 			}
 			i++
+		case '(':
+			if i+1 < len(cmd) && cmd[i+1] == '(' {
+				arith++
+				i += 2
+				continue
+			}
+			i++
+		case ')':
+			if arith > 0 && i+1 < len(cmd) && cmd[i+1] == ')' {
+				arith--
+				i += 2
+				continue
+			}
+			i++
 		case '\n':
 			flush(cmd[groupStart:i])
 			b.WriteByte('\n')
 			i++
 			groupStart = i
 			inComment = false
+			arith = 0
 			if len(pending) > 0 {
 				end := drainHeredocs(cmd, i, pending)
 				b.WriteString(cmd[i:end])

--- a/internal/hook/rewrite_bench_test.go
+++ b/internal/hook/rewrite_bench_test.go
@@ -1,0 +1,43 @@
+package hook
+
+import "testing"
+
+// Benchmarks for the hook hot path: RewriteCommand runs on every shell command
+// an agent issues, so its cost is part of the <10ms startup budget.
+var benchCmdSet = map[string]struct{}{
+	"git": {}, "go": {}, "grep": {}, "make": {}, "npm": {}, "cargo": {},
+}
+
+var benchSink RewriteResult
+
+func benchRewrite(b *testing.B, cmd string) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		benchSink = RewriteCommand(cmd, benchCmdSet, nil, "/usr/local/bin/snip")
+	}
+}
+
+// Realistic: the single most common shape an agent issues.
+func BenchmarkRewriteSimple(b *testing.B) {
+	benchRewrite(b, "go test ./...")
+}
+
+// Realistic: a compound command.
+func BenchmarkRewriteCompound(b *testing.B) {
+	benchRewrite(b, "git add . && go test ./... && git commit -m 'x'")
+}
+
+// Realistic: a multi-line script with a block in the middle.
+func BenchmarkRewriteScript(b *testing.B) {
+	benchRewrite(b, "go mod tidy\nfor f in *.go\ndo\n  gofmt -l $f\ndone\ngo build ./...\ngo test ./...")
+}
+
+// Pathological: nested blocks, quotes and a pipeline on the closer.
+func BenchmarkRewriteBlock(b *testing.B) {
+	benchRewrite(b, "for f in *.yaml\ndo\n  if grep -q 'a && b' $f; then\n    grep reason $f\n  fi\ndone | wc -l")
+}
+
+// Pathological: a heredoc payload that must be copied through verbatim.
+func BenchmarkRewriteHeredoc(b *testing.B) {
+	benchRewrite(b, "cat > Makefile <<'EOF'\ntest:\n\tgo test ./...\nbuild:\n\tgo build ./...\nEOF\ngo vet ./...")
+}


### PR DESCRIPTION
Closes #133.

The segmenter splits on top-level `;`, `&&`, `||`, `&` and `\n` with no notion of block structure, so a loop body became an ordinary group. The #111 guard that keeps a producer raw when its output feeds a consumer only inspects the group it is in, and `done | wc -l` lives in a different group from the body — so the body was wrapped and the consumer read snip's compacted view. Heredoc bodies had the same problem: `snip run --` was injected into text the command was about to write to disk.

`blockScope` is a kind-stack over the segmentation loop that already exists. Groups flushed inside a block are emitted verbatim; heredoc bodies are copied through to their terminator.

## The measurement that decided the trade

Over 6,832 real Bash commands (this project's session history plus its docs, workflows and fixtures), the branch changes 78 hook decisions. Of the wrappers it drops, **the large majority were master producing broken commands**: 26 `git commit -F - <<EOF` and 14 `psql <<SQL` (snip does not forward stdin to a filtered child, so those aborted), and 8 where `snip run --` was injected *inside* a heredoc payload and corrupted the file being written. One real in-the-wild corruption disappears: `(cd "$OUT" && find ... -exec shasum {} \; | sort) > run1.sha`, where the escaped `;` hid the pipe from the #111 guard and master compacted find's output into the file.

Genuine lost filtering is a long tail concentrated in one shape, `for n in ...; do gh pr view $n --json ...; done`. Auto-allow is **unchanged on all 6,832 commands** across all four handlers. End-to-end hook latency is indistinguishable (17.2 ms both sides); `RewriteBlock` and `RewriteHeredoc` get 27% and 53% faster because their bodies stop being rewritten.

## What it fixes, verified end to end

Each against a 60-match file behind `filters/grep.yaml`'s cap of 50, running the original and the rewritten command in real bash:

| shape | raw | master | this branch |
|---|---:|---:|---:|
| `for … do grep … done \| wc -l` | 60 | 51 | 60 |
| `function f { grep … }` + `f \| wc -l` | 60 | 51 | 60 |
| `(cd . && grep …; echo x) \| wc -l` | 61 | 52 | 61 |
| comment containing `; done` in a body | 60 | 51 | 60 |
| `cat <<EOF / go test ./... / EOF` | verbatim | `snip run --` injected | verbatim |

## Three rounds of adversarial review

Round 1 shipped a depth counter; review reproduced a `case` pattern written `a )` closing the block early. Round 2 rebuilt it as a kind stack; review reproduced `function NAME {` not opening a block, a `#` comment containing `; done` closing one, and a tight-paren subshell being exempt. Round 3 closed all three. Round 3's review then found four more, all of which **corrupt identically on master** — verified, table above extended:

`case $s in done)`, extglob `for f in @(data|done).txt`, `time -p for`, and `a)# done marker` (a `#` flush against `)`). Command position is approximated, not decided the way the shell does. These are pre-existing, this branch does not reach them, and the doc comment now names them rather than implying the classifier is complete. Filed separately.

That is also why the contract in `blockscope.go` is written as "nothing inside a block **it detects** is ever rewritten", followed by exactly what it detects and what it does not. The first two rounds each shipped a comment asserting a guarantee the code did not honour.

## Tests

`blockscope_test.go` is new. The old `(cd sub && go test ./...) | wc -l` case was replaced: it passed only because the whole command is one group so the per-group #111 check caught it, which masked the gap rather than covering it. It is now `(cd sub && go test ./...; echo x) | wc -l`, the shape that actually exercises the scope.

Regression set pinned byte-identical to master's rewrite: `go test ./...\necho nothing else to do`, `go build ./...\ngrep '<<' main.go`, `make build\necho build ok then deploy`, the four-line go script, `((x = 1 << n))\ngo test ./...`, `arr=(a b c)\ngo test ./...`.

CI green: build, vet, `test -race`, `-tags lite`, `golangci-lint` 0 issues, `snip verify` 132 filters / 45 tests / 0 failed.

## Accepted cost

A subshell or block with no consumer is no longer filtered — 2 occurrences in the 6,832-command corpus. Recovering them needs consumer propagation, scanning past the matching `)` for a pipe or redirect, whose failure mode is wrong output. This path takes the opposite trade, as #127 did.
