### PR TITLE
ci(lint): gofmt the tree and check it from now on

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+# golangci-lint keeps the standard linter set; this file only adds formatting,
+# which nothing checked before: `gofmt -l` listed six files on master and
+# unrelated PRs kept picking up reformatting hunks from editors that format on
+# save (issue #144). The pinned version lives in .golangci-lint-version.
+version: "2"
+
+formatters:
+  enable:
+    - gofmt

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -95,7 +95,7 @@ func TestUnproxyableCommands(t *testing.T) {
 		{"else", true},
 		{"done", true},
 		{"do", true},
-		{"perform", false},  // contains "for" but isn't the keyword
+		{"perform", false}, // contains "for" but isn't the keyword
 		{"git", false},
 		{"go", false},
 		{"docker", false},

--- a/internal/discover/discover.go
+++ b/internal/discover/discover.go
@@ -21,8 +21,8 @@ import (
 type sessionLine struct {
 	Type    string `json:"type"`
 	Message *struct {
-		Role    string            `json:"role"`
-		Content json.RawMessage   `json:"content"`
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
 	} `json:"message,omitempty"`
 	Timestamp string `json:"timestamp,omitempty"`
 }

--- a/internal/economics/economics.go
+++ b/internal/economics/economics.go
@@ -10,8 +10,8 @@ import (
 
 // Tier holds a model tier name and its input price per 1M tokens.
 type Tier struct {
-	Name     string
-	PriceM   float64 // price per 1M input tokens
+	Name   string
+	PriceM float64 // price per 1M input tokens
 }
 
 // Tiers lists all supported pricing tiers in display order.

--- a/internal/economics/economics_test.go
+++ b/internal/economics/economics_test.go
@@ -34,10 +34,10 @@ func seedTracker(t *testing.T, tracker *tracking.Tracker) {
 
 func TestCostForTokens(t *testing.T) {
 	tests := []struct {
-		name    string
-		tokens  int
-		priceM  float64
-		want    float64
+		name   string
+		tokens int
+		priceM float64
+		want   float64
 	}{
 		{"1M tokens at sonnet price", 1_000_000, 3.00, 3.00},
 		{"500K tokens at sonnet price", 500_000, 3.00, 1.50},

--- a/internal/learn/learn.go
+++ b/internal/learn/learn.go
@@ -72,22 +72,22 @@ type bashInput struct {
 
 // commandEntry represents a Bash command extracted from a session with its result.
 type commandEntry struct {
-	Command    string // full command string
-	BaseCmd    string // extracted base command name
-	ToolUseID  string // tool_use id for matching results
-	Output     string // tool result content (if found)
-	IsError    bool   // whether the tool result indicated an error
-	HasResult  bool   // whether a result was matched
-	Timestamp  string // timestamp from the JSONL entry
+	Command   string // full command string
+	BaseCmd   string // extracted base command name
+	ToolUseID string // tool_use id for matching results
+	Output    string // tool result content (if found)
+	IsError   bool   // whether the tool result indicated an error
+	HasResult bool   // whether a result was matched
+	Timestamp string // timestamp from the JSONL entry
 }
 
 // ErrorPattern represents a detected error-correction pattern.
 type ErrorPattern struct {
-	BaseCommand    string // base command name (e.g. "go", "git")
-	ErrorCommand   string // the command that failed
-	ErrorOutput    string // truncated error output
-	FixCommand     string // the command that succeeded
-	Count          int    // number of times this pattern occurred
+	BaseCommand  string // base command name (e.g. "go", "git")
+	ErrorCommand string // the command that failed
+	ErrorOutput  string // truncated error output
+	FixCommand   string // the command that succeeded
+	Count        int    // number of times this pattern occurred
 }
 
 // PatternGroup aggregates similar error patterns by base command.

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -169,10 +169,10 @@ func PrintReport(s Summary) {
 
 	// Group results by filter
 	type filterGroup struct {
-		name    string
-		total   int
-		passed  int
-		failed  []TestResult
+		name   string
+		total  int
+		passed int
+		failed []TestResult
 	}
 
 	groups := make(map[string]*filterGroup)


### PR DESCRIPTION
Closes #144. Two commits, in the order the issue asked for.

## 1. `style: gofmt the tree`

The six files `gofmt -l` listed on master, reformatted on their own so the diff is reviewable rather than smeared across future feature PRs. Only whitespace: comment alignment and struct tag alignment. `go build` and `go test ./...` unaffected.

## 2. `ci(lint): check formatting through golangci-lint`

A minimal `.golangci.yml` that adds the `gofmt` formatter and nothing else. The standard linter set is untouched, so no new class of finding appears.

Verified: with the config in place, an unformatted file makes `golangci-lint run` report

```
internal/cli/zz_tmp.go:3:1: File is not properly formatted (gofmt)
```

which `make lint` and the hosted lint job both pick up for free, so this cannot drift again. On a clean tree: `0 issues`.

Chose the config over a separate CI step because it also catches the problem locally, which is where the friction actually is.