### PR TITLE
fix(hook): keep a line continuation inside its group

### DIFF
--- a/internal/hook/blockscope.go
+++ b/internal/hook/blockscope.go
@@ -65,10 +65,9 @@ const (
 //     `closeKeyword` bounds that to the enclosing block by dropping stray
 //     blockParen entries, so one malformed group cannot disable filtering for
 //     the whole message.
-//   - Not covered, by construction: line continuations (a trailing backslash is
-//     a group boundary here but not for the shell), and consumer propagation —
-//     deciding that a block's output has no consumer and rewriting its body
-//     anyway. The latter is why `(cd sub && go test ./...)` is no longer
+//   - Not covered, by construction: consumer propagation, meaning deciding that
+//     a block's output has no consumer and rewriting its body anyway. That is
+//     why `(cd sub && go test ./...)` is no longer
 //     filtered: resolving which block a trailing pipe belongs to fails towards
 //     wrong output, and this hook path prefers the opposite trade (see the #127
 //     process-substitution fix).

--- a/internal/hook/blockscope_test.go
+++ b/internal/hook/blockscope_test.go
@@ -874,3 +874,64 @@ func TestRewriteCommandPosition(t *testing.T) {
 		})
 	}
 }
+
+// TestRewriteLineContinuation pins the fifth shape of issue #138: a trailing
+// unquoted backslash joins two lines into one command for the shell, but the
+// segmenter split on the newline anyway. The trailing `| wc -l` then sat in a
+// different group from the head, the #111 consumer guard never saw it, and the
+// head was rewritten while the consumer counted snip's compacted output.
+func TestRewriteLineContinuation(t *testing.T) {
+	const bin = "/usr/local/bin/snip"
+	const w = `"/usr/local/bin/snip" run -- `
+	cmdSet := map[string]struct{}{"git": {}, "go": {}, "grep": {}, "wc": {}}
+
+	cases := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{
+			// The reported form: raw output is 60 lines, and `wc -l` must count
+			// all of them.
+			name: "continuation before a consumer",
+			cmd:  "grep MATCH \\\n  data.txt | wc -l",
+			want: "grep MATCH \\\n  data.txt | wc -l",
+		},
+		{
+			// No consumer: the command is still one command, so the wrapper goes
+			// in front of it once, not once per line.
+			name: "continuation without a consumer",
+			cmd:  "grep MATCH \\\n  data.txt",
+			want: w + "grep MATCH \\\n  data.txt",
+		},
+		{
+			// An even number of backslashes is a literal backslash: the line
+			// really ends and the two commands are separate groups.
+			name: "escaped backslash still ends the line",
+			cmd:  "grep MATCH data.txt \\\\\ngo build ./...",
+			want: w + "grep MATCH data.txt \\\\\n" + w + "go build ./...",
+		},
+		{
+			// A backslash inside quotes does not escape the newline either.
+			name: "backslash inside quotes",
+			cmd:  "grep 'a\\' data.txt\ngo build ./...",
+			want: w + "grep 'a\\' data.txt\n" + w + "go build ./...",
+		},
+		{
+			// The block tracker still sees the opener and the closer across a
+			// continuation.
+			name: "continuation inside a loop body",
+			cmd:  "for f in *.go\ndo\n  grep MATCH \\\n    $f\ndone | wc -l",
+			want: "for f in *.go\ndo\n  grep MATCH \\\n    $f\ndone | wc -l",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := RewriteCommand(tc.cmd, cmdSet, nil, bin)
+			if res.Command != tc.want {
+				t.Errorf("Command = %q, want %q", res.Command, tc.want)
+			}
+		})
+	}
+}

--- a/internal/hook/rewrite.go
+++ b/internal/hook/rewrite.go
@@ -172,6 +172,17 @@ func RewriteCommand(cmd string, cmdSet map[string]struct{}, prefixes []Transpare
 			}
 			i++
 		case '\n':
+			// A trailing unquoted backslash escapes the newline: the shell reads
+			// one command across the two lines, so this is not a group boundary.
+			// Splitting here put a trailing consumer in a different group from
+			// the head, the #111 guard never saw it, and the head was rewritten
+			// while the consumer read snip's compacted output (issue #138).
+			// Pending heredocs keep the old behaviour: their bodies start at the
+			// next line and must still be drained here.
+			if len(pending) == 0 && escapesNewline(cmd, i) {
+				i++
+				continue
+			}
 			flush(cmd[groupStart:i])
 			b.WriteByte('\n')
 			i++
@@ -286,6 +297,19 @@ func rewriteGroup(group string, cmdSet map[string]struct{}, prefixes []Transpare
 
 	wrappedHead := prefix + envVars + quotedBin + " run -- " + bareCmd
 	return wrappedHead + tail, true, hasTail
+}
+
+// escapesNewline reports whether the newline at i is escaped by the backslash
+// before it, which joins the two lines into one command. Backslashes are counted
+// because an even run is a literal backslash and really ends the line
+// ("git log \\\\" is a trailing backslash argument, not a continuation). The
+// caller only reaches here outside quotes, where a backslash can escape.
+func escapesNewline(cmd string, i int) bool {
+	n := 0
+	for j := i - 1; j >= 0 && cmd[j] == '\\'; j-- {
+		n++
+	}
+	return n%2 == 1
 }
 
 // splitFirstPipe splits group at its first top-level '|' (quoted regions are


### PR DESCRIPTION
Closes #138, the fifth shape left over from #151.

## The defect

A trailing unquoted backslash escapes the newline, so the shell reads one command across two lines. The segmenter split on that newline anyway, so `grep MATCH \\` and `data.txt | wc -l` became separate groups. `splitFirstPipe` only ever saw the first one, the #111 consumer guard never saw the pipe, and the head was rewritten while `wc -l` counted snip's compacted output.

Against real bash, 60-line file behind `filters/grep.yaml`'s cap of 50:

```
grep MATCH \\
  data.txt | wc -l      raw 60, before 51, after 60
```

All five shapes of the issue now return 60.

## The fix

The newline is a group boundary only when it is not escaped. `escapesNewline` counts the backslash run, so an even one is a literal backslash argument and really ends the line. A pending heredoc keeps the old path, because its body starts on the next line and must still be drained there.

The file-level comment that listed line continuations as out of scope by construction is updated in the same commit.

## Tests

`TestRewriteLineContinuation`: the reported form, a continuation with no consumer, an escaped backslash that must still end the line, a backslash inside quotes, and a continuation inside a loop body so the block tracker keeps seeing its opener and closer. The first case fails on master.

`make test-race`, `make verify` (55/55) and `golangci-lint` are clean.