### PR TITLE
fix(install): resolve source install destinations safely

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,8 +62,10 @@ make build-lite          # Build without SQLite tracking (-tags lite, ~5MB small
 make test                # Run all tests with coverage
 make test-race           # Run tests with race detector
 make lint                # go vet + golangci-lint
-make install             # Install to $GOPATH/bin
+make install             # Install using GOBIN or the Go environment
 make install-lite        # Install lite variant
+make upgrade             # Replace active snip (GOBIN overrides)
+make upgrade-lite        # Replace active snip with lite variant
 go test -run TestName ./internal/filter/...   # Single test
 goreleaser release --snapshot --clean          # Test release build locally
 ```

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-lite build-windows test test-race lint install install-lite clean
+.PHONY: build build-lite build-windows test test-install test-race lint install install-lite upgrade upgrade-lite clean
 
 BINARY=snip
 BUILD_DIR=cmd/snip
@@ -17,6 +17,9 @@ build-windows:
 test:
 	go test -cover ./...
 
+test-install:
+	sh tests/source-install/test.sh
+
 test-race:
 	go test -race ./...
 
@@ -25,10 +28,43 @@ lint:
 	@which golangci-lint > /dev/null 2>&1 && golangci-lint run || echo "golangci-lint not installed, skipping"
 
 install: build
-	cp $(BINARY) $(GOPATH)/bin/$(BINARY) 2>/dev/null || cp $(BINARY) /usr/local/bin/$(BINARY)
 
 install-lite: build-lite
-	cp $(BINARY) $(GOPATH)/bin/$(BINARY) 2>/dev/null || cp $(BINARY) /usr/local/bin/$(BINARY)
+
+upgrade: build
+
+upgrade-lite: build-lite
+
+install install-lite upgrade upgrade-lite:
+	@case "$@" in \
+		upgrade*) destination="$$(scripts/install-path --upgrade)" ;; \
+		*) destination="$$(scripts/install-path)" ;; \
+	esac || exit 1; \
+	install_dir="$$(dirname "$$destination")"; \
+	printf 'Installing %s\n' "$$destination"; \
+	if ! mkdir -p "$$install_dir"; then \
+		printf 'snip: cannot create install directory %s; set GOBIN to a writable directory\n' "$$install_dir" >&2; \
+		exit 1; \
+	fi; \
+	temporary="$$(mktemp "$$install_dir/.snip.install.XXXXXX")" || { \
+		printf 'snip: cannot create temporary file in %s; set GOBIN to a writable directory\n' "$$install_dir" >&2; \
+		exit 1; \
+	}; \
+	trap 'rm -f "$$temporary"' 0; \
+	trap 'exit 1' 1 2 15; \
+	if ! cp "$(BINARY)" "$$temporary"; then \
+		printf 'snip: cannot install to %s; set GOBIN to a writable directory\n' "$$destination" >&2; \
+		exit 1; \
+	fi; \
+	if ! chmod 0755 "$$temporary"; then \
+		printf 'snip: cannot make %s executable; set GOBIN to a writable directory\n' "$$destination" >&2; \
+		exit 1; \
+	fi; \
+	if ! mv -f "$$temporary" "$$destination"; then \
+		printf 'snip: cannot replace %s; set GOBIN to a writable directory\n' "$$destination" >&2; \
+		exit 1; \
+	fi; \
+	trap - 0 1 2 15
 
 clean:
 	rm -f $(BINARY) $(BINARY).exe

--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ git clone https://github.com/edouard-claude/snip.git
 cd snip && make install
 ```
 
+On Linux, `make install` and `make install-lite` use the first available destination:
+an explicit `GOBIN`, `go env GOBIN`, or the first `go env GOPATH` entry plus
+`/bin`. Use `make upgrade` or `make upgrade-lite` to replace the resolved
+`snip` on `PATH` instead. An explicit `GOBIN` overrides the upgrade destination.
+
 Requires Go 1.25+.
 
 ## Supported AI Tools
@@ -548,7 +553,8 @@ make build        # static binary (CGO_ENABLED=0)
 make test         # all tests with coverage
 make test-race    # race detector
 make lint         # go vet + golangci-lint
-make install      # install to $GOPATH/bin
+make install      # install using GOBIN or the Go environment
+make upgrade      # replace the active snip binary (GOBIN overrides)
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ git clone https://github.com/edouard-claude/snip.git
 cd snip && make install
 ```
 
-On Linux, `make install` and `make install-lite` use the first available destination:
+`make install` and `make install-lite` use the first available destination:
 an explicit `GOBIN`, `go env GOBIN`, or the first `go env GOPATH` entry plus
 `/bin`. Use `make upgrade` or `make upgrade-lite` to replace the resolved
 `snip` on `PATH` instead. An explicit `GOBIN` overrides the upgrade destination.

--- a/scripts/install-path
+++ b/scripts/install-path
@@ -1,0 +1,75 @@
+#!/bin/sh
+
+set -eu
+
+upgrade=false
+case "$#" in
+	0) ;;
+	1)
+		if [ "$1" != "--upgrade" ]; then
+			printf 'usage: install-path [--upgrade]\n' >&2
+			exit 2
+		fi
+		upgrade=true
+		;;
+	*)
+		printf 'usage: install-path [--upgrade]\n' >&2
+		exit 2
+		;;
+esac
+
+if [ -n "${GOBIN:-}" ]; then
+	printf '%s/snip\n' "${GOBIN%/}"
+	exit 0
+fi
+
+snip_path=
+if [ "$upgrade" = true ]; then
+	snip_path=$(command -v snip 2>/dev/null || true)
+fi
+if [ -n "$snip_path" ]; then
+	link_count=0
+	while [ -L "$snip_path" ]; do
+		if [ "$link_count" -ge 40 ]; then
+			printf 'snip: cannot resolve existing snip symlink: too many links\n' >&2
+			exit 1
+		fi
+		link_target=$(readlink "$snip_path") || {
+			printf 'snip: cannot resolve existing snip symlink; set GOBIN explicitly\n' >&2
+			exit 1
+		}
+		case "$link_target" in
+			/*) snip_path=$link_target ;;
+			*) snip_path=$(dirname "$snip_path")/$link_target ;;
+		esac
+		link_count=$((link_count + 1))
+	done
+	snip_dir=$(CDPATH='' cd -- "$(dirname "$snip_path")" && pwd -P) || {
+		printf 'snip: cannot resolve existing snip path; set GOBIN explicitly\n' >&2
+		exit 1
+	}
+	printf '%s/%s\n' "$snip_dir" "$(basename "$snip_path")"
+	exit 0
+fi
+
+go_bin=$(go env GOBIN) || {
+	printf 'snip: cannot read GOBIN from Go; set GOBIN or configure the Go environment\n' >&2
+	exit 1
+}
+if [ -n "$go_bin" ]; then
+	printf '%s/snip\n' "${go_bin%/}"
+	exit 0
+fi
+
+go_path=$(go env GOPATH) || {
+	printf 'snip: cannot read GOPATH from Go; set GOBIN or configure the Go environment\n' >&2
+	exit 1
+}
+first_go_path=${go_path%%:*}
+if [ -n "$first_go_path" ]; then
+	printf '%s/bin/snip\n' "${first_go_path%/}"
+	exit 0
+fi
+
+printf 'snip: no install destination; set GOBIN or configure the Go environment\n' >&2
+exit 1

--- a/source_install_test.go
+++ b/source_install_test.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+package snip
+
+import (
+	_ "embed"
+	"os/exec"
+	"testing"
+)
+
+// Embedding makes shell-suite changes invalidate the Go test cache.
+//go:embed tests/source-install/test.sh
+var sourceInstallTestScript string
+
+func TestSourceInstall(t *testing.T) {
+	if sourceInstallTestScript == "" {
+		t.Fatal("embedded source-install test is empty")
+	}
+
+	cmd := exec.Command("sh", "tests/source-install/test.sh")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("source-install tests failed: %v\n%s", err, output)
+	}
+}

--- a/source_install_test.go
+++ b/source_install_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 // Embedding makes shell-suite changes invalidate the Go test cache.
+//
 //go:embed tests/source-install/test.sh
 var sourceInstallTestScript string
 

--- a/tests/source-install/test.sh
+++ b/tests/source-install/test.sh
@@ -1,0 +1,221 @@
+#!/bin/sh
+
+set -eu
+
+repo_root=$(CDPATH='' cd -- "$(dirname "$0")/../.." && pwd)
+resolver="$repo_root/scripts/install-path"
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fake_bin="$tmp_dir/bin"
+mkdir -p "$fake_bin"
+test_path="$fake_bin:/usr/bin:/bin"
+
+cat >"$fake_bin/go" <<'EOF'
+#!/bin/sh
+case "$1 $2" in
+  "env GOBIN")
+    printf '%s\n' "${TEST_GO_GOBIN:-}"
+    ;;
+  "env GOPATH")
+    printf '%s\n' "${TEST_GO_GOPATH:-}"
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+EOF
+chmod +x "$fake_bin/go"
+
+assert_destination() {
+	name=$1
+	want=$2
+	shift 2
+
+	got=$("$@")
+	if [ "$got" != "$want" ]; then
+		printf '%s: got %s, want %s\n' "$name" "$got" "$want" >&2
+		exit 1
+	fi
+}
+
+existing_bin="$tmp_dir/existing/bin"
+mkdir -p "$existing_bin"
+cat >"$existing_bin/snip" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+chmod +x "$existing_bin/snip"
+
+assert_destination "explicit GOBIN" "$tmp_dir/explicit dir/snip" \
+	env GOBIN="$tmp_dir/explicit dir" PATH="$existing_bin:$fake_bin" \
+	TEST_GO_GOBIN="$tmp_dir/go-bin" TEST_GO_GOPATH="$tmp_dir/go-path" \
+	"$resolver"
+
+assert_destination "explicit GOBIN upgrade" "$tmp_dir/explicit dir/snip" \
+	env GOBIN="$tmp_dir/explicit dir" PATH="$existing_bin:$fake_bin" \
+	TEST_GO_GOBIN="$tmp_dir/go-bin" TEST_GO_GOPATH="$tmp_dir/go-path" \
+	"$resolver" --upgrade
+
+assert_destination "install ignores existing snip" "$tmp_dir/go-bin/snip" \
+	env GOBIN= PATH="$existing_bin:$test_path" \
+	TEST_GO_GOBIN="$tmp_dir/go-bin" TEST_GO_GOPATH="$tmp_dir/go-path" \
+	"$resolver"
+
+assert_destination "upgrade existing snip" "$existing_bin/snip" \
+	env GOBIN= PATH="$existing_bin:$test_path" \
+	TEST_GO_GOBIN="$tmp_dir/go-bin" TEST_GO_GOPATH="$tmp_dir/go-path" \
+	"$resolver" --upgrade
+
+assert_destination "go env GOBIN" "$tmp_dir/go-bin/snip" \
+	env GOBIN= PATH="$test_path" \
+	TEST_GO_GOBIN="$tmp_dir/go-bin" TEST_GO_GOPATH="$tmp_dir/go-path" \
+	"$resolver"
+
+assert_destination "upgrade without existing snip" "$tmp_dir/go-bin/snip" \
+	env GOBIN= PATH="$test_path" \
+	TEST_GO_GOBIN="$tmp_dir/go-bin" TEST_GO_GOPATH="$tmp_dir/go-path" \
+	"$resolver" --upgrade
+
+assert_destination "first GOPATH entry" "$tmp_dir/go-path-one/bin/snip" \
+	env GOBIN= PATH="$test_path" \
+	TEST_GO_GOBIN="" TEST_GO_GOPATH="$tmp_dir/go-path-one:$tmp_dir/go-path-two" \
+	"$resolver"
+
+error_file="$tmp_dir/error"
+if env GOBIN= PATH="$test_path" TEST_GO_GOBIN="" TEST_GO_GOPATH="" \
+	"$resolver" >"$tmp_dir/output" 2>"$error_file"; then
+	printf 'empty Go environment unexpectedly resolved a destination\n' >&2
+	exit 1
+fi
+
+if [ -s "$tmp_dir/output" ]; then
+	printf 'empty Go environment produced a destination: %s\n' "$(cat "$tmp_dir/output")" >&2
+	exit 1
+fi
+
+if ! grep -q "set GOBIN or configure the Go environment" "$error_file"; then
+	printf 'empty Go environment did not produce an actionable error\n' >&2
+	exit 1
+fi
+
+if "$resolver" --unknown >"$tmp_dir/output" 2>"$error_file"; then
+	printf 'unknown resolver option unexpectedly succeeded\n' >&2
+	exit 1
+else
+	status=$?
+fi
+if [ "$status" -ne 2 ] || ! grep -q 'usage: install-path' "$error_file"; then
+	printf 'unknown resolver option did not produce a usage error\n' >&2
+	exit 1
+fi
+
+symlink_target="$tmp_dir/releases/0.25.0/snip-real"
+mkdir -p "$(dirname "$symlink_target")" "$tmp_dir/current/bin"
+cp "$existing_bin/snip" "$symlink_target"
+ln -s "../../releases/0.25.0/snip-real" "$tmp_dir/current/bin/snip"
+assert_destination "existing snip symlink" "$symlink_target" \
+	env GOBIN= PATH="$tmp_dir/current/bin:$test_path" \
+	TEST_GO_GOBIN="$tmp_dir/go-bin" TEST_GO_GOPATH="$tmp_dir/go-path" \
+	"$resolver" --upgrade
+
+for target in install install-lite upgrade upgrade-lite; do
+	recipe=$(make -C "$repo_root" -n "$target")
+	if ! printf '%s\n' "$recipe" | grep -q 'scripts/install-path'; then
+		printf '%s does not use the shared destination resolver\n' "$target" >&2
+		exit 1
+	fi
+	if printf '%s\n' "$recipe" | grep -q '/usr/local/bin'; then
+		printf '%s still contains the privileged fallback\n' "$target" >&2
+		exit 1
+	fi
+	if ! printf '%s\n' "$recipe" | grep -q 'mv -f.*temporary.*destination'; then
+		printf '%s does not replace the destination atomically\n' "$target" >&2
+		exit 1
+	fi
+	if ! printf '%s\n' "$recipe" | grep -q 'mktemp'; then
+		printf '%s uses a predictable temporary path\n' "$target" >&2
+		exit 1
+	fi
+done
+
+make_project="$tmp_dir/make-project"
+mkdir -p "$make_project/scripts"
+cp "$repo_root/Makefile" "$make_project/Makefile"
+cp "$resolver" "$make_project/scripts/install-path"
+printf '#!/bin/sh\nprintf updated\n' >"$make_project/snip"
+chmod +x "$make_project/snip"
+
+if PATH="$test_path" GOBIN='' TEST_GO_GOBIN='' TEST_GO_GOPATH='' \
+	make -s -C "$make_project" -o build install \
+	>"$tmp_dir/install-output" 2>"$tmp_dir/install-error"; then
+	printf 'install unexpectedly succeeded without a destination\n' >&2
+	exit 1
+fi
+if [ -s "$tmp_dir/install-output" ]; then
+	printf 'install continued after destination resolution failed\n' >&2
+	exit 1
+fi
+if ! grep -q "no install destination" "$tmp_dir/install-error"; then
+	printf 'install did not report destination resolution failure\n' >&2
+	exit 1
+fi
+
+blocked_parent="$tmp_dir/not-a-directory"
+printf 'blocked\n' >"$blocked_parent"
+if make -s -C "$make_project" -o build install \
+	GOBIN="$blocked_parent/child" >"$tmp_dir/install-output" 2>"$tmp_dir/install-error"; then
+	printf 'install unexpectedly succeeded with an invalid destination\n' >&2
+	exit 1
+fi
+if ! grep -Fq "Installing $blocked_parent/child/snip" "$tmp_dir/install-output"; then
+	printf 'failed install did not print its resolved destination\n' >&2
+	exit 1
+fi
+if ! grep -Fq "cannot create install directory $blocked_parent/child" "$tmp_dir/install-error"; then
+	printf 'failed install did not produce an actionable error\n' >&2
+	exit 1
+fi
+
+for target in install install-lite upgrade upgrade-lite; do
+	case "$target" in
+		install|upgrade) build_target=build ;;
+		install-lite|upgrade-lite) build_target=build-lite ;;
+	esac
+	install_dir="$tmp_dir/$target destination"
+	make -s -C "$make_project" -o "$build_target" "$target" GOBIN="$install_dir"
+	if ! cmp -s "$make_project/snip" "$install_dir/snip"; then
+		printf '%s did not install the requested binary\n' "$target" >&2
+		exit 1
+	fi
+	if [ ! -x "$install_dir/snip" ]; then
+		printf '%s did not install an executable binary\n' "$target" >&2
+		exit 1
+	fi
+done
+
+printf '#!/bin/sh\nprintf old\n' >"$symlink_target"
+PATH="$tmp_dir/current/bin:$test_path" GOBIN='' \
+	TEST_GO_GOBIN="$tmp_dir/default-install" TEST_GO_GOPATH="$tmp_dir/go-path" \
+	make -s -C "$make_project" -o build install
+if ! grep -q old "$symlink_target"; then
+	printf 'install unexpectedly changed the active snip target\n' >&2
+	exit 1
+fi
+if ! cmp -s "$make_project/snip" "$tmp_dir/default-install/snip"; then
+	printf 'install did not use the Go-configured destination\n' >&2
+	exit 1
+fi
+
+PATH="$tmp_dir/current/bin:$test_path" GOBIN='' \
+	make -s -C "$make_project" -o build upgrade
+if [ ! -L "$tmp_dir/current/bin/snip" ]; then
+	printf 'upgrade replaced the active snip symlink\n' >&2
+	exit 1
+fi
+if ! cmp -s "$make_project/snip" "$symlink_target"; then
+	printf 'upgrade did not replace the active snip symlink target\n' >&2
+	exit 1
+fi
+
+printf 'source-install destination tests passed\n'

--- a/tests/source-install/test.sh
+++ b/tests/source-install/test.sh
@@ -4,7 +4,7 @@ set -eu
 
 repo_root=$(CDPATH='' cd -- "$(dirname "$0")/../.." && pwd)
 resolver="$repo_root/scripts/install-path"
-tmp_dir=$(mktemp -d)
+tmp_dir=$(CDPATH='' cd -- "$(mktemp -d)" && pwd -P)
 trap 'rm -rf "$tmp_dir"' EXIT
 
 fake_bin="$tmp_dir/bin"


### PR DESCRIPTION
The Makefile currently copies to `$(GOPATH)/bin`, then silently retries `/usr/local/bin` when that fails.

When `GOPATH` is unset, the first destination expands to `/bin/snip`. That makes a routine source install depend on privileged system directories, ignores `GOBIN`, and can replace a different installation than the one the user intended.

## Destination policy

This separates ordinary installation from explicitly replacing the active binary.

`make install` and `make install-lite` use:

1. an explicit `GOBIN`
2. `go env GOBIN`
3. the first `go env GOPATH` entry plus `/bin`

They do not inspect `PATH`. This follows Go's install-directory convention and makes the result independent of whichever `snip` happens to be active in the current shell.

`make upgrade` and `make upgrade-lite` use:

1. an explicit `GOBIN`
2. the resolved location of the active `snip` on `PATH`
3. the same Go-environment fallbacks as `make install`

The separate target makes replacing an existing installation intentional. `GOBIN` remains an explicit override in both modes.

## Replacement safety

Installation now stages the built binary in a destination-local temporary file, sets mode `0755`, and renames it over the destination.

Keeping the temporary file in the destination directory means the final rename stays on one filesystem. Failures stop at the selected destination and report an actionable error; there is no retry into an unrelated privileged directory.

For upgrades through a symlink, the resolver follows the link chain and replaces the final target. The user-facing symlink remains intact. Resolution is bounded at 40 links and fails closed if the path cannot be resolved.

## Scope

The source installer is documented as Linux-only until the shell behavior has been exercised on macOS.

This does not change:

- `go install`
- the release installer
- Homebrew installation
- the public `snip` CLI
- Windows builds

## Tests

The source-install suite covers:

- explicit `GOBIN` precedence
- `go env GOBIN`
- the first entry in a multi-entry `GOPATH`
- ordinary install ignoring an active `snip`
- explicit upgrade selecting the active `snip`
- upgrade fallback when no active binary exists
- relative symlink resolution and target replacement
- paths containing spaces
- full and lite install/upgrade targets
- executable permissions
- empty Go environment failures
- Make-level resolver failure propagation
- invalid and unwritable destinations
- destination-local atomic replacement

The shell suite is embedded as a Go test input so edits invalidate Go's test cache, then executed through `sh` on non-Windows platforms.

Passed:

- `shellcheck scripts/install-path tests/source-install/test.sh`
- `sh -n scripts/install-path tests/source-install/test.sh`
- `sh tests/source-install/test.sh`
- `make test`
- `go vet ./...`
- `make test-race`
- Windows root-package test compilation with `GOOS=windows CGO_ENABLED=0`
- `git diff --check`

## Documentation

`README.md` and `CLAUDE.md` describe the install/upgrade distinction.

The Installation wiki should receive the same source-install note. I do not have push access to `snip.wiki`, so that update is not included here.

🤖 Generated with Codex
