### PR TITLE
fix(filters): keep the failure report in cargo-test

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -180,8 +180,8 @@ on_error: "passthrough"
 
 ```yaml
 name: "cargo-test"
-version: 1
-description: "Condensed cargo test output"
+version: 2
+description: "cargo test summary lines, plus the failure report when a test fails"
 match:
   command: "cargo"
   subcommand: "test"
@@ -193,22 +193,24 @@ pipeline:
   - action: "state_machine"
     states:
       start:
-        keep: "^(test |running |test result)"
+        keep: "^test result"
         until: "^failures"
         next: "failures"
       failures:
         keep: "."
-        until: "^$"
-        next: "done"
-  - action: "aggregate"
-    patterns:
-      pass: "\\.\\.\\. ok$"
-      fail: "\\.\\.\\. FAILED$"
-      ignored: "\\.\\.\\. ignored$"
+  - action: "head"
+    n: 150
   - action: "format_template"
     template: "{{.lines}}"
 on_error: "passthrough"
 ```
+
+The `until` on `start` is what makes this safe. Everything after the first
+`failures:` line is the failure report, and a panic message can hold any text at
+all — including a line that looks exactly like a test result. So every stage that
+drops or counts lines has to sit on the `start` side of that boundary, which
+`keep` does. A `remove_lines` placed after the state machine would instead run
+over the panic messages and delete them.
 
 ## Workflow to Create a New Filter
 

--- a/filters/cargo-test.yaml
+++ b/filters/cargo-test.yaml
@@ -1,6 +1,6 @@
 name: "cargo-test"
-version: 1
-description: "Condensed cargo test output"
+version: 2
+description: "cargo test summary lines, plus the failure report when a test fails"
 
 match:
   command: "cargo"
@@ -11,22 +11,281 @@ pipeline:
     pattern: "^\\s*(Compiling|Downloading|Downloaded|Updating|Running|Executable)"
   - action: "keep_lines"
     pattern: "\\S"
+  # libtest prints every per-test result before the first `failures:` line, and
+  # everything after it is the failure report: the captured output of each
+  # failing test, the list of failing names, the trailing `test result:` line.
+  # The split is the only place in the stream where panic text can be told
+  # apart from a test result, so every stage that drops or counts lines has to
+  # sit on the `start` side of it. `keep` does exactly that, which is why the
+  # per-test lines are dropped here rather than by a later `remove_lines`:
+  # a panic message that happens to read `... ok` is then impossible to delete.
   - action: "state_machine"
     states:
       start:
-        keep: "^(test |running |test result)"
+        # `test result:` is cargo's own count, one line per target. It is
+        # correct in every mode, including `-q` and `--color always`, which the
+        # suffix-matching counter this replaces was not.
+        keep: "^test result"
         until: "^failures"
         next: "failures"
+      # Deliberately terminal, with no way back to `start`. Under
+      # `--no-fail-fast` that keeps the per-test lines of the targets that run
+      # after the first failure, which `head` bounds. The alternative, leaving
+      # on the next `running N tests`, would let a test that prints that line
+      # end the region early and take the rest of its own panic message with it.
       failures:
         keep: "."
-        until: "^$"
-        next: "done"
-  - action: "aggregate"
-    patterns:
-      pass: "\\.\\.\\. ok$"
-      fail: "\\.\\.\\. FAILED$"
-      ignored: "\\.\\.\\. ignored$"
+  # A run with hundreds of failing tests would otherwise dump every panic
+  # message. `head` announces the cut with "+N more lines" so nothing is lost
+  # silently, and the raw output stays recoverable through the tee file.
+  #
+  # 150, not 60: the report ends with the `failures:` name list and cargo's own
+  # `test result: FAILED. N passed; M failed` line, so a cap that bites cuts the
+  # count itself. At 60 a 23-failure run lost it, which is the one thing the
+  # unfiltered output got right. 150 covers a couple of dozen failures with
+  # their panic blocks; past that the count goes and the tee file is the answer.
+  - action: "head"
+    n: 150
   - action: "format_template"
     template: "{{.lines}}"
 
 on_error: "passthrough"
+
+tests:
+  - name: "a passing run keeps only cargo's own result line"
+    input: |
+      running 3 tests
+      test tests::adds ... ok
+      test tests::subs ... ok
+      test tests::muls ... ok
+
+      test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+    expected: |
+      test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+
+  - name: "a failing run keeps the whole failure report"
+    input: |
+      running 3 tests
+      test tests::adds ... ok
+      test tests::subs ... FAILED
+      test tests::muls ... ok
+
+      failures:
+
+      ---- tests::subs stdout ----
+
+      thread 'tests::subs' panicked at src/lib.rs:12:9:
+      assertion `left == right` failed
+        left: 3
+       right: 4
+
+      failures:
+          tests::subs
+
+      test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+    expected: |
+      ---- tests::subs stdout ----
+      thread 'tests::subs' panicked at src/lib.rs:12:9:
+      assertion `left == right` failed
+        left: 3
+       right: 4
+      failures:
+          tests::subs
+      test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+  - name: "a panic message shaped like a test result is never counted, never deleted"
+    input: |
+      running 2 tests
+      test tests::spoof ... FAILED
+      test tests::plain ... ok
+
+      failures:
+
+      ---- tests::spoof stdout ----
+      test spoofed::case ... ok
+      test result: ok. 99 passed; 8 failed; 0 ignored; 0 measured; 0 filtered out; finished in 9.99s
+
+      thread 'tests::spoof' panicked at src/lib.rs:9:9:
+      spoofing test still fails
+
+      failures:
+          tests::spoof
+
+      test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+    expected: |
+      ---- tests::spoof stdout ----
+      test spoofed::case ... ok
+      test result: ok. 99 passed; 8 failed; 0 ignored; 0 measured; 0 filtered out; finished in 9.99s
+      thread 'tests::spoof' panicked at src/lib.rs:9:9:
+      spoofing test still fails
+      failures:
+          tests::spoof
+      test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+  - name: "quiet mode keeps cargo's own result line too"
+    input: |
+      running 3 tests
+      ...
+
+      test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+    expected: |
+      test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+
+  - name: "a multi-target run keeps one result line per target"
+    input: |
+      running 2 tests
+      test tests::adds ... ok
+      test tests::muls ... ok
+
+      test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+      running 1 test
+      test ok_integration_one ... ok
+
+      test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+    expected: |
+      test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+      test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+  - name: "the report keeps its tail, so cargo's own count survives"
+    input: |
+      running 1 test
+      test tests::boom ... FAILED
+
+      failures:
+
+      ---- tests::boom stdout ----
+      noise 01
+      noise 02
+      noise 03
+      noise 04
+      noise 05
+      noise 06
+      noise 07
+      noise 08
+      noise 09
+      noise 10
+      noise 11
+      noise 12
+      noise 13
+      noise 14
+      noise 15
+      noise 16
+      noise 17
+      noise 18
+      noise 19
+      noise 20
+      noise 21
+      noise 22
+      noise 23
+      noise 24
+      noise 25
+      noise 26
+      noise 27
+      noise 28
+      noise 29
+      noise 30
+      noise 31
+      noise 32
+      noise 33
+      noise 34
+      noise 35
+      noise 36
+      noise 37
+      noise 38
+      noise 39
+      noise 40
+      noise 41
+      noise 42
+      noise 43
+      noise 44
+      noise 45
+      noise 46
+      noise 47
+      noise 48
+      noise 49
+      noise 50
+      noise 51
+      noise 52
+      noise 53
+      noise 54
+      noise 55
+      noise 56
+      noise 57
+      noise 58
+      noise 59
+      noise 60
+      noise 61
+      noise 62
+
+      failures:
+          tests::boom
+
+      test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+    expected: |
+      ---- tests::boom stdout ----
+      noise 01
+      noise 02
+      noise 03
+      noise 04
+      noise 05
+      noise 06
+      noise 07
+      noise 08
+      noise 09
+      noise 10
+      noise 11
+      noise 12
+      noise 13
+      noise 14
+      noise 15
+      noise 16
+      noise 17
+      noise 18
+      noise 19
+      noise 20
+      noise 21
+      noise 22
+      noise 23
+      noise 24
+      noise 25
+      noise 26
+      noise 27
+      noise 28
+      noise 29
+      noise 30
+      noise 31
+      noise 32
+      noise 33
+      noise 34
+      noise 35
+      noise 36
+      noise 37
+      noise 38
+      noise 39
+      noise 40
+      noise 41
+      noise 42
+      noise 43
+      noise 44
+      noise 45
+      noise 46
+      noise 47
+      noise 48
+      noise 49
+      noise 50
+      noise 51
+      noise 52
+      noise 53
+      noise 54
+      noise 55
+      noise 56
+      noise 57
+      noise 58
+      noise 59
+      noise 60
+      noise 61
+      noise 62
+      failures:
+          tests::boom
+      test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


### PR DESCRIPTION
Closes #136 (the rails-migrate half landed in #140).

On a failing `cargo test`, v0.24.0 emits this and nothing else:

```
fail: 3
ignored: 1
pass: 21
```

Every panic message and every failing test name is discarded, with nothing saying so. `aggregate` replaces the lines it counted unless `append: true` is set, and the template is a bare `{{.lines}}`.

## The change

Four behavioural lines. The `aggregate` is deleted and cargo's own `test result:` line carries the summary.

The reason it is not `append: true` plus a `remove_lines`, which is what #135 and #140 did: libtest prints per-test lines *before* the first `failures:` line and the failure report *after* it, and a panic message can contain any text at all, including a line shaped exactly like a test result. Any stage placed after the state machine sees both regions and cannot tell them apart. So the per-test lines are dropped by the state machine's own `keep` on the `start` side of that boundary, and nothing downstream drops or counts anything.

That is what makes a panic line reading `test spoofed::case ... ok` impossible to miscount and impossible to delete. Pinned by an inline test.

## Measured against master, real cargo 1.94

| mode | v0.24.0 | this PR |
|---|---|---|
| failing, default | `pass: 21` — count wrong by one, whole report discarded | full report + `20 passed; 3 failed; 1 ignored` |
| failing, `-q` | `fail: 0` on a 3-failure run | full report, correct counts |
| failing, `--color always` | `fail: 0` | full report, correct counts |
| `--nocapture` | fail count wrong | correct, panics kept |
| `-- --list` | all 30 lines deleted | raw list restored |
| `--no-run` | three false zero lines | stderr only |
| compile failure | three false zeros + rustc diagnostic | rustc diagnostic, no false zeros |
| passing run | `pass: 22` | cargo's own per-target lines |

Better or equal in 13 of 14 modes measured; the 14th was the head cap, see below. The `-q` and `--color always` header inaccuracy needed no separate fix: it was a property of the suffix-matching `aggregate` patterns and disappeared with the stage.

## The cap

The first version of this branch capped at 60 lines, and adversarial review found the one row where it was worse than master: on a 23-failure run the cut swallowed the `failures:` name list and the trailing `test result:` line, losing the count that the unfiltered output got right. Raised to 150, which covers a couple of dozen failures with their panic blocks. Past that the count goes and the tee file is the answer, and the cut is announced with `+N more lines` either way.

Pinned: dropping the cap to 10 fails the inline test.

## Two earlier attempts, for the record

The first added `append: true` plus a `remove_lines`; review reproduced the header reading "no tests ran" under `-q` and `--color always`, and the `remove_lines` both miscounting and deleting panic text. The second reworked it with a new `sum:` mode on `aggregate` in `internal/filter/actions.go` and `streams: [stdout, stderr]`; review reproduced four defects, three of them regressions against its own parent, including a dropped panic under `--nocapture`. Its stated justification for `streams:` was also wrong: `pipeline.go` already re-emits stderr verbatim when a filter does not consume it, so master showed the full rustc diagnostic all along.

This branch touches no Go file and adds no DSL capability.

## Tests

Six inline `tests:`, CI-enforced since #139: a passing run, a failing run, a panic shaped like a test result, quiet mode, a multi-target run, and the report keeping its tail. Written against the unmodified pipeline first, where they ran 0/6.

`snip verify` 132 filters / 22 tested / 55 tests / 0 failed. Full CI green locally. `SKILL.md` embeds this filter verbatim as its state-machine example and is updated, with a note on why drop and count stages must sit before the `failures:` boundary.
