### PR TITLE
ci: run snip verify so the filters' inline tests are enforced

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,15 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+      # The inline `tests:` blocks in filters/*.yaml were enforced by nothing:
+      # `go test` does not read them, so a contributor could break a filter's
+      # own fixtures and CI stayed green. snip verify runs them against the
+      # embedded filter set, which is why the binary is built first.
+      - name: Verify filters
+        run: |
+          go build -o /tmp/snip ./cmd/snip
+          /tmp/snip verify
+
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Found while reviewing the #136 fixes.

The 132 bundled filters carry inline `tests:` blocks and 21 of them use it. **Nothing runs them.** `ci.yaml` has `go test -race -cover`, `go vet`, `golangci-lint` and `govulncheck`, and `go test` does not read filter YAML. A contributor could break any filter's own fixtures and CI would stay green.

That is not hypothetical here. #117, #121, #132, #135 and #136 each added or changed inline tests precisely so `snip verify` would guard the behaviour being fixed:

- `filters/tsc.yaml` — the two tests updated in #117, the only automated guard that `compact_path` does not come back
- `filters/git-diff.yaml`, `git-log.yaml`, `git-show.yaml` — added in #132 to pin that snip invents no file count and that the diffstat substitution is labelled
- `filters/rails-routes.yaml` — added in #135, and the *only* place that pins the fix, since the Go integration fixture is larger than the head cap and passes either way

All of those were unenforced.

## The change

One step in the `test` job. The binary is built first because `verify` runs the embedded filter set rather than the files on disk, so an edit under `filters/` is only visible after a rebuild.

```yaml
      - name: Verify filters
        run: |
          go build -o /tmp/snip ./cmd/snip
          /tmp/snip verify
```

## Confirmed it can actually fail

Breaking one `expected:` block in `filters/git-diff.yaml` and rebuilding:

```
git-diff ............ FAIL (2/3 passed)
132 filters, 20 tested, 45 tests, 44 passed, 1 failed
$ echo $?
1
```

Restored, and `snip verify` is back to 45/45 with exit 0. Runtime is under a second, so it costs nothing in the pipeline.
