### PR TITLE
docs(hook): align Codex rewrite guidance

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -262,8 +262,9 @@ func runHook() int {
 }
 
 // runHookCodex handles "snip hook codex" — Codex's PreToolUse hook entry.
-// Codex cannot rewrite the command in place, so the handler responds with
-// a deny + suggested rewrite. Always returns 0 (graceful degradation).
+// Fully attestable commands are rewritten through updatedInput and allowed;
+// mixed or unverifiable commands pass through unchanged. Always returns 0
+// (graceful degradation).
 func runHookCodex() int {
 	snipBin, commands, prefixes, ok := loadHookContext()
 	if !ok {

--- a/internal/hook/suggest.go
+++ b/internal/hook/suggest.go
@@ -6,8 +6,8 @@ import (
 )
 
 // snipSuggestion is the outcome of analyzing a command for a deny-and-steer
-// re-run suggestion, used by hosts whose PreToolUse hooks cannot rewrite the
-// command in place (Codex, Grok Build).
+// re-run suggestion, used by Grok Build because its PreToolUse hook cannot
+// rewrite the command in place.
 type snipSuggestion struct {
 	// command is the full suggested re-run command; empty when no snip filter
 	// matched.

--- a/internal/initcmd/grok.go
+++ b/internal/initcmd/grok.go
@@ -51,7 +51,7 @@ func initGrok(snipBin, home, filterDir string) error {
 	fmt.Printf("  config: %s\n", path)
 	fmt.Println()
 	fmt.Println("note: Grok Build hooks cannot rewrite commands in place, so snip denies")
-	fmt.Println("      matched commands with a re-run suggestion (same pattern as Codex).")
+	fmt.Println("      matched commands with a re-run suggestion.")
 	fmt.Println("      Verify the hook is loaded with `grok inspect` or /hooks-list.")
 	fmt.Println("      For the prompt-injection setup instead use:")
 	fmt.Println("        snip init --agent grok --mode prompt")


### PR DESCRIPTION
## Why

Codex hook support changed in `e61b319` from deny-and-rerun guidance to transparent command rewriting through `updatedInput` and an `allow` decision.

The implementation and primary documentation already describe that behavior, but three nearby descriptions still reflected the previous model:

- the CLI hook registration comment described Codex as unable to rewrite commands;
- the rerun suggestion helper implied that Codex still consumed Grok-style guidance;
- `snip init grok` called its deny-and-rerun integration “the same pattern as Codex.”

These stale descriptions made the integration architecture appear inconsistent even though the runtime behavior was already correct.

## What changed

- Describe Codex commands as transparently rewritten when the command is fully attestable.
- Clarify that mixed or unverifiable Codex commands pass through unchanged.
- Describe the rerun suggestion helper as Grok-specific.
- Remove the obsolete Codex comparison from the Grok initialization output.

## What did not change

This PR does not change hook execution, command classification, permission decisions, audit behavior, or public APIs.

Codex continues to:

- return `allow` with `updatedInput` for fully attestable commands;
- preserve supported hook input fields such as `timeout`;
- pass mixed commands through unchanged.

Grok continues to use deny-and-rerun guidance because its hook protocol does not provide the same transparent rewrite path.

## Scope and test rationale

The diff is limited to two internal comments and one initialization message.

The earlier draft added a production constant solely so a test could assert the wording of that message. This revision keeps the production flow unchanged and avoids introducing a test-only abstraction that would not exercise hook behavior or initialization output end to end.

Existing Codex hook tests continue to cover the runtime rewrite contract.

## Validation

- `go test ./internal/hook/... ./internal/cli/... ./internal/initcmd/...`
- `go test ./...`
- `go vet ./...`
- `go test -race ./...`
- `git diff --check`
- Built-binary hook probe:
  - verified that `git status` returns `allow` with a `snip run -- git status` replacement;
  - verified that the input `timeout` is preserved;
  - verified that `git status && custom-tool deploy` passes through unchanged.
- Searched Go and Markdown sources for remaining Codex deny/rerun wording; no stale matches remained.

No wiki update is required because runtime behavior and the documented integration contract are unchanged.
