### PR TITLE
fix(hook): stop quoting the snip path as a Go literal on Windows

### DIFF
--- a/internal/hook/quote.go
+++ b/internal/hook/quote.go
@@ -1,0 +1,37 @@
+package hook
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+// quoteSnipBin renders the snip binary path for inclusion in a rewritten
+// command, so a path containing spaces still executes as one word.
+func quoteSnipBin(path string) string {
+	return quoteBinFor(path, runtime.GOOS)
+}
+
+// quoteBinFor is quoteSnipBin with the target OS injected, so both branches are
+// testable from any host.
+//
+// Go's %q is a Go string literal, not a shell word, and on Windows it is wrong
+// twice over: it doubles every backslash of a native path
+// (`"C:\\Users\\me\\snip.exe"`), and the quotes it adds make PowerShell parse
+// the result as a string expression rather than a command, which fails with
+// "Unexpected token 'run' in expression or statement" (issue #150).
+//
+// A Windows path with no space needs no quoting at all, and unquoted is the one
+// form that runs in PowerShell, cmd.exe and a POSIX shell alike. A path that
+// does contain a space still needs the quotes; PowerShell would additionally
+// need its call operator there, which cmd.exe rejects, so the quotes are
+// emitted without guessing which shell is on the other side.
+func quoteBinFor(path, goos string) string {
+	if goos == "windows" {
+		if !strings.ContainsAny(path, " \t\"") {
+			return path
+		}
+		return `"` + path + `"`
+	}
+	return fmt.Sprintf("%q", path)
+}

--- a/internal/hook/quote_test.go
+++ b/internal/hook/quote_test.go
@@ -1,0 +1,73 @@
+package hook
+
+import "testing"
+
+// TestQuoteBinFor pins issue #150: on Windows the rewritten command carried a
+// Go string literal, so the executable path arrived with doubled backslashes
+// and wrapped in quotes that PowerShell reads as a string expression
+// ("Unexpected token 'run' in expression or statement").
+func TestQuoteBinFor(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		goos string
+		want string
+	}{
+		{
+			name: "windows path without spaces is bare",
+			path: `C:\Users\Administrator\.snip\snip.exe`,
+			goos: "windows",
+			want: `C:\Users\Administrator\.snip\snip.exe`,
+		},
+		{
+			// Quotes are still required, and the backslashes must survive
+			// verbatim: "C:\\Program Files\\..." names no existing file.
+			name: "windows path with a space keeps its backslashes",
+			path: `C:\Program Files\snip\snip.exe`,
+			goos: "windows",
+			want: `"C:\Program Files\snip\snip.exe"`,
+		},
+		{
+			name: "posix path is quoted",
+			path: "/usr/local/bin/snip",
+			goos: "darwin",
+			want: `"/usr/local/bin/snip"`,
+		},
+		{
+			name: "posix path with a space is quoted",
+			path: "/Users/John Doe/bin/snip",
+			goos: "linux",
+			want: `"/Users/John Doe/bin/snip"`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := quoteBinFor(tc.path, tc.goos); got != tc.want {
+				t.Errorf("quoteBinFor(%q, %q) = %q, want %q", tc.path, tc.goos, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRewriteCommandWindowsBin is the end-to-end shape Codex receives: the
+// command must start with the executable, not with a quoted string.
+func TestRewriteCommandWindowsBin(t *testing.T) {
+	const bin = `C:\Users\Administrator\.snip\snip.exe`
+	cmdSet := map[string]struct{}{"git": {}}
+
+	got, known, _ := rewriteGroup("git diff --check", cmdSet, nil, quoteBinFor(bin, "windows"), bin)
+	want := `C:\Users\Administrator\.snip\snip.exe run -- git diff --check`
+	if got != want {
+		t.Errorf("rewritten = %q, want %q", got, want)
+	}
+	if !known {
+		t.Error("expected the git base to be known")
+	}
+
+	// Re-running the hook on its own output must not wrap it twice.
+	again, _, _ := rewriteGroup(want, cmdSet, nil, quoteBinFor(bin, "windows"), bin)
+	if again != want {
+		t.Errorf("second pass = %q, want it unchanged", again)
+	}
+}

--- a/internal/hook/rewrite.go
+++ b/internal/hook/rewrite.go
@@ -1,7 +1,6 @@
 package hook
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -53,7 +52,7 @@ type RewriteResult struct {
 // (HasUnverifiableConstruct) before calling this, so cmd here is free of command
 // substitution and carriage returns.
 func RewriteCommand(cmd string, cmdSet map[string]struct{}, prefixes []TransparentPrefix, snipBin string) RewriteResult {
-	quotedBin := fmt.Sprintf("%q", snipBin)
+	quotedBin := quoteSnipBin(snipBin)
 
 	var b strings.Builder
 	b.Grow(len(cmd) + 32)

--- a/internal/hook/suggest.go
+++ b/internal/hook/suggest.go
@@ -1,7 +1,6 @@
 package hook
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -31,7 +30,7 @@ func suggestSnipRerun(command string, cmdSet map[string]struct{}, prefixes []Tra
 	prefix, envVars, bareCmd := ParseSegment(firstSegment)
 	base := BaseCommand(bareCmd)
 
-	quotedBin := fmt.Sprintf("%q", snipBin)
+	quotedBin := quoteSnipBin(snipBin)
 	trimmed := strings.TrimLeft(bareCmd, " \t")
 	if base == quotedBin || base == snipBin ||
 		strings.HasPrefix(trimmed, quotedBin) || strings.HasPrefix(trimmed, snipBin) {


### PR DESCRIPTION
Closes #150.

## The defect

Both rewrite paths built the wrapper with `fmt.Sprintf("%q", snipBin)`. That produces a **Go** string literal, not a shell word, and on Windows it is wrong twice:

```
input : C:\Users\Administrator\.snip\snip.exe
%q    : "C:\\Users\\Administrator\\.snip\\snip.exe"
```

- every backslash is doubled, so the path names no existing file;
- the quotes make PowerShell parse the command as a string expression, which is the reported `Unexpected token 'run' in expression or statement`.

Codex therefore received `permissionDecision: allow` carrying a command the user's shell could not run.

## The fix

`quoteSnipBin` replaces the raw `%q`. On Windows a path with no space is emitted bare, which is the one form valid in PowerShell, cmd.exe and a POSIX shell alike, and is what the default install path (`%USERPROFILE%\.snip\snip.exe`) looks like. A path that does contain a space keeps its quotes, without the doubled backslashes. POSIX platforms keep `%q` and every existing expectation.

**One case is deliberately left as-is:** a Windows path *with* a space. PowerShell needs its call operator there (`& "C:\Program Files\..."`) and cmd.exe rejects that operator, and the hook payload carries nothing that identifies the shell. Emitting the quotes without guessing is the conservative half. Say the word if you would rather bet on PowerShell, since that is what Codex runs on Windows, and I will add the `&`.

## Tests

`TestQuoteBinFor` covers both Windows shapes and both POSIX ones through an injected GOOS, so the Windows branch is exercised from any host. `TestRewriteCommandWindowsBin` checks the end-to-end command Codex receives and that a second pass over it does not wrap it twice. `make test-race`, `golangci-lint` and `GOOS=windows go build ./...` are clean.