### PR TITLE
fix(hook): stop four shapes from closing a live block

### DIFF
--- a/internal/hook/blockscope.go
+++ b/internal/hook/blockscope.go
@@ -49,17 +49,13 @@ const (
 //     group, and never on a case-arm pattern ("  a )"). Reserved words count
 //     only in command position and comments are skipped whole, so neither
 //     `echo done` nor `# done` closes anything.
-//   - Command position is approximated, not decided the way the shell does, and
-//     four shapes are known to fool it. A case-arm pattern that is itself a
-//     reserved word (`case $s in done)`) is read as a command and closes the
-//     case. An extglob alternative does the same, because '|' is treated as a
-//     pipeline separator everywhere (`for f in @(data|done).txt`). `time -p`
-//     loses the opener that follows it, since only bare `time` is whitelisted.
-//     And a '#' written flush against a ')' is not seen as a comment, because
-//     isWordStart does not count ')' as a word boundary (`a)# done marker`).
-//     All four are pre-existing: they corrupt identically on master, which has
-//     no block tracking at all, so this file narrows the defect rather than
-//     introducing it. Tracked separately.
+//   - Command position is approximated, not decided the way the shell does. The
+//     four shapes of issue #138 used to fool it and are now handled: a case-arm
+//     pattern spelled like a reserved word (`case $s in done)`), an extglob
+//     alternative (`for f in @(data|done).txt`), `time` with its own options
+//     (`time -p for i in 1`), and a '#' flush against an operator ')'
+//     (`a)# done marker`). The approximation remains one: a shape nobody has
+//     hit yet can still read a pattern or an argument as a command.
 //   - A missed opener costs correctness, not just savings: the body is rewritten
 //     and a consumer of the block reads snip's compacted output. Every opener
 //     above is therefore matched on the shell's own rule (command position),
@@ -84,6 +80,19 @@ type blockScope struct {
 	// funcName is set between the `function` reserved word and the name that
 	// follows it, so the '{' after the name is still seen in command position.
 	funcName bool
+	// casePattern is set while the words being read are a case-arm pattern
+	// rather than a command: from the `in` of `case $s in` to that arm's ')',
+	// and again from each ';;' to the next ')'. A pattern spelled like a
+	// reserved word ("done)") must not be classified as one.
+	casePattern bool
+	// caseHeader is set between `case` and the `in` that ends its subject, so
+	// only that `in` arms casePattern. An `in` in an arm body ("echo in") is an
+	// ordinary word and must not turn the rest of the body into a pattern.
+	caseHeader bool
+	// afterTime is set just past `time` and its own option words, which keep
+	// command position so the timed command — possibly a block opener — is
+	// still seen ("time -p for i in 1").
+	afterTime bool
 }
 
 // inBlock reports whether the group being flushed sits inside a compound
@@ -122,7 +131,23 @@ func (s *blockScope) closeKeyword() {
 	for len(s.stack) > 0 && s.stack[len(s.stack)-1] == blockParen {
 		s.stack = s.stack[:len(s.stack)-1]
 	}
+	if k, ok := s.top(); ok && k == blockCase {
+		// `esac`: whatever arm state was open belongs to the case being closed.
+		// An enclosing case, if any, is back in an arm body, never in a pattern.
+		s.casePattern = false
+		s.caseHeader = false
+	}
 	s.pop()
+}
+
+// caseArmEnd records the ';;' that ends a case arm. The words after it are the
+// next arm's pattern, so a pattern spelled like a reserved word ("done)") does
+// not close the case. The segmenter reports it because ';' is a group boundary
+// and advance never sees one.
+func (s *blockScope) caseArmEnd() {
+	if k, ok := s.top(); ok && k == blockCase {
+		s.casePattern = true
+	}
 }
 
 // advance updates the scope from a group that has just been emitted. It walks
@@ -135,7 +160,16 @@ func (s *blockScope) closeKeyword() {
 // scope stays open and every later top-level command silently loses filtering.
 func (s *blockScope) advance(group string) {
 	cmdPos := true
+	// Set while the byte just consumed was a ')' acting as an operator: a
+	// case-arm pattern's or a subshell's. Bash starts a word right after such a
+	// ')', so a '#' flush against it opens a comment. isWordStart cannot tell
+	// that ')' from the one closing a command substitution, where the '#' is
+	// still inside the word ("$(ls)#tail"), so the distinction is made here,
+	// where the kind of the paren being closed is known.
+	operatorParen := false
 	for i := 0; i < len(group); {
+		afterOperatorParen := operatorParen
+		operatorParen = false
 		switch c := group[i]; c {
 		case ' ', '\t', '\n':
 			i++
@@ -147,14 +181,21 @@ func (s *blockScope) advance(group string) {
 			// position ("cat list | while read -r l" opens a loop). ';' is a
 			// group boundary and cannot reach here, but costs nothing to accept.
 			i++
-			cmdPos = true
+			// Inside parentheses that are not a subshell, '|' is pattern
+			// alternation and the word after it is a pattern: in
+			// "@(data|done).txt" a bare `done` must not close the enclosing loop.
+			if k, ok := s.top(); ok && k == blockParen {
+				cmdPos = false
+			} else {
+				cmdPos = true
+			}
 		case '&', '<', '>':
 			// Redirections only: "&&" and a bare "&" are group boundaries, so an
 			// '&' here belongs to a form like "2>&1".
 			i++
 			cmdPos = false
 		case '#':
-			if !isWordStart(group, i) {
+			if !isWordStart(group, i) && !afterOperatorParen {
 				// Not a comment: '#' can follow a quoted region inside one word
 				// (`"x"#y`). The only way to land here is just past a closing
 				// quote, which already cleared cmdPos.
@@ -174,9 +215,13 @@ func (s *blockScope) advance(group string) {
 				// End of a case-arm pattern ("  a )" or "  -v | --verbose )").
 				// The case block stays open, so the arm body stays unwrapped,
 				// and the arm's own body is a command position.
+				s.casePattern = false
+				s.caseHeader = false
+				operatorParen = true
 				cmdPos = true
 				continue
 			} else if ok && (k == blockParen || k == blockSubshell) {
+				operatorParen = k == blockSubshell
 				s.pop()
 			}
 			cmdPos = false
@@ -251,8 +296,37 @@ func (s *blockScope) openParen(group string, i int, cmdPos bool) (int, bool) {
 // is still in command position. Quoting is not stripped, matching the shell: a
 // quoted 'for' is not a reserved word, and advance never reaches here for one.
 func (s *blockScope) classify(word string, cmdPos bool) bool {
+	// `in` closes the subject of a case and opens its first arm pattern. It is
+	// read outside command position, which is where the subject leaves it.
+	if s.caseHeader && word == "in" {
+		if k, ok := s.top(); ok && k == blockCase {
+			s.caseHeader = false
+			s.casePattern = true
+			return false
+		}
+	}
+	if s.casePattern {
+		if word == "esac" {
+			// The one reserved word that still counts here: bash rejects a bare
+			// `esac` as an arm pattern, so this closes the case. Without it the
+			// scope would stay open and everything after it lose filtering.
+			s.closeKeyword()
+			return false
+		}
+		// Every other word is a pattern, not a command: `done)` opens an arm of
+		// the case, it does not close it.
+		return false
+	}
 	if !cmdPos {
 		return false
+	}
+	if s.afterTime {
+		// `time [-p] [--] pipeline`: its own options keep command position, so
+		// the opener that follows them is still seen.
+		if word == "-p" || word == "--" {
+			return true
+		}
+		s.afterTime = false
 	}
 	if s.funcName {
 		// The word after `function` is the name being defined, not a command.
@@ -277,11 +351,15 @@ func (s *blockScope) classify(word string, cmdPos bool) bool {
 		return false // a variable name follows, not a command
 	case "case":
 		s.push(blockCase)
+		s.caseHeader = true
 		return false
 	case "done", "fi", "esac":
 		s.closeKeyword()
 		return false
-	case "then", "do", "else", "elif", "!", "time":
+	case "time":
+		s.afterTime = true
+		return true
+	case "then", "do", "else", "elif", "!":
 		// Reserved words that introduce another command position, so a nested
 		// opener on the same line ("then if false") is still seen.
 		return true

--- a/internal/hook/blockscope_test.go
+++ b/internal/hook/blockscope_test.go
@@ -780,3 +780,97 @@ func TestRewriteNoFalsePositives(t *testing.T) {
 		})
 	}
 }
+
+// TestRewriteCommandPosition pins issue #138: four shapes fooled the
+// command-position approximation, so a reserved word that is not a command
+// closed a block that was still open and the body was rewritten. Each case here
+// corrupts identically on master, where a `grep` capped at 50 lines answered a
+// consumer that must see all 60.
+func TestRewriteCommandPosition(t *testing.T) {
+	const bin = "/usr/local/bin/snip"
+	const w = `"/usr/local/bin/snip" run -- `
+	cmdSet := map[string]struct{}{"git": {}, "go": {}, "grep": {}, "wc": {}}
+
+	cases := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{
+			// A case-arm pattern is a pattern, never a command: `done)` must not
+			// pop the case it is an arm of.
+			name: "case arm pattern is a reserved word",
+			cmd:  "case $s in\n  done)\n    grep MATCH data.txt\n    ;;\nesac | wc -l",
+			want: "case $s in\n  done)\n    grep MATCH data.txt\n    ;;\nesac | wc -l",
+		},
+		{
+			// The arm pattern is re-armed after ';;', so a later arm is protected
+			// too, not just the first one.
+			name: "reserved word in a later case arm",
+			cmd:  "case $s in\n  a)\n    echo x\n    ;;\n  done)\n    grep MATCH data.txt\n    ;;\nesac | wc -l",
+			want: "case $s in\n  a)\n    echo x\n    ;;\n  done)\n    grep MATCH data.txt\n    ;;\nesac | wc -l",
+		},
+		{
+			// Inside parentheses '|' is pattern alternation, not a pipeline, so it
+			// does not restore command position.
+			name: "extglob alternative names a reserved word",
+			cmd:  "for f in @(data|done).txt\ndo\n  grep MATCH $f\ndone | wc -l",
+			want: "for f in @(data|done).txt\ndo\n  grep MATCH $f\ndone | wc -l",
+		},
+		{
+			// `time` keeps command position for the command it times; its own
+			// options must not lose the opener that follows them.
+			name: "time with its -p option",
+			cmd:  "time -p for i in 1\ndo\n  grep MATCH data.txt\ndone | wc -l",
+			want: "time -p for i in 1\ndo\n  grep MATCH data.txt\ndone | wc -l",
+		},
+		{
+			// Bash starts a word right after the ')' operator, so this is a
+			// comment and the `done` inside it closes nothing.
+			name: "comment flush against a case arm paren",
+			cmd:  "case $s in\n  a)# done marker\n    grep MATCH data.txt\n    ;;\nesac | wc -l",
+			want: "case $s in\n  a)# done marker\n    grep MATCH data.txt\n    ;;\nesac | wc -l",
+		},
+		{
+			name: "comment flush against a subshell paren",
+			cmd:  "(grep MATCH data.txt)# done\ngrep x y",
+			want: "(grep MATCH data.txt)# done\n" + w + "grep x y",
+		},
+		{
+			// Not a comment: this ')' closes a command substitution, so '#' is
+			// still inside the word. The block must keep closing normally.
+			name: "hash after a command substitution",
+			cmd:  "for f in $(ls)#tail\ndo\n  grep x $f\ndone\ngrep y z",
+			want: "for f in $(ls)#tail\ndo\n  grep x $f\ndone\n" + w + "grep y z",
+		},
+		{
+			// ${#f} is a length expansion, not a comment: the `done` after it must
+			// still close the loop, otherwise the next command loses filtering.
+			name: "length expansion inside a body",
+			cmd:  "for f in *.go\ndo\n  grep ${#f} $f\ndone\ngrep x y",
+			want: "for f in *.go\ndo\n  grep ${#f} $f\ndone\n" + w + "grep x y",
+		},
+		{
+			// `time` is not a known base command, so the group is left alone;
+			// what matters is that nothing here opens or closes a block.
+			name: "bare time before a plain command",
+			cmd:  "time grep MATCH data.txt\ngrep x y",
+			want: "time grep MATCH data.txt\n" + w + "grep x y",
+		},
+		{
+			// A pipeline after a case closes it: filtering resumes afterwards.
+			name: "filtering resumes after a case",
+			cmd:  "case $s in\n  done)\n    grep MATCH data.txt\n    ;;\nesac\ngrep x y",
+			want: "case $s in\n  done)\n    grep MATCH data.txt\n    ;;\nesac\n" + w + "grep x y",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := RewriteCommand(tc.cmd, cmdSet, nil, bin)
+			if res.Command != tc.want {
+				t.Errorf("Command = %q, want %q", res.Command, tc.want)
+			}
+		})
+	}
+}

--- a/internal/hook/rewrite.go
+++ b/internal/hook/rewrite.go
@@ -189,6 +189,13 @@ func RewriteCommand(cmd string, cmdSet map[string]struct{}, prefixes []Transpare
 			flush(cmd[groupStart:i])
 			b.WriteByte(ch)
 			i++
+			// ";;" ends a case arm, as do its ";&" and ";;&" variants. What
+			// follows is the next arm's pattern rather than a command, and
+			// blockScope cannot see it: ';' is a group boundary, so advance is
+			// never handed one (issue #138).
+			if i < len(cmd) && (cmd[i] == ';' || cmd[i] == '&') {
+				scope.caseArmEnd()
+			}
 			groupStart = i
 		case '&':
 			flush(cmd[groupStart:i])


### PR DESCRIPTION
Closes the first four shapes of #138. The fifth (a trailing backslash line continuation) has a different cause and is left for its own PR.

## The defect

The command-position approximation read a reserved word that is not a command as one, popped a block that was still open, and the body was then rewritten. A consumer of the block read snip's compacted output instead of the real one. All four corrupt identically on master.

Reproduced end to end against real bash, 60-line file behind `filters/grep.yaml`'s cap of `head n:50`:

| shape | raw | before | after |
|---|---:|---:|---:|
| `case $s in done)` | 60 | 51 | 60 |
| `for f in @(data\|done).txt` | 60 | 51 | 60 |
| `time -p for i in 1` | 60 | 51 | 60 |
| `a)# done marker` | 60 | 51 | 60 |

## The fixes

- **Case-arm patterns.** `blockScope` tracks the arm state of a case: entered at the `in` that ends the subject, re-entered at each `;;`, left at the arm's `)`. Words read in that state are patterns, so `done)` no longer pops the case. `esac` is the one exception, because bash rejects a bare `esac` as a pattern; without it the scope would stay open and everything after it would lose filtering. `;;` is reported by the segmenter, since ';' is a group boundary and `advance` never sees one.
- **Extglob alternatives.** Inside a paren that is not a subshell, '|' is pattern alternation and no longer restores command position.
- **`time` options.** `-p` and `--` keep command position, so the opener being timed is still seen. Bare `time` is unchanged.
- **`)#`.** A '#' flush against an operator ')' opens a comment. `advance` decides this where the kind of the paren being closed is known, which distinguishes it from `$(ls)#tail` where the ')' ends a command substitution and the '#' is still inside the word. The segmenter's own `isWordStart` is deliberately untouched: adding '{' there would read `${#var}` as a comment.

The file-level comment listing these four as known limitations is updated in the same commit.

## Tests

`TestRewriteCommandPosition` covers the four shapes, the `;;` re-arm on a later arm, and five non-regressions: `$(ls)#tail`, `${#f}`, a subshell `)#`, bare `time`, and filtering resuming after `esac`. Every case fails on master.

`make test-race`, `make verify` (55/55) and `golangci-lint` are clean.