### PR TITLE
fix(filters): keep the migration names in rails-migrate

### DIFF
--- a/filters/rails-migrate.yaml
+++ b/filters/rails-migrate.yaml
@@ -1,5 +1,5 @@
 name: "rails-migrate"
-version: 1
+version: 2
 description: "Condensed rails db:migrate output"
 
 match:
@@ -16,10 +16,58 @@ pipeline:
   - action: "regex_extract"
     pattern: "== \\d+ (\\w+): migrated"
     format: "- $1"
+  # append keeps the extracted migration names: without it, aggregate replaces
+  # the very lines it counted and the template renders the count twice
   - action: "aggregate"
     patterns:
       migrated: "^-"
+    append: true
+  # the count is carried by .stats, so drop the summary line aggregate appended
+  # (extracted names are "- Name", so this pattern cannot match a payload line)
+  - action: "remove_lines"
+    pattern: "^migrated: \\d+$"
   - action: "format_template"
-    template: "{{with .stats}}{{.migrated}} migrations executed:{{end}}\n{{.lines}}"
+    template: "{{with .stats}}{{if .migrated}}{{.migrated}} migration{{if ne .migrated 1}}s{{end}} executed:{{else}}no migrations executed{{end}}{{end}}\n{{.lines}}"
 
 on_error: "passthrough"
+
+tests:
+  - name: "migration names survive the count summary"
+    input: |
+      == 20240101000000 CreateUsers: migrating ======================================
+      -- create_table(:users)
+         -> 0.0100s
+      -- add_index(:users, :email, {:unique=>true})
+         -> 0.0023s
+      == 20240101000000 CreateUsers: migrated (0.0123s) =============================
+
+      == 20240202120000 CreatePosts: migrating ======================================
+      -- create_table(:posts)
+         -> 0.0081s
+      -- add_foreign_key(:posts, :users)
+         -> 0.0044s
+      == 20240202120000 CreatePosts: migrated (0.0125s) =============================
+    expected: |
+      2 migrations executed:
+      - CreateUsers
+      - CreatePosts
+  - name: "a single migration is announced in the singular"
+    input: |
+      == 20240101000000 CreateUsers: migrating ======================================
+      -- create_table(:users)
+         -> 0.0100s
+      == 20240101000000 CreateUsers: migrated (0.0123s) =============================
+    expected: |
+      1 migration executed:
+      - CreateUsers
+  - name: "a migration that only started is not reported as executed"
+    input: |
+      == 20240101000000 CreateUsers: migrating ======================================
+      -- create_table(:users)
+         -> 0.0100s
+    expected: |
+      no migrations executed
+  - name: "nothing pending produces no phantom count"
+    input: ""
+    expected: |
+      no migrations executed

--- a/internal/filter/actions_integration_test.go
+++ b/internal/filter/actions_integration_test.go
@@ -370,8 +370,20 @@ func TestRailsMigrateFilterIntegration(t *testing.T) {
 	}
 
 	// Should contain migrations executed summary
-	if !strings.Contains(filtered, "migrations executed") {
-		t.Error("filtered output missing 'migrations executed'")
+	if !strings.Contains(filtered, "3 migrations executed") {
+		t.Errorf("filtered output missing the migration count header: %q", filtered)
+	}
+
+	// The migration names must survive the aggregate stage (issue #136)
+	for _, name := range []string{"CreateUsers", "AddIndexToOrders", "CreateProducts"} {
+		if !strings.Contains(filtered, "- "+name) {
+			t.Errorf("filtered output missing migration %q: %q", name, filtered)
+		}
+	}
+
+	// The summary line aggregate appends must not leak into the payload
+	if strings.Contains(filtered, "migrated: 3") {
+		t.Errorf("aggregate summary line leaked into the payload: %q", filtered)
 	}
 
 	// Calculate and log token savings


### PR DESCRIPTION
First half of #136. Same defect as #134/#135, in `filters/rails-migrate.yaml`.

```
$ snip run -- rails db:migrate      # v0.24.0
2 migrations executed:
migrated: 2

$ snip run -- rails db:migrate      # this PR
2 migrations executed:
- CreateUsers
- CreatePosts
```

`aggregate` replaces the lines it counted unless `append: true` is set, so it discarded the `- CreateUsers` / `- CreatePosts` lines `regex_extract` had just produced, and `{{.lines}}` rendered its own summary instead.

## Changes

- `append: true` on the aggregate stage.
- `remove_lines` on `^migrated: \d+$` to drop the summary line aggregate appends. Checked for collision: `regex_extract` emits only `- Name` lines, so the pattern cannot match a payload line. Unlike rails-routes this filter has no `head` cap, so the stray line always leaked rather than being masked by truncation, which also makes it directly assertable.
- Honest header across the range. Master printed `1 migrations executed:` for a single migration, and `0 migrations executed:` plus a phantom `migrated: 0` when nothing ran. Now `N migration(s) executed:`, or `no migrations executed`.
- Inline `tests:` block, which this filter lacked: many migrations, exactly one, a run that only reached `migrating`, and empty input.

## Cost

165 tokens in. Before: 9 out, 94.5% "savings". After: 19 out, 88.5%. About 3 to 4 tokens per migration thereafter.

The 6 points are the bug being removed. Master bought them by deleting the only part of the output worth reading, with nothing to say anything was missing. `db:migrate` emits 4 to 5 lines of `create_table` and timing noise per migration and all of that is still dropped.

## Tests

Non-vacuous, proved twice. Full revert with the tests in place: `rails-migrate FAIL (0/4 passed)`, and the Go integration test fires on three missing names plus the leaked summary line. Finer mutant, `append: true` kept and only the `remove_lines` deleted: still `0/4`, e.g. `2 migrations executed:\n- CreateUsers\n- CreatePosts\nmigrated: 2`. Both new stages are independently pinned.

The Go integration test previously asserted only `Contains(filtered, "migrations executed")`, which passed on the broken output. It now checks each migration name, the header, and that `migrated: 3` does not leak.

`snip verify` 132 filters / 21 tested / 49 tests / 0 failed. Now actually enforced in CI, per #139. Full CI green locally.

The cargo-test half of #136 is on its own branch; it needs a real decision rather than the same recipe, since the aggregate summary is arguably the right output on a passing run and destroys the failure detail on a failing one.
