### PR TITLE
feat(config): honor CLAUDE_CONFIG_DIR for all .claude path lookups

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -339,3 +339,17 @@ func configPath() string {
 	}
 	return filepath.Join(home, ".config", "snip", "config.toml")
 }
+
+// ClaudeBaseDir returns the base directory for Claude Code's `.claude` files.
+// It honors the CLAUDE_CONFIG_DIR environment variable (which Claude Code itself
+// respects), falling back to ~/.claude. Returns empty string on error.
+func ClaudeBaseDir() string {
+	if d := os.Getenv("CLAUDE_CONFIG_DIR"); d != "" {
+		return d
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".claude")
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -342,14 +342,24 @@ func configPath() string {
 
 // ClaudeBaseDir returns the base directory for Claude Code's `.claude` files.
 // It honors the CLAUDE_CONFIG_DIR environment variable (which Claude Code itself
-// respects), falling back to ~/.claude. Returns empty string on error.
-func ClaudeBaseDir() string {
+// respects), falling back to ~/.claude.
+func ClaudeBaseDir() (string, error) {
 	if d := os.Getenv("CLAUDE_CONFIG_DIR"); d != "" {
-		return d
+		return d, nil
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".claude"), nil
+}
+
+// ClaudeProjectsDir returns the base Claude Code projects directory,
+// honoring CLAUDE_CONFIG_DIR. Returns "" if the base directory cannot be resolved.
+func ClaudeProjectsDir() string {
+	base, err := ClaudeBaseDir()
+	if err != nil {
 		return ""
 	}
-	return filepath.Join(home, ".claude")
+	return filepath.Join(base, "projects")
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -355,7 +355,8 @@ func ClaudeBaseDir() (string, error) {
 }
 
 // ClaudeProjectsDir returns the base Claude Code projects directory,
-// honoring CLAUDE_CONFIG_DIR. Returns "" if the base directory cannot be resolved.
+// honoring CLAUDE_CONFIG_DIR. Returns "" when the home directory cannot be
+// resolved; callers treat that as "no sessions found".
 func ClaudeProjectsDir() string {
 	base, err := ClaudeBaseDir()
 	if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1258,7 +1258,10 @@ func TestLoadMergedMinimalProjectConfig(t *testing.T) {
 func TestClaudeBaseDirRespectsEnvVar(t *testing.T) {
 	t.Setenv("CLAUDE_CONFIG_DIR", "/custom/claude/config")
 
-	got := ClaudeBaseDir()
+	got, err := ClaudeBaseDir()
+	if err != nil {
+		t.Fatalf("ClaudeBaseDir() error: %v", err)
+	}
 	if got != "/custom/claude/config" {
 		t.Errorf("ClaudeBaseDir() = %q, want %q", got, "/custom/claude/config")
 	}
@@ -1272,7 +1275,10 @@ func TestClaudeBaseDirFallsBackToHomeClaude(t *testing.T) {
 		t.Skip("cannot get home dir")
 	}
 
-	got := ClaudeBaseDir()
+	got, err := ClaudeBaseDir()
+	if err != nil {
+		t.Fatalf("ClaudeBaseDir() error: %v", err)
+	}
 	want := filepath.Join(home, ".claude")
 	if got != want {
 		t.Errorf("ClaudeBaseDir() = %q, want %q", got, want)
@@ -1289,5 +1295,30 @@ func TestClaudeBaseDirDoesNotAffectSnipConfig(t *testing.T) {
 
 	if got := configPath(); got != snipConfigPath {
 		t.Errorf("configPath() = %q, want %q (should ignore CLAUDE_CONFIG_DIR)", got, snipConfigPath)
+	}
+}
+
+func TestClaudeProjectsDirRespectsEnvVar(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "/custom/claude/dir")
+
+	got := ClaudeProjectsDir()
+	want := filepath.Join("/custom/claude/dir", "projects")
+	if got != want {
+		t.Errorf("ClaudeProjectsDir() = %q, want %q", got, want)
+	}
+}
+
+func TestClaudeProjectsDirFallsBackToHome(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot get home dir")
+	}
+
+	got := ClaudeProjectsDir()
+	want := filepath.Join(home, ".claude", "projects")
+	if got != want {
+		t.Errorf("ClaudeProjectsDir() = %q, want %q", got, want)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1254,3 +1254,40 @@ func TestLoadMergedMinimalProjectConfig(t *testing.T) {
 		t.Error("user git-diff should be preserved with minimal project config")
 	}
 }
+
+func TestClaudeBaseDirRespectsEnvVar(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "/custom/claude/config")
+
+	got := ClaudeBaseDir()
+	if got != "/custom/claude/config" {
+		t.Errorf("ClaudeBaseDir() = %q, want %q", got, "/custom/claude/config")
+	}
+}
+
+func TestClaudeBaseDirFallsBackToHomeClaude(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot get home dir")
+	}
+
+	got := ClaudeBaseDir()
+	want := filepath.Join(home, ".claude")
+	if got != want {
+		t.Errorf("ClaudeBaseDir() = %q, want %q", got, want)
+	}
+}
+
+func TestClaudeBaseDirDoesNotAffectSnipConfig(t *testing.T) {
+	// CLAUDE_CONFIG_DIR must never override SNIP_CONFIG or snip's own
+	// config path resolution — it only affects .claude paths.
+	dir := t.TempDir()
+	snipConfigPath := filepath.Join(dir, "snip-config.toml")
+	t.Setenv("SNIP_CONFIG", snipConfigPath)
+	t.Setenv("CLAUDE_CONFIG_DIR", "/some/other/claude/dir")
+
+	if got := configPath(); got != snipConfigPath {
+		t.Errorf("configPath() = %q, want %q (should ignore CLAUDE_CONFIG_DIR)", got, snipConfigPath)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1268,6 +1268,7 @@ func TestClaudeBaseDirRespectsEnvVar(t *testing.T) {
 }
 
 func TestClaudeBaseDirFallsBackToHomeClaude(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	t.Setenv("CLAUDE_CONFIG_DIR", "")
 
 	home, err := os.UserHomeDir()
@@ -1286,8 +1287,9 @@ func TestClaudeBaseDirFallsBackToHomeClaude(t *testing.T) {
 }
 
 func TestClaudeBaseDirDoesNotAffectSnipConfig(t *testing.T) {
-	// CLAUDE_CONFIG_DIR must never override SNIP_CONFIG or snip's own
-	// config path resolution — it only affects .claude paths.
+	// Guard, not a regression test: configPath() never read CLAUDE_CONFIG_DIR
+	// before this PR either. CLAUDE_CONFIG_DIR must never override SNIP_CONFIG
+	// or snip's own config path resolution — it only affects .claude paths.
 	dir := t.TempDir()
 	snipConfigPath := filepath.Join(dir, "snip-config.toml")
 	t.Setenv("SNIP_CONFIG", snipConfigPath)
@@ -1309,6 +1311,7 @@ func TestClaudeProjectsDirRespectsEnvVar(t *testing.T) {
 }
 
 func TestClaudeProjectsDirFallsBackToHome(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	t.Setenv("CLAUDE_CONFIG_DIR", "")
 
 	home, err := os.UserHomeDir()

--- a/internal/discover/discover.go
+++ b/internal/discover/discover.go
@@ -21,8 +21,8 @@ import (
 type sessionLine struct {
 	Type    string `json:"type"`
 	Message *struct {
-		Role    string          `json:"role"`
-		Content json.RawMessage `json:"content"`
+		Role    string            `json:"role"`
+		Content json.RawMessage   `json:"content"`
 	} `json:"message,omitempty"`
 	Timestamp string `json:"timestamp,omitempty"`
 }

--- a/internal/discover/discover.go
+++ b/internal/discover/discover.go
@@ -21,8 +21,8 @@ import (
 type sessionLine struct {
 	Type    string `json:"type"`
 	Message *struct {
-		Role    string            `json:"role"`
-		Content json.RawMessage   `json:"content"`
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
 	} `json:"message,omitempty"`
 	Timestamp string `json:"timestamp,omitempty"`
 }
@@ -125,16 +125,6 @@ func parseArgs(args []string) Options {
 	return opts
 }
 
-// claudeProjectsDir returns the base Claude Code projects directory,
-// honoring CLAUDE_CONFIG_DIR.
-func claudeProjectsDir() string {
-	base := config.ClaudeBaseDir()
-	if base == "" {
-		return ""
-	}
-	return filepath.Join(base, "projects")
-}
-
 // cwdToProjectName converts a working directory path to the Claude Code
 // project directory name format: slashes become dashes, leading slash stripped.
 func cwdToProjectName(cwd string) string {
@@ -145,7 +135,7 @@ func cwdToProjectName(cwd string) string {
 
 // findProjectDirs returns the list of Claude Code project directories to scan.
 func findProjectDirs(opts Options) ([]string, error) {
-	base := claudeProjectsDir()
+	base := config.ClaudeProjectsDir()
 	if base == "" {
 		return nil, nil
 	}

--- a/internal/discover/discover.go
+++ b/internal/discover/discover.go
@@ -125,13 +125,14 @@ func parseArgs(args []string) Options {
 	return opts
 }
 
-// claudeProjectsDir returns the base Claude Code projects directory.
+// claudeProjectsDir returns the base Claude Code projects directory,
+// honoring CLAUDE_CONFIG_DIR.
 func claudeProjectsDir() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
+	base := config.ClaudeBaseDir()
+	if base == "" {
 		return ""
 	}
-	return filepath.Join(home, ".claude", "projects")
+	return filepath.Join(base, "projects")
 }
 
 // cwdToProjectName converts a working directory path to the Claude Code

--- a/internal/discover/discover_test.go
+++ b/internal/discover/discover_test.go
@@ -409,6 +409,30 @@ func TestPrintResultTruncatesLongNames(t *testing.T) {
 	}
 }
 
+func TestFindProjectDirsRespectsClaudeConfigDir(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	claudeDir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", claudeDir)
+	t.Chdir(t.TempDir())
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectDir := filepath.Join(claudeDir, "projects", cwdToProjectName(cwd))
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	dirs, err := findProjectDirs(Options{})
+	if err != nil {
+		t.Fatalf("findProjectDirs: %v", err)
+	}
+	if len(dirs) != 1 || dirs[0] != projectDir {
+		t.Errorf("findProjectDirs() = %v, want [%s]", dirs, projectDir)
+	}
+}
+
 func writeLines(t *testing.T, path string, lines []string) {
 	t.Helper()
 	data := ""

--- a/internal/discover/discover_test.go
+++ b/internal/discover/discover_test.go
@@ -419,3 +419,28 @@ func writeLines(t *testing.T, path string, lines []string) {
 		t.Fatal(err)
 	}
 }
+
+func TestClaudeProjectsDirRespectsEnvVar(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "/custom/claude/dir")
+
+	got := claudeProjectsDir()
+	want := filepath.Join("/custom/claude/dir", "projects")
+	if got != want {
+		t.Errorf("claudeProjectsDir() = %q, want %q", got, want)
+	}
+}
+
+func TestClaudeProjectsDirFallsBackToHome(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot get home dir")
+	}
+
+	got := claudeProjectsDir()
+	want := filepath.Join(home, ".claude", "projects")
+	if got != want {
+		t.Errorf("claudeProjectsDir() = %q, want %q", got, want)
+	}
+}

--- a/internal/discover/discover_test.go
+++ b/internal/discover/discover_test.go
@@ -419,28 +419,3 @@ func writeLines(t *testing.T, path string, lines []string) {
 		t.Fatal(err)
 	}
 }
-
-func TestClaudeProjectsDirRespectsEnvVar(t *testing.T) {
-	t.Setenv("CLAUDE_CONFIG_DIR", "/custom/claude/dir")
-
-	got := claudeProjectsDir()
-	want := filepath.Join("/custom/claude/dir", "projects")
-	if got != want {
-		t.Errorf("claudeProjectsDir() = %q, want %q", got, want)
-	}
-}
-
-func TestClaudeProjectsDirFallsBackToHome(t *testing.T) {
-	t.Setenv("CLAUDE_CONFIG_DIR", "")
-
-	home, err := os.UserHomeDir()
-	if err != nil {
-		t.Skip("cannot get home dir")
-	}
-
-	got := claudeProjectsDir()
-	want := filepath.Join(home, ".claude", "projects")
-	if got != want {
-		t.Errorf("claudeProjectsDir() = %q, want %q", got, want)
-	}
-}

--- a/internal/initcmd/init.go
+++ b/internal/initcmd/init.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/edouard-claude/snip/internal/config"
 )
 
 const (
@@ -136,7 +138,7 @@ func Run(args []string) error {
 
 	switch agent {
 	case "claude-code":
-		return initClaudeCode(snipBin, home, filterDir)
+		return initClaudeCode(snipBin, filterDir)
 	case "cursor":
 		return initCursor(snipBin, home, filterDir)
 	case "codex":
@@ -187,16 +189,21 @@ func resolveSnipBin() (string, error) {
 }
 
 // initClaudeCode installs the snip hook for Claude Code.
-func initClaudeCode(snipBin, home, filterDir string) error {
+func initClaudeCode(snipBin, filterDir string) error {
+	claudeBase := config.ClaudeBaseDir()
+	if claudeBase == "" {
+		return fmt.Errorf("get home dir: resolve CLAUDE_CONFIG_DIR or $HOME")
+	}
+
 	// Migrate: remove old bash hook script if present
-	oldHookPath := filepath.Join(home, ".claude", "hooks", legacyHookFile)
+	oldHookPath := filepath.Join(claudeBase, "hooks", legacyHookFile)
 	if _, err := os.Stat(oldHookPath); err == nil {
 		_ = os.Remove(oldHookPath)
 		fmt.Printf("  migrated: removed old %s\n", legacyHookFile)
 	}
 
 	hookCommand := snipBin + " hook"
-	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	settingsPath := filepath.Join(claudeBase, "settings.json")
 	if err := patchClaudeSettings(settingsPath, hookCommand); err != nil {
 		return fmt.Errorf("patch settings: %w", err)
 	}
@@ -300,16 +307,16 @@ func Uninstall(agent string) error {
 
 // uninstallClaudeCode removes snip integration from Claude Code.
 func uninstallClaudeCode() error {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("get home dir: %w", err)
+	claudeBase := config.ClaudeBaseDir()
+	if claudeBase == "" {
+		return fmt.Errorf("get home dir: resolve CLAUDE_CONFIG_DIR or $HOME")
 	}
 
 	// Remove legacy bash script if present
-	oldHookPath := filepath.Join(home, ".claude", "hooks", legacyHookFile)
+	oldHookPath := filepath.Join(claudeBase, "hooks", legacyHookFile)
 	_ = os.Remove(oldHookPath)
 
-	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	settingsPath := filepath.Join(claudeBase, "settings.json")
 	if err := unpatchClaudeSettings(settingsPath); err != nil {
 		return fmt.Errorf("unpatch settings: %w", err)
 	}

--- a/internal/initcmd/init.go
+++ b/internal/initcmd/init.go
@@ -190,9 +190,9 @@ func resolveSnipBin() (string, error) {
 
 // initClaudeCode installs the snip hook for Claude Code.
 func initClaudeCode(snipBin, filterDir string) error {
-	claudeBase := config.ClaudeBaseDir()
-	if claudeBase == "" {
-		return fmt.Errorf("get home dir: resolve CLAUDE_CONFIG_DIR or $HOME")
+	claudeBase, err := config.ClaudeBaseDir()
+	if err != nil {
+		return fmt.Errorf("get home dir: %w", err)
 	}
 
 	// Migrate: remove old bash hook script if present
@@ -307,9 +307,9 @@ func Uninstall(agent string) error {
 
 // uninstallClaudeCode removes snip integration from Claude Code.
 func uninstallClaudeCode() error {
-	claudeBase := config.ClaudeBaseDir()
-	if claudeBase == "" {
-		return fmt.Errorf("get home dir: resolve CLAUDE_CONFIG_DIR or $HOME")
+	claudeBase, err := config.ClaudeBaseDir()
+	if err != nil {
+		return fmt.Errorf("get home dir: %w", err)
 	}
 
 	// Remove legacy bash script if present

--- a/internal/initcmd/init_test.go
+++ b/internal/initcmd/init_test.go
@@ -621,6 +621,66 @@ func TestRunUnknownAgent(t *testing.T) {
 	}
 }
 
+func TestInitClaudeCodeRespectsClaudeConfigDir(t *testing.T) {
+	claudeDir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", claudeDir)
+
+	filterDir := t.TempDir()
+	err := initClaudeCode("/usr/local/bin/snip", filterDir)
+	if err != nil {
+		t.Fatalf("initClaudeCode: %v", err)
+	}
+
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	if _, err := os.Stat(settingsPath); err != nil {
+		t.Errorf("expected settings.json at %s honoring CLAUDE_CONFIG_DIR: %v", settingsPath, err)
+	}
+}
+
+func TestInitClaudeCodeMigratesLegacyHookUnderClaudeConfigDir(t *testing.T) {
+	claudeDir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", claudeDir)
+
+	hooksDir := filepath.Join(claudeDir, "hooks")
+	if err := os.MkdirAll(hooksDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	oldHookPath := filepath.Join(hooksDir, legacyHookFile)
+	if err := os.WriteFile(oldHookPath, []byte("#!/bin/bash\nexit 0"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	filterDir := t.TempDir()
+	if err := initClaudeCode("/usr/local/bin/snip", filterDir); err != nil {
+		t.Fatalf("initClaudeCode: %v", err)
+	}
+
+	if _, err := os.Stat(oldHookPath); !os.IsNotExist(err) {
+		t.Error("legacy hook script under CLAUDE_CONFIG_DIR should be removed")
+	}
+}
+
+func TestUninstallClaudeCodeRespectsClaudeConfigDir(t *testing.T) {
+	claudeDir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", claudeDir)
+
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	if err := patchClaudeSettings(settingsPath, "/usr/local/bin/snip hook"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := uninstallClaudeCode(); err != nil {
+		t.Fatalf("uninstallClaudeCode: %v", err)
+	}
+
+	settings := readSettings(t, settingsPath)
+	if hooks, ok := settings["hooks"].(map[string]any); ok {
+		if _, ok := hooks["PreToolUse"]; ok {
+			t.Error("expected snip hook removed from CLAUDE_CONFIG_DIR settings")
+		}
+	}
+}
+
 func readSettings(t *testing.T, path string) map[string]any {
 	t.Helper()
 	data, err := os.ReadFile(path)

--- a/internal/initcmd/init_test.go
+++ b/internal/initcmd/init_test.go
@@ -622,6 +622,7 @@ func TestRunUnknownAgent(t *testing.T) {
 }
 
 func TestInitClaudeCodeRespectsClaudeConfigDir(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	claudeDir := t.TempDir()
 	t.Setenv("CLAUDE_CONFIG_DIR", claudeDir)
 
@@ -638,6 +639,7 @@ func TestInitClaudeCodeRespectsClaudeConfigDir(t *testing.T) {
 }
 
 func TestInitClaudeCodeMigratesLegacyHookUnderClaudeConfigDir(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	claudeDir := t.TempDir()
 	t.Setenv("CLAUDE_CONFIG_DIR", claudeDir)
 
@@ -661,6 +663,7 @@ func TestInitClaudeCodeMigratesLegacyHookUnderClaudeConfigDir(t *testing.T) {
 }
 
 func TestUninstallClaudeCodeRespectsClaudeConfigDir(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	claudeDir := t.TempDir()
 	t.Setenv("CLAUDE_CONFIG_DIR", claudeDir)
 

--- a/internal/learn/learn.go
+++ b/internal/learn/learn.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/edouard-claude/snip/internal/config"
 	"github.com/edouard-claude/snip/internal/hook"
 )
 
@@ -196,13 +197,14 @@ func parseArgs(args []string) Options {
 	return opts
 }
 
-// claudeProjectsDir returns the base Claude Code projects directory.
+// claudeProjectsDir returns the base Claude Code projects directory,
+// honoring CLAUDE_CONFIG_DIR.
 func claudeProjectsDir() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
+	base := config.ClaudeBaseDir()
+	if base == "" {
 		return ""
 	}
-	return filepath.Join(home, ".claude", "projects")
+	return filepath.Join(base, "projects")
 }
 
 // cwdToProjectName converts a working directory path to the Claude Code

--- a/internal/learn/learn.go
+++ b/internal/learn/learn.go
@@ -72,22 +72,22 @@ type bashInput struct {
 
 // commandEntry represents a Bash command extracted from a session with its result.
 type commandEntry struct {
-	Command   string // full command string
-	BaseCmd   string // extracted base command name
-	ToolUseID string // tool_use id for matching results
-	Output    string // tool result content (if found)
-	IsError   bool   // whether the tool result indicated an error
-	HasResult bool   // whether a result was matched
-	Timestamp string // timestamp from the JSONL entry
+	Command    string // full command string
+	BaseCmd    string // extracted base command name
+	ToolUseID  string // tool_use id for matching results
+	Output     string // tool result content (if found)
+	IsError    bool   // whether the tool result indicated an error
+	HasResult  bool   // whether a result was matched
+	Timestamp  string // timestamp from the JSONL entry
 }
 
 // ErrorPattern represents a detected error-correction pattern.
 type ErrorPattern struct {
-	BaseCommand  string // base command name (e.g. "go", "git")
-	ErrorCommand string // the command that failed
-	ErrorOutput  string // truncated error output
-	FixCommand   string // the command that succeeded
-	Count        int    // number of times this pattern occurred
+	BaseCommand    string // base command name (e.g. "go", "git")
+	ErrorCommand   string // the command that failed
+	ErrorOutput    string // truncated error output
+	FixCommand     string // the command that succeeded
+	Count          int    // number of times this pattern occurred
 }
 
 // PatternGroup aggregates similar error patterns by base command.
@@ -581,6 +581,7 @@ func generateRules(r Result) error {
 		return nil
 	}
 
+	// Project-relative, not CLAUDE_CONFIG_DIR: rules live with the project, not user config.
 	dir := filepath.Join(".claude", "rules")
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("create rules directory: %w", err)

--- a/internal/learn/learn.go
+++ b/internal/learn/learn.go
@@ -72,22 +72,22 @@ type bashInput struct {
 
 // commandEntry represents a Bash command extracted from a session with its result.
 type commandEntry struct {
-	Command    string // full command string
-	BaseCmd    string // extracted base command name
-	ToolUseID  string // tool_use id for matching results
-	Output     string // tool result content (if found)
-	IsError    bool   // whether the tool result indicated an error
-	HasResult  bool   // whether a result was matched
-	Timestamp  string // timestamp from the JSONL entry
+	Command   string // full command string
+	BaseCmd   string // extracted base command name
+	ToolUseID string // tool_use id for matching results
+	Output    string // tool result content (if found)
+	IsError   bool   // whether the tool result indicated an error
+	HasResult bool   // whether a result was matched
+	Timestamp string // timestamp from the JSONL entry
 }
 
 // ErrorPattern represents a detected error-correction pattern.
 type ErrorPattern struct {
-	BaseCommand    string // base command name (e.g. "go", "git")
-	ErrorCommand   string // the command that failed
-	ErrorOutput    string // truncated error output
-	FixCommand     string // the command that succeeded
-	Count          int    // number of times this pattern occurred
+	BaseCommand  string // base command name (e.g. "go", "git")
+	ErrorCommand string // the command that failed
+	ErrorOutput  string // truncated error output
+	FixCommand   string // the command that succeeded
+	Count        int    // number of times this pattern occurred
 }
 
 // PatternGroup aggregates similar error patterns by base command.
@@ -197,16 +197,6 @@ func parseArgs(args []string) Options {
 	return opts
 }
 
-// claudeProjectsDir returns the base Claude Code projects directory,
-// honoring CLAUDE_CONFIG_DIR.
-func claudeProjectsDir() string {
-	base := config.ClaudeBaseDir()
-	if base == "" {
-		return ""
-	}
-	return filepath.Join(base, "projects")
-}
-
 // cwdToProjectName converts a working directory path to the Claude Code
 // project directory name format.
 func cwdToProjectName(cwd string) string {
@@ -215,7 +205,7 @@ func cwdToProjectName(cwd string) string {
 
 // findProjectDirs returns the list of Claude Code project directories to scan.
 func findProjectDirs(opts Options) ([]string, error) {
-	base := claudeProjectsDir()
+	base := config.ClaudeProjectsDir()
 	if base == "" {
 		return nil, nil
 	}

--- a/internal/learn/learn_test.go
+++ b/internal/learn/learn_test.go
@@ -517,3 +517,28 @@ func writeLines(t *testing.T, path string, lines []string) {
 		t.Fatal(err)
 	}
 }
+
+func TestClaudeProjectsDirRespectsEnvVar(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "/custom/claude/dir")
+
+	got := claudeProjectsDir()
+	want := filepath.Join("/custom/claude/dir", "projects")
+	if got != want {
+		t.Errorf("claudeProjectsDir() = %q, want %q", got, want)
+	}
+}
+
+func TestClaudeProjectsDirFallsBackToHome(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot get home dir")
+	}
+
+	got := claudeProjectsDir()
+	want := filepath.Join(home, ".claude", "projects")
+	if got != want {
+		t.Errorf("claudeProjectsDir() = %q, want %q", got, want)
+	}
+}

--- a/internal/learn/learn_test.go
+++ b/internal/learn/learn_test.go
@@ -507,6 +507,30 @@ func TestStringOrArrayUnmarshal(t *testing.T) {
 	}
 }
 
+func TestFindProjectDirsRespectsClaudeConfigDir(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	claudeDir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", claudeDir)
+	t.Chdir(t.TempDir())
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectDir := filepath.Join(claudeDir, "projects", cwdToProjectName(cwd))
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	dirs, err := findProjectDirs(Options{})
+	if err != nil {
+		t.Fatalf("findProjectDirs: %v", err)
+	}
+	if len(dirs) != 1 || dirs[0] != projectDir {
+		t.Errorf("findProjectDirs() = %v, want [%s]", dirs, projectDir)
+	}
+}
+
 func writeLines(t *testing.T, path string, lines []string) {
 	t.Helper()
 	data := ""

--- a/internal/learn/learn_test.go
+++ b/internal/learn/learn_test.go
@@ -517,28 +517,3 @@ func writeLines(t *testing.T, path string, lines []string) {
 		t.Fatal(err)
 	}
 }
-
-func TestClaudeProjectsDirRespectsEnvVar(t *testing.T) {
-	t.Setenv("CLAUDE_CONFIG_DIR", "/custom/claude/dir")
-
-	got := claudeProjectsDir()
-	want := filepath.Join("/custom/claude/dir", "projects")
-	if got != want {
-		t.Errorf("claudeProjectsDir() = %q, want %q", got, want)
-	}
-}
-
-func TestClaudeProjectsDirFallsBackToHome(t *testing.T) {
-	t.Setenv("CLAUDE_CONFIG_DIR", "")
-
-	home, err := os.UserHomeDir()
-	if err != nil {
-		t.Skip("cannot get home dir")
-	}
-
-	got := claudeProjectsDir()
-	want := filepath.Join(home, ".claude", "projects")
-	if got != want {
-		t.Errorf("claudeProjectsDir() = %q, want %q", got, want)
-	}
-}


### PR DESCRIPTION
## Summary
- `snip learn`, `snip discover`, and the Claude Code hook installer (`snip init`/`snip uninstall`) hardcoded `~/.claude`, so they silently found nothing for users running Claude Code with a non-default `CLAUDE_CONFIG_DIR`.
- Adds `config.ClaudeBaseDir()` as the single source of truth for `.claude` path resolution: checks `CLAUDE_CONFIG_DIR` (the same env var Claude Code itself respects) before falling back to `~/.claude`.
- Adds `config.ClaudeProjectsDir()` (base dir + `projects`) used by both `discover` and `learn` — previously each package had its own byte-identical copy of this helper.
- `discover.go`, `learn.go`, and `initcmd/init.go` now route through these helpers instead of constructing `.claude` paths directly.
- `SNIP_CONFIG` and snip's own config resolution (`configPath()`) are untouched — `CLAUDE_CONFIG_DIR` only affects `.claude` lookups, not snip's own config directory.

## Fixed during review
A pre-PR review pass (code-reviewer, semgrep, silent-failure-hunter, variant-bug-hunter, code-simplifier) surfaced two issues, both fixed:
- **P1 — lost error context:** `ClaudeBaseDir()` originally swallowed the underlying `os.UserHomeDir()` error and returned `""`, so `initClaudeCode`/`uninstallClaudeCode` had to hand-roll a generic error message instead of wrapping the real cause (a regression vs. the pre-PR code, which did `fmt.Errorf("get home dir: %w", err)`). Changed `ClaudeBaseDir()` to return `(string, error)` so callers can wrap the actual failure; `discover`/`learn` keep their existing silent-on-failure behavior by discarding the error, matching their pre-existing UX.
- **P2 — duplicated helper:** `discover.go` and `learn.go` each had a byte-identical `claudeProjectsDir()` wrapper. Consolidated into `config.ClaudeProjectsDir()`, removing the duplicate implementation and duplicate test pairs.

## Reviewed and dismissed
- Silent-failure-hunter flagged that `discover`/`learn` return "no session directories found" instead of surfacing a HOME-resolution error — confirmed via `git show master:<file>` that this exact behavior predates this PR (not a regression), so left as-is.
- The asymmetry between `discover`/`learn` (silent) and `initcmd` (loud error) on a resolution failure also predates this branch.
- semgrep and variant-bug-hunter: no findings.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean
- [x] `go test ./...` (all 18 packages pass)
- [x] Tests: `ClaudeBaseDir`/`ClaudeProjectsDir` env-var/fallback/isolation-from-`SNIP_CONFIG` (config), `initClaudeCode`/`uninstallClaudeCode` env-var behavior (initcmd)
