### PR TITLE
fix(hook): recognize Grok's run_terminal_command tool name

### DIFF
--- a/internal/hook/grok.go
+++ b/internal/hook/grok.go
@@ -12,9 +12,17 @@ import (
 // grokAgent is the value written to hookaudit.Event.Agent for Grok Build events.
 const grokAgent = "grok"
 
-// grokToolName is the native shell tool name of Grok Build (xAI's coding CLI).
-// Grok Build also maps Claude-style tool aliases, so "Bash" is accepted too.
-const grokToolName = "run_terminal_cmd"
+// grokShellTools are the tool names Grok Build uses for its shell tool.
+// `run_terminal_command` is what the released CLI actually sends;
+// `run_terminal_cmd` is the spelling its hook docs use, and `Bash` is the
+// Claude-style alias Grok Build also maps. Missing one means the hook exits 0
+// with empty stdout, which Grok reads as allow, and nothing is ever filtered
+// (issue #145).
+var grokShellTools = map[string]struct{}{
+	"run_terminal_command": {},
+	"run_terminal_cmd":     {},
+	"Bash":                 {},
+}
 
 // grokInput represents the PreToolUse payload from Grok Build. Grok Build
 // sends camelCase keys, unlike Claude Code's snake_case:
@@ -54,7 +62,7 @@ func RunGrok(r io.Reader, w io.Writer, commands []string, prefixes []Transparent
 		return false, nil // malformed JSON: pass through silently
 	}
 
-	if input.ToolName != grokToolName && input.ToolName != "Bash" {
+	if _, ok := grokShellTools[input.ToolName]; !ok {
 		return false, nil
 	}
 

--- a/internal/hook/grok_test.go
+++ b/internal/hook/grok_test.go
@@ -86,6 +86,29 @@ func TestRunGrokBashAliasToolName(t *testing.T) {
 	}
 }
 
+// TestRunGrokShellToolNames pins issue #145: the released Grok CLI sends
+// `run_terminal_command`, which was not classified as a shell tool, so the hook
+// exited 0 with empty stdout — an allow — and no Grok session was ever filtered.
+func TestRunGrokShellToolNames(t *testing.T) {
+	for _, toolName := range []string{"run_terminal_command", "run_terminal_cmd", "Bash"} {
+		t.Run(toolName, func(t *testing.T) {
+			input := makeGrokPayload(toolName, "git status")
+			var out bytes.Buffer
+			denied, err := RunGrok(strings.NewReader(input), &out, []string{"git"}, nil, "/usr/local/bin/snip")
+			if err != nil {
+				t.Fatalf("RunGrok: %v", err)
+			}
+			if !denied {
+				t.Fatalf("expected denied=true for tool name %q, got an empty allow", toolName)
+			}
+			reason := extractGrokDenyReason(t, out.String())
+			if want := `"/usr/local/bin/snip" run -- git status`; !strings.Contains(reason, want) {
+				t.Errorf("reason = %q, want it to contain %q", reason, want)
+			}
+		})
+	}
+}
+
 func TestRunGrokUnsupportedPassthrough(t *testing.T) {
 	commands := []string{"git", "go"}
 	snipBin := "/usr/local/bin/snip"

--- a/internal/initcmd/grok.go
+++ b/internal/initcmd/grok.go
@@ -11,9 +11,10 @@ import (
 const grokHookSubcommand = "hook grok"
 
 // grokMatcher is the PreToolUse matcher written to the hook config. The field
-// is a regex tested against the tool name; it covers Grok Build's native shell
-// tool (run_terminal_cmd) and the Claude-style alias (Bash) it also accepts.
-const grokMatcher = "Bash|run_terminal_cmd"
+// is a regex tested against the tool name; it covers what the released CLI
+// sends (run_terminal_command), the spelling in Grok Build's hook docs
+// (run_terminal_cmd) and the Claude-style alias (Bash) it also accepts.
+const grokMatcher = "Bash|run_terminal_cmd|run_terminal_command"
 
 // grokHookFile is the snip-owned hook config filename. Grok Build loads every
 // *.json under its hooks directory, so snip writes a dedicated file rather


### PR DESCRIPTION
Closes #145.

## The defect

`snip hook grok` classified only `run_terminal_cmd` and `Bash` as shell tools. The released Grok CLI sends `run_terminal_command`, which fell through to the passthrough path: empty stdout, exit 0, which Grok reads as allow. `snip init --agent grok` therefore installed a hook that filtered nothing, and `snip gain` only ever moved for manual `snip run` invocations.

Before:

```
$ printf '%s' '{"toolName":"run_terminal_command","toolInput":{"command":"git status"}}' | snip hook grok
 exit:0
```

After:

```
$ printf '%s' '{"toolName":"run_terminal_command","toolInput":{"command":"git status"}}' | snip hook grok
{"decision":"deny","reason":"snip can filter this command. Re-run as: \"/usr/local/bin/snip\" run -- git status"}
 exit:2
```

## The fix

The three spellings live in one set: `run_terminal_command` (what the CLI sends), `run_terminal_cmd` (what the hook docs use) and `Bash` (the Claude-style alias). The init matcher gains the released name as well, so a fresh install matches it host-side too.

Not included: the issue's optional suggestion to audit unrecognized shell-like tool names under `SNIP_HOOK_AUDIT=1`. That is a separate feature, not this bug.

## Tests

`TestRunGrokShellToolNames` runs the deny path across the three names. Dropping `run_terminal_command` from the set fails it; the two existing names keep their own coverage. `make test-race` and `golangci-lint` are clean.