### PR TITLE
docs: correct Codex hook descriptions

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -262,8 +262,9 @@ func runHook() int {
 }
 
 // runHookCodex handles "snip hook codex" — Codex's PreToolUse hook entry.
-// Codex cannot rewrite the command in place, so the handler responds with
-// a deny + suggested rewrite. Always returns 0 (graceful degradation).
+// Fully attestable commands are rewritten through updatedInput and allowed;
+// mixed or unverifiable commands pass through unchanged. Always returns 0
+// (graceful degradation).
 func runHookCodex() int {
 	snipBin, commands, prefixes, ok := loadHookContext()
 	if !ok {

--- a/internal/hook/suggest.go
+++ b/internal/hook/suggest.go
@@ -6,8 +6,8 @@ import (
 )
 
 // snipSuggestion is the outcome of analyzing a command for a deny-and-steer
-// re-run suggestion, used by hosts whose PreToolUse hooks cannot rewrite the
-// command in place (Codex, Grok Build).
+// re-run suggestion, used by Grok Build because its PreToolUse hook cannot
+// rewrite the command in place.
 type snipSuggestion struct {
 	// command is the full suggested re-run command; empty when no snip filter
 	// matched.

--- a/internal/initcmd/grok.go
+++ b/internal/initcmd/grok.go
@@ -51,7 +51,7 @@ func initGrok(snipBin, home, filterDir string) error {
 	fmt.Printf("  config: %s\n", path)
 	fmt.Println()
 	fmt.Println("note: Grok Build hooks cannot rewrite commands in place, so snip denies")
-	fmt.Println("      matched commands with a re-run suggestion (same pattern as Codex).")
+	fmt.Println("      matched commands with a re-run suggestion.")
 	fmt.Println("      Verify the hook is loaded with `grok inspect` or /hooks-list.")
 	fmt.Println("      For the prompt-injection setup instead use:")
 	fmt.Println("        snip init --agent grok --mode prompt")

--- a/internal/initcmd/grok.go
+++ b/internal/initcmd/grok.go
@@ -10,6 +10,9 @@ import (
 // grokHookSubcommand is the snip subsubcommand Grok Build invokes.
 const grokHookSubcommand = "hook grok"
 
+const grokDenyRerunNote = "note: Grok Build hooks cannot rewrite commands in place, so snip denies\n" +
+	"      matched commands with a re-run suggestion."
+
 // grokMatcher is the PreToolUse matcher written to the hook config. The field
 // is a regex tested against the tool name; it covers Grok Build's native shell
 // tool (run_terminal_cmd) and the Claude-style alias (Bash) it also accepts.
@@ -50,8 +53,7 @@ func initGrok(snipBin, home, filterDir string) error {
 	fmt.Printf("  filters: %s\n", filterDir)
 	fmt.Printf("  config: %s\n", path)
 	fmt.Println()
-	fmt.Println("note: Grok Build hooks cannot rewrite commands in place, so snip denies")
-	fmt.Println("      matched commands with a re-run suggestion.")
+	fmt.Println(grokDenyRerunNote)
 	fmt.Println("      Verify the hook is loaded with `grok inspect` or /hooks-list.")
 	fmt.Println("      For the prompt-injection setup instead use:")
 	fmt.Println("        snip init --agent grok --mode prompt")

--- a/internal/initcmd/grok_test.go
+++ b/internal/initcmd/grok_test.go
@@ -7,6 +7,15 @@ import (
 	"testing"
 )
 
+func TestGrokDenyRerunNoteDescribesOnlyGrok(t *testing.T) {
+	if !strings.Contains(grokDenyRerunNote, "Grok Build hooks cannot rewrite commands in place") {
+		t.Fatalf("Grok limitation missing from init note: %q", grokDenyRerunNote)
+	}
+	if strings.Contains(grokDenyRerunNote, "Codex") {
+		t.Fatalf("Grok init note must not describe Codex as deny-and-rerun: %q", grokDenyRerunNote)
+	}
+}
+
 func TestBuildGrokHookConfig(t *testing.T) {
 	cfg := buildGrokHookConfig(`"/usr/local/bin/snip" hook grok`)
 


### PR DESCRIPTION
## What changed

- describe the Codex hook as transparent `updatedInput` rewriting for fully
  attestable commands
- document that mixed or unverifiable commands pass through unchanged
- remove Grok initialization text claiming its deny-and-rerun behavior matches
  Codex
- remove the remaining stale Codex reference from the deny-and-rerun suggestion
  helper
- add a regression test that keeps Grok's initialization guidance Grok-only

## Why

Codex gained native command rewriting, but two stale descriptions still
documented its former deny-and-rerun behavior. That made the CLI source and
Grok initialization output disagree with the implemented hook contract.

## Validation

- `go test ./internal/hook/... ./internal/cli/... ./internal/initcmd/...`
- `go test ./...`
- `go vet ./...`
- repository-wide search for obsolete Codex deny-and-rerun wording
