### PR TITLE
fix(codex): preserve config during hook setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Use `snip proxy -- <command>` when full unfiltered output is required.
 snip init --agent codex --uninstall
 ```
 
-For older Codex releases without `PreToolUse` input rewriting, use the legacy project-scoped prompt integration:
+Codex CLI 0.131.0 or later is required for `PreToolUse` input rewriting. For older releases, use the legacy project-scoped prompt integration:
 
 ```bash
 snip init --agent codex --mode prompt

--- a/internal/hook/quote.go
+++ b/internal/hook/quote.go
@@ -9,10 +9,10 @@ import (
 // quoteSnipBin renders the snip binary path for inclusion in a rewritten
 // command, so a path containing spaces still executes as one word.
 func quoteSnipBin(path string) string {
-	return quoteBinFor(path, runtime.GOOS)
+	return QuoteBinFor(path, runtime.GOOS)
 }
 
-// quoteBinFor is quoteSnipBin with the target OS injected, so both branches are
+// QuoteBinFor is quoteSnipBin with the target OS injected, so both branches are
 // testable from any host.
 //
 // Go's %q is a Go string literal, not a shell word, and on Windows it is wrong
@@ -26,7 +26,7 @@ func quoteSnipBin(path string) string {
 // does contain a space still needs the quotes; PowerShell would additionally
 // need its call operator there, which cmd.exe rejects, so the quotes are
 // emitted without guessing which shell is on the other side.
-func quoteBinFor(path, goos string) string {
+func QuoteBinFor(path, goos string) string {
 	if goos == "windows" {
 		if !strings.ContainsAny(path, " \t\"") {
 			return path

--- a/internal/hook/quote_test.go
+++ b/internal/hook/quote_test.go
@@ -43,8 +43,8 @@ func TestQuoteBinFor(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := quoteBinFor(tc.path, tc.goos); got != tc.want {
-				t.Errorf("quoteBinFor(%q, %q) = %q, want %q", tc.path, tc.goos, got, tc.want)
+			if got := QuoteBinFor(tc.path, tc.goos); got != tc.want {
+				t.Errorf("QuoteBinFor(%q, %q) = %q, want %q", tc.path, tc.goos, got, tc.want)
 			}
 		})
 	}
@@ -56,7 +56,7 @@ func TestRewriteCommandWindowsBin(t *testing.T) {
 	const bin = `C:\Users\Administrator\.snip\snip.exe`
 	cmdSet := map[string]struct{}{"git": {}}
 
-	got, known, _ := rewriteGroup("git diff --check", cmdSet, nil, quoteBinFor(bin, "windows"), bin)
+	got, known, _ := rewriteGroup("git diff --check", cmdSet, nil, QuoteBinFor(bin, "windows"), bin)
 	want := `C:\Users\Administrator\.snip\snip.exe run -- git diff --check`
 	if got != want {
 		t.Errorf("rewritten = %q, want %q", got, want)
@@ -66,7 +66,7 @@ func TestRewriteCommandWindowsBin(t *testing.T) {
 	}
 
 	// Re-running the hook on its own output must not wrap it twice.
-	again, _, _ := rewriteGroup(want, cmdSet, nil, quoteBinFor(bin, "windows"), bin)
+	again, _, _ := rewriteGroup(want, cmdSet, nil, QuoteBinFor(bin, "windows"), bin)
 	if again != want {
 		t.Errorf("second pass = %q, want it unchanged", again)
 	}

--- a/internal/initcmd/codex.go
+++ b/internal/initcmd/codex.go
@@ -8,8 +8,10 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 
+	"github.com/edouard-claude/snip/internal/hook"
 	toml "github.com/pelletier/go-toml/v2"
 )
 
@@ -36,7 +38,8 @@ func codexConfigPath(home string) string {
 // migrated to the current hooks=true name without reserializing config.toml.
 func initCodex(snipBin, home, filterDir string) error {
 	configPath := codexConfigPath(home)
-	if err := migrateDeprecatedCodexHooks(configPath); err != nil {
+	migrated, err := migrateDeprecatedCodexHooks(configPath)
+	if err != nil {
 		return fmt.Errorf("check codex config.toml: %w", err)
 	}
 
@@ -44,10 +47,9 @@ func initCodex(snipBin, home, filterDir string) error {
 		return fmt.Errorf("create codex config dir: %w", err)
 	}
 
-	// Hook commands are interpreted by a shell. Quote the binary path so an
-	// installation under a directory containing spaces or shell metacharacters
-	// still invokes snip.
-	hookCommand := shellQuote(snipBin) + " " + codexHookSubcommand
+	// Reuse the command-rewrite quoting so the installed hook works with the
+	// platform shell, including cmd.exe on Windows.
+	hookCommand := hook.QuoteBinFor(snipBin, runtime.GOOS) + " " + codexHookSubcommand
 
 	hooksPath := codexHooksPath(home)
 	if err := patchCodexHooks(hooksPath, hookCommand); err != nil {
@@ -66,6 +68,9 @@ func initCodex(snipBin, home, filterDir string) error {
 	fmt.Println("      updatedInput. Supported commands are transparently")
 	fmt.Println("      rewritten through snip. For older Codex releases use:")
 	fmt.Println("      snip init --agent codex --mode prompt")
+	if migrated {
+		fmt.Printf("      original config.toml backed up to %s.bak\n", configPath)
+	}
 	if legacyAgentsMd != "" {
 		fmt.Printf("      legacy %s detected — remove with `snip init --agent codex --uninstall`\n", legacyAgentsMd)
 		fmt.Println("      or delete it manually if it has been edited or committed")
@@ -225,60 +230,52 @@ var codexHooksDottedSetting = regexp.MustCompile(`^(\s*features\.)(?:codex_hooks
 // migrateDeprecatedCodexHooks validates the user's explicit hooks setting and
 // replaces only the deprecated [features].codex_hooks=true key. A line-level
 // edit preserves their comments, quotes, key order, and unrelated settings.
-func migrateDeprecatedCodexHooks(path string) error {
+func migrateDeprecatedCodexHooks(path string) (bool, error) {
 	data, err := os.ReadFile(path)
-	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("read config.toml: %w", err)
-	}
-	if os.IsNotExist(err) || len(data) == 0 {
-		return nil
+	if err != nil || len(data) == 0 {
+		return false, nil
 	}
 
 	cfg := make(map[string]any)
 	if err := toml.Unmarshal(data, &cfg); err != nil {
-		return fmt.Errorf("parse config.toml: %w", err)
+		return false, nil
 	}
 	features, _ := cfg["features"].(map[string]any)
 	if featureFlagDisabled(features, "hooks") || featureFlagDisabled(features, "codex_hooks") {
-		return errCodexHooksExplicitlyDisabled
+		return false, errCodexHooksExplicitlyDisabled
 	}
 	legacyEnabled, _ := features["codex_hooks"].(bool)
 	if !legacyEnabled {
-		return nil
+		return false, nil
 	}
 
 	canonical, canonicalPresent := features["hooks"]
 	canonicalEnabled, canonicalIsBool := canonical.(bool)
 	if canonicalPresent && !canonicalIsBool {
-		return fmt.Errorf("[features].hooks must be a boolean")
+		return false, nil
 	}
 	updated, changed := rewriteDeprecatedCodexHooks(string(data), canonicalPresent && canonicalEnabled)
 	if !changed {
-		return fmt.Errorf("find [features].codex_hooks setting to migrate")
+		return false, nil
 	}
 	info, statErr := os.Stat(path)
 	if statErr != nil {
-		return fmt.Errorf("stat config.toml: %w", statErr)
+		return false, nil
 	}
 	mode := info.Mode().Perm()
 	if err := os.WriteFile(path+".bak", data, mode); err != nil {
-		return fmt.Errorf("back up config.toml: %w", err)
+		return false, nil
 	}
 	if err := os.WriteFile(path, []byte(updated), mode); err != nil {
-		return fmt.Errorf("write config.toml: %w", err)
+		return false, nil
 	}
-	return nil
+	return true, nil
 }
 
 func featureFlagDisabled(features map[string]any, key string) bool {
 	value, present := features[key]
 	disabled, isBool := value.(bool)
 	return present && isBool && !disabled
-}
-
-// shellQuote returns a POSIX-shell-safe single-quoted argument.
-func shellQuote(value string) string {
-	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }
 
 // rewriteDeprecatedCodexHooks updates the legacy key in [features] or its
@@ -289,10 +286,29 @@ func rewriteDeprecatedCodexHooks(config string, canonicalPresent bool) (string, 
 	lines := strings.SplitAfter(config, "\n")
 	inFeatures := false
 	atTopLevel := true
+	multilineDelimiter := ""
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
+		if multilineDelimiter != "" {
+			if strings.Count(line, multilineDelimiter)%2 == 1 {
+				multilineDelimiter = ""
+			}
+			continue
+		}
+		if strings.Contains(line, `"""`) {
+			if strings.Count(line, `"""`)%2 == 1 {
+				multilineDelimiter = `"""`
+			}
+			continue
+		}
+		if strings.Contains(line, `'''`) {
+			if strings.Count(line, `'''`)%2 == 1 {
+				multilineDelimiter = `'''`
+			}
+			continue
+		}
 		if strings.HasPrefix(trimmed, "[") {
-			inFeatures = trimmed == "[features]"
+			inFeatures = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "["), "]")) == "features"
 			atTopLevel = false
 			continue
 		}

--- a/internal/initcmd/codex.go
+++ b/internal/initcmd/codex.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strings"
 
@@ -34,13 +33,11 @@ func codexConfigPath(home string) string {
 }
 
 // initCodex installs the snip Codex hook in ~/.codex/hooks.json. Codex hooks
-// are enabled by default. Existing deprecated codex_hooks=true settings are
-// migrated to the current hooks=true name without reserializing config.toml.
+// are enabled by default, so config.toml is only read to honour an explicit
+// opt-out and is never written to.
 func initCodex(snipBin, home, filterDir string) error {
-	configPath := codexConfigPath(home)
-	migrated, err := migrateDeprecatedCodexHooks(configPath)
-	if err != nil {
-		return fmt.Errorf("check codex config.toml: %w", err)
+	if err := checkCodexHooksEnabled(codexConfigPath(home)); err != nil {
+		return err
 	}
 
 	if err := os.MkdirAll(codexConfigDir(home), 0o755); err != nil {
@@ -68,9 +65,6 @@ func initCodex(snipBin, home, filterDir string) error {
 	fmt.Println("      updatedInput. Supported commands are transparently")
 	fmt.Println("      rewritten through snip. For older Codex releases use:")
 	fmt.Println("      snip init --agent codex --mode prompt")
-	if migrated {
-		fmt.Printf("      original config.toml backed up to %s.bak\n", configPath)
-	}
 	if legacyAgentsMd != "" {
 		fmt.Printf("      legacy %s detected — remove with `snip init --agent codex --uninstall`\n", legacyAgentsMd)
 		fmt.Println("      or delete it manually if it has been edited or committed")
@@ -222,114 +216,45 @@ func isSnipCodexEntry(entry any) bool {
 // Codex hooks in config.toml. We refuse to silently override their choice.
 var errCodexHooksExplicitlyDisabled = errors.New(
 	"~/.codex/config.toml has [features].hooks = false (or deprecated codex_hooks = false); " +
-		"set it to true (or remove the line) and re-run snip init")
+		"set it to true (or remove the line) and re-run snip init. " +
+		"Older snip releases wrote codex_hooks = false themselves on uninstall, " +
+		"so the line may not be yours")
 
-var codexHooksSetting = regexp.MustCompile(`^(\s*)(?:codex_hooks|"codex_hooks"|'codex_hooks')(\s*=)`)
-var codexHooksDottedSetting = regexp.MustCompile(`^(\s*features\.)(?:codex_hooks|"codex_hooks"|'codex_hooks')(\s*=)`)
-
-// migrateDeprecatedCodexHooks validates the user's explicit hooks setting and
-// replaces only the deprecated [features].codex_hooks=true key. A line-level
-// edit preserves their comments, quotes, key order, and unrelated settings.
-func migrateDeprecatedCodexHooks(path string) (bool, error) {
+// checkCodexHooksEnabled reports whether snip may install its Codex hook.
+//
+// config.toml is only read, never written: Codex enables hooks by default, so
+// the file has nothing snip needs to add. The deprecated codex_hooks alias is
+// still honoured by Codex, so an existing one is left in place rather than
+// renamed. A config that cannot be read or parsed is an error, not an implicit
+// "no opt-out": silently installing over an unreadable opt-out is the one
+// outcome this check exists to prevent.
+func checkCodexHooksEnabled(path string) error {
 	data, err := os.ReadFile(path)
-	if err != nil || len(data) == 0 {
-		return false, nil
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read codex config.toml: %w", err)
 	}
 
 	cfg := make(map[string]any)
 	if err := toml.Unmarshal(data, &cfg); err != nil {
-		return false, nil
+		return fmt.Errorf("parse codex config.toml: %w", err)
 	}
+
 	features, _ := cfg["features"].(map[string]any)
 	if featureFlagDisabled(features, "hooks") || featureFlagDisabled(features, "codex_hooks") {
-		return false, errCodexHooksExplicitlyDisabled
+		return errCodexHooksExplicitlyDisabled
 	}
-	legacyEnabled, _ := features["codex_hooks"].(bool)
-	if !legacyEnabled {
-		return false, nil
-	}
-
-	canonical, canonicalPresent := features["hooks"]
-	canonicalEnabled, canonicalIsBool := canonical.(bool)
-	if canonicalPresent && !canonicalIsBool {
-		return false, nil
-	}
-	updated, changed := rewriteDeprecatedCodexHooks(string(data), canonicalPresent && canonicalEnabled)
-	if !changed {
-		return false, nil
-	}
-	info, statErr := os.Stat(path)
-	if statErr != nil {
-		return false, nil
-	}
-	mode := info.Mode().Perm()
-	if err := os.WriteFile(path+".bak", data, mode); err != nil {
-		return false, nil
-	}
-	if err := os.WriteFile(path, []byte(updated), mode); err != nil {
-		return false, nil
-	}
-	return true, nil
+	return nil
 }
 
+// featureFlagDisabled reports whether key is present in features and set to
+// the boolean false. A missing key or a non-boolean value is not an opt-out.
 func featureFlagDisabled(features map[string]any, key string) bool {
 	value, present := features[key]
 	disabled, isBool := value.(bool)
 	return present && isBool && !disabled
-}
-
-// rewriteDeprecatedCodexHooks updates the legacy key in [features] or its
-// top-level dotted-key form. If the canonical key already exists, it comments
-// out the redundant legacy setting rather than creating a duplicate key or
-// discarding its inline comment.
-func rewriteDeprecatedCodexHooks(config string, canonicalPresent bool) (string, bool) {
-	lines := strings.SplitAfter(config, "\n")
-	inFeatures := false
-	atTopLevel := true
-	multilineDelimiter := ""
-	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if multilineDelimiter != "" {
-			if strings.Count(line, multilineDelimiter)%2 == 1 {
-				multilineDelimiter = ""
-			}
-			continue
-		}
-		if strings.Contains(line, `"""`) {
-			if strings.Count(line, `"""`)%2 == 1 {
-				multilineDelimiter = `"""`
-			}
-			continue
-		}
-		if strings.Contains(line, `'''`) {
-			if strings.Count(line, `'''`)%2 == 1 {
-				multilineDelimiter = `'''`
-			}
-			continue
-		}
-		if strings.HasPrefix(trimmed, "[") {
-			inFeatures = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "["), "]")) == "features"
-			atTopLevel = false
-			continue
-		}
-
-		setting := codexHooksSetting
-		if atTopLevel {
-			setting = codexHooksDottedSetting
-		} else if !inFeatures {
-			continue
-		}
-		if !setting.MatchString(line) {
-			continue
-		}
-		if canonicalPresent {
-			lines[i] = "# Deprecated Codex setting removed by snip: " + line
-		} else {
-			lines[i] = setting.ReplaceAllString(line, "${1}hooks${2}")
-		}
-		return strings.Join(lines, ""), true
-	}
-	return config, false
 }
 
 // detectLegacyAgentsMD returns the path to AGENTS.md in dir if its content

--- a/internal/initcmd/codex.go
+++ b/internal/initcmd/codex.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	toml "github.com/pelletier/go-toml/v2"
@@ -30,25 +31,27 @@ func codexConfigPath(home string) string {
 	return filepath.Join(codexConfigDir(home), "config.toml")
 }
 
-// initCodex installs the snip Codex hook: writes ~/.codex/hooks.json with a
-// PreToolUse entry and patches ~/.codex/config.toml to set
-// [features].codex_hooks = true.
+// initCodex installs the snip Codex hook in ~/.codex/hooks.json. Codex hooks
+// are enabled by default. Existing deprecated codex_hooks=true settings are
+// migrated to the current hooks=true name without reserializing config.toml.
 func initCodex(snipBin, home, filterDir string) error {
+	configPath := codexConfigPath(home)
+	if err := migrateDeprecatedCodexHooks(configPath); err != nil {
+		return fmt.Errorf("check codex config.toml: %w", err)
+	}
+
 	if err := os.MkdirAll(codexConfigDir(home), 0o755); err != nil {
 		return fmt.Errorf("create codex config dir: %w", err)
 	}
 
-	hookCommand := snipBin + " " + codexHookSubcommand
+	// Hook commands are interpreted by a shell. Quote the binary path so an
+	// installation under a directory containing spaces or shell metacharacters
+	// still invokes snip.
+	hookCommand := shellQuote(snipBin) + " " + codexHookSubcommand
 
 	hooksPath := codexHooksPath(home)
 	if err := patchCodexHooks(hooksPath, hookCommand); err != nil {
 		return fmt.Errorf("patch codex hooks: %w", err)
-	}
-
-	configPath := codexConfigPath(home)
-	res, err := patchCodexConfigToml(configPath, true)
-	if err != nil {
-		return fmt.Errorf("patch codex config.toml: %w", err)
 	}
 
 	legacyAgentsMd := detectLegacyAgentsMD(".")
@@ -58,16 +61,11 @@ func initCodex(snipBin, home, filterDir string) error {
 	fmt.Printf("  hook: %s\n", hookCommand)
 	fmt.Printf("  filters: %s\n", filterDir)
 	fmt.Printf("  hooks: %s\n", hooksPath)
-	fmt.Printf("  config: %s ([features].codex_hooks=true)\n", configPath)
 	fmt.Println()
-	fmt.Println("note: Codex hooks require a recent Codex CLI release that supports")
-	fmt.Println("      PreToolUse updatedInput. Supported commands are transparently")
+	fmt.Println("note: Codex hooks require Codex CLI 0.131.0 or later for PreToolUse")
+	fmt.Println("      updatedInput. Supported commands are transparently")
 	fmt.Println("      rewritten through snip. For older Codex releases use:")
 	fmt.Println("      snip init --agent codex --mode prompt")
-	if res.backupWritten {
-		fmt.Printf("      original config.toml backed up to %s.bak (comments are not\n", configPath)
-		fmt.Println("      preserved by the TOML round-trip)")
-	}
 	if legacyAgentsMd != "" {
 		fmt.Printf("      legacy %s detected — remove with `snip init --agent codex --uninstall`\n", legacyAgentsMd)
 		fmt.Println("      or delete it manually if it has been edited or committed")
@@ -76,9 +74,10 @@ func initCodex(snipBin, home, filterDir string) error {
 	return nil
 }
 
-// uninstallCodex removes the snip entry from ~/.codex/hooks.json and flips
-// [features].codex_hooks to false in ~/.codex/config.toml. It also removes a
-// legacy AGENTS.md prompt file if it still matches the snip template.
+// uninstallCodex removes only the snip entry from ~/.codex/hooks.json. It
+// leaves config.toml untouched so it cannot disable the user's other Codex
+// lifecycle hooks. It also removes a legacy AGENTS.md prompt file if it still
+// matches the snip template.
 func uninstallCodex() error {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -88,11 +87,6 @@ func uninstallCodex() error {
 	hooksPath := codexHooksPath(home)
 	if err := unpatchCodexHooks(hooksPath); err != nil {
 		return fmt.Errorf("unpatch codex hooks: %w", err)
-	}
-
-	configPath := codexConfigPath(home)
-	if _, err := patchCodexConfigToml(configPath, false); err != nil {
-		return fmt.Errorf("unpatch codex config.toml: %w", err)
 	}
 
 	// Best-effort cleanup of a legacy AGENTS.md. Skipped when the file is shared
@@ -219,93 +213,107 @@ func isSnipCodexEntry(entry any) bool {
 	return false
 }
 
-// errCodexHooksExplicitlyDisabled is returned when the user has set
-// [features].codex_hooks = false in config.toml and tries to install snip.
-// We refuse to silently flip their explicit choice.
+// errCodexHooksExplicitlyDisabled is returned when the user has disabled
+// Codex hooks in config.toml. We refuse to silently override their choice.
 var errCodexHooksExplicitlyDisabled = errors.New(
-	"~/.codex/config.toml has [features].codex_hooks = false; " +
+	"~/.codex/config.toml has [features].hooks = false (or deprecated codex_hooks = false); " +
 		"set it to true (or remove the line) and re-run snip init")
 
-// configPatchResult reports the outcome of a config.toml patch so the
-// install summary can decide which warnings to print.
-type configPatchResult struct {
-	// noOp is true when the desired state already matched on disk and no
-	// write happened (comments preserved verbatim).
-	noOp bool
-	// backupWritten is true when an existing file was rewritten and a .bak
-	// was saved alongside. False for fresh installs (no original existed).
-	backupWritten bool
-}
+var codexHooksSetting = regexp.MustCompile(`^(\s*)(?:codex_hooks|"codex_hooks"|'codex_hooks')(\s*=)`)
+var codexHooksDottedSetting = regexp.MustCompile(`^(\s*features\.)(?:codex_hooks|"codex_hooks"|'codex_hooks')(\s*=)`)
 
-// patchCodexConfigToml sets [features].codex_hooks to enable.
-//
-// When enable is false (uninstall), the key is forced to false rather than
-// deleted so user intent is recorded explicitly.
-//
-// Returns errCodexHooksExplicitlyDisabled when the user has already pinned
-// codex_hooks=false and we'd be installing — we refuse to silently override.
-func patchCodexConfigToml(path string, enable bool) (configPatchResult, error) {
-	mode := os.FileMode(0o600)
+// migrateDeprecatedCodexHooks validates the user's explicit hooks setting and
+// replaces only the deprecated [features].codex_hooks=true key. A line-level
+// edit preserves their comments, quotes, key order, and unrelated settings.
+func migrateDeprecatedCodexHooks(path string) error {
 	data, err := os.ReadFile(path)
-	exists := err == nil
 	if err != nil && !os.IsNotExist(err) {
-		return configPatchResult{}, fmt.Errorf("read config.toml: %w", err)
+		return fmt.Errorf("read config.toml: %w", err)
 	}
-	if exists {
-		if info, statErr := os.Stat(path); statErr == nil {
-			mode = info.Mode().Perm()
-		}
-	} else {
-		data = nil
+	if os.IsNotExist(err) || len(data) == 0 {
+		return nil
 	}
 
 	cfg := make(map[string]any)
-	if len(data) > 0 {
-		if err := toml.Unmarshal(data, &cfg); err != nil {
-			return configPatchResult{}, fmt.Errorf("parse config.toml: %w", err)
-		}
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return fmt.Errorf("parse config.toml: %w", err)
 	}
-
 	features, _ := cfg["features"].(map[string]any)
-	if features == nil {
-		features = make(map[string]any)
+	if featureFlagDisabled(features, "hooks") || featureFlagDisabled(features, "codex_hooks") {
+		return errCodexHooksExplicitlyDisabled
+	}
+	legacyEnabled, _ := features["codex_hooks"].(bool)
+	if !legacyEnabled {
+		return nil
 	}
 
-	current, present := features["codex_hooks"]
-	currentBool, _ := current.(bool)
+	canonical, canonicalPresent := features["hooks"]
+	canonicalEnabled, canonicalIsBool := canonical.(bool)
+	if canonicalPresent && !canonicalIsBool {
+		return fmt.Errorf("[features].hooks must be a boolean")
+	}
+	updated, changed := rewriteDeprecatedCodexHooks(string(data), canonicalPresent && canonicalEnabled)
+	if !changed {
+		return fmt.Errorf("find [features].codex_hooks setting to migrate")
+	}
+	info, statErr := os.Stat(path)
+	if statErr != nil {
+		return fmt.Errorf("stat config.toml: %w", statErr)
+	}
+	mode := info.Mode().Perm()
+	if err := os.WriteFile(path+".bak", data, mode); err != nil {
+		return fmt.Errorf("back up config.toml: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(updated), mode); err != nil {
+		return fmt.Errorf("write config.toml: %w", err)
+	}
+	return nil
+}
 
-	if enable {
-		if present && !currentBool {
-			return configPatchResult{}, errCodexHooksExplicitlyDisabled
+func featureFlagDisabled(features map[string]any, key string) bool {
+	value, present := features[key]
+	disabled, isBool := value.(bool)
+	return present && isBool && !disabled
+}
+
+// shellQuote returns a POSIX-shell-safe single-quoted argument.
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+// rewriteDeprecatedCodexHooks updates the legacy key in [features] or its
+// top-level dotted-key form. If the canonical key already exists, it comments
+// out the redundant legacy setting rather than creating a duplicate key or
+// discarding its inline comment.
+func rewriteDeprecatedCodexHooks(config string, canonicalPresent bool) (string, bool) {
+	lines := strings.SplitAfter(config, "\n")
+	inFeatures := false
+	atTopLevel := true
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") {
+			inFeatures = trimmed == "[features]"
+			atTopLevel = false
+			continue
 		}
-		if present && currentBool {
-			return configPatchResult{noOp: true}, nil
+
+		setting := codexHooksSetting
+		if atTopLevel {
+			setting = codexHooksDottedSetting
+		} else if !inFeatures {
+			continue
 		}
-		features["codex_hooks"] = true
-	} else {
-		if present && !currentBool {
-			return configPatchResult{noOp: true}, nil
+		if !setting.MatchString(line) {
+			continue
 		}
-		features["codex_hooks"] = false
+		if canonicalPresent {
+			lines[i] = "# Deprecated Codex setting removed by snip: " + line
+		} else {
+			lines[i] = setting.ReplaceAllString(line, "${1}hooks${2}")
+		}
+		return strings.Join(lines, ""), true
 	}
-	cfg["features"] = features
-
-	if exists {
-		_ = os.WriteFile(path+".bak", data, mode)
-	}
-
-	out, err := toml.Marshal(cfg)
-	if err != nil {
-		return configPatchResult{}, fmt.Errorf("marshal config.toml: %w", err)
-	}
-
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return configPatchResult{}, fmt.Errorf("create config dir: %w", err)
-	}
-	if err := os.WriteFile(path, out, mode); err != nil {
-		return configPatchResult{}, fmt.Errorf("write config.toml: %w", err)
-	}
-	return configPatchResult{backupWritten: exists}, nil
+	return config, false
 }
 
 // detectLegacyAgentsMD returns the path to AGENTS.md in dir if its content

--- a/internal/initcmd/codex_test.go
+++ b/internal/initcmd/codex_test.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	toml "github.com/pelletier/go-toml/v2"
 )
 
 func TestPatchCodexHooksNew(t *testing.T) {
@@ -166,42 +164,29 @@ func TestUnpatchCodexHooksRemovesOnlySnip(t *testing.T) {
 	}
 }
 
-func TestPatchCodexConfigTomlNew(t *testing.T) {
+func TestMigrateDeprecatedCodexHooksMissingConfigIsNoOp(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")
 
-	res, err := patchCodexConfigToml(path, true)
-	if err != nil {
-		t.Fatalf("patch: %v", err)
+	if err := migrateDeprecatedCodexHooks(path); err != nil {
+		t.Fatalf("migrate: %v", err)
 	}
-	if res.noOp {
-		t.Error("noOp should be false for fresh write")
-	}
-	if res.backupWritten {
-		t.Error("backupWritten should be false for fresh install (no original to back up)")
-	}
-	if _, err := os.Stat(path + ".bak"); !os.IsNotExist(err) {
-		t.Error("no backup should be written when there was no original file")
-	}
-
-	got := readToml(t, path)
-	features, ok := got["features"].(map[string]any)
-	if !ok {
-		t.Fatalf("features section missing: %#v", got)
-	}
-	if v, _ := features["codex_hooks"].(bool); !v {
-		t.Errorf("codex_hooks = %v, want true", features["codex_hooks"])
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("a missing config.toml must not be created")
 	}
 }
 
-func TestPatchCodexConfigTomlPreservesOtherKeys(t *testing.T) {
+func TestMigrateDeprecatedCodexHooksPreservesConfigFormatting(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")
 
-	original := []byte(`model = "gpt-5"
+	original := []byte(`# user comment
+model = 'gpt-5.6-terra'
+approval_policy = "never"
 
 [features]
-some_other_flag = true
+codex_hooks = true # keep this comment
+some_other_flag = true # preserve this
 
 [other]
 key = "value"
@@ -210,31 +195,16 @@ key = "value"
 		t.Fatal(err)
 	}
 
-	res, err := patchCodexConfigToml(path, true)
+	if err := migrateDeprecatedCodexHooks(path); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	expected := strings.Replace(string(original), "codex_hooks = true", "hooks = true", 1)
+	got, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatalf("patch: %v", err)
+		t.Fatal(err)
 	}
-	if res.noOp {
-		t.Error("noOp should be false when a write happened")
-	}
-	if !res.backupWritten {
-		t.Error("backupWritten should be true when an existing file was rewritten")
-	}
-
-	got := readToml(t, path)
-	if got["model"] != "gpt-5" {
-		t.Errorf("model = %v, want gpt-5", got["model"])
-	}
-	features := got["features"].(map[string]any)
-	if v, _ := features["some_other_flag"].(bool); !v {
-		t.Error("some_other_flag was dropped")
-	}
-	if v, _ := features["codex_hooks"].(bool); !v {
-		t.Error("codex_hooks not set")
-	}
-	other := got["other"].(map[string]any)
-	if other["key"] != "value" {
-		t.Errorf("other.key = %v, want value", other["key"])
+	if string(got) != expected {
+		t.Errorf("config was not minimally migrated. got:\n%s", got)
 	}
 	bak, err := os.ReadFile(path + ".bak")
 	if err != nil {
@@ -245,28 +215,42 @@ key = "value"
 	}
 }
 
-func TestPatchCodexConfigTomlAlreadyEnabledIsNoOp(t *testing.T) {
+func TestMigrateDeprecatedCodexHooksDottedKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	original := []byte("model = 'gpt-5.6-terra'\nfeatures.codex_hooks = true # preserve this\n")
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := migrateDeprecatedCodexHooks(path); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "model = 'gpt-5.6-terra'\nfeatures.hooks = true # preserve this\n"
+	if string(got) != want {
+		t.Errorf("config = %q, want %q", got, want)
+	}
+}
+
+func TestMigrateDeprecatedCodexHooksCanonicalSettingIsNoOp(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")
 
 	original := []byte(`# user comment preserved
 [features]
-codex_hooks = true
+hooks = true
 `)
 	if err := os.WriteFile(path, original, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	infoBefore, _ := os.Stat(path)
 
-	res, err := patchCodexConfigToml(path, true)
-	if err != nil {
-		t.Fatalf("patch: %v", err)
-	}
-	if !res.noOp {
-		t.Error("noOp should be true for already-enabled state")
-	}
-	if res.backupWritten {
-		t.Error("backupWritten should be false for no-op")
+	if err := migrateDeprecatedCodexHooks(path); err != nil {
+		t.Fatalf("migrate: %v", err)
 	}
 	infoAfter, _ := os.Stat(path)
 	if infoBefore.ModTime() != infoAfter.ModTime() {
@@ -284,41 +268,25 @@ codex_hooks = true
 	}
 }
 
-func TestPatchCodexConfigTomlExplicitOptOutRefused(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.toml")
+func TestMigrateDeprecatedCodexHooksExplicitOptOutRefused(t *testing.T) {
+	for _, setting := range []string{"hooks", "codex_hooks"} {
+		t.Run(setting, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "config.toml")
+			original := []byte("[features]\n" + setting + " = false\n")
+			if err := os.WriteFile(path, original, 0o600); err != nil {
+				t.Fatal(err)
+			}
 
-	if err := os.WriteFile(path, []byte("[features]\ncodex_hooks = false\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	_, err := patchCodexConfigToml(path, true)
-	if err == nil {
-		t.Fatal("expected error when codex_hooks is explicitly false")
-	}
-	if !errors.Is(err, errCodexHooksExplicitlyDisabled) {
-		t.Errorf("err = %v, want errCodexHooksExplicitlyDisabled", err)
-	}
-}
-
-func TestUnpatchCodexConfigTomlSetsFalse(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.toml")
-
-	if _, err := patchCodexConfigToml(path, true); err != nil {
-		t.Fatalf("patch: %v", err)
-	}
-	if _, err := patchCodexConfigToml(path, false); err != nil {
-		t.Fatalf("unpatch: %v", err)
-	}
-
-	got := readToml(t, path)
-	features, ok := got["features"].(map[string]any)
-	if !ok {
-		t.Fatalf("features missing")
-	}
-	if v, _ := features["codex_hooks"].(bool); v {
-		t.Errorf("codex_hooks = true after unpatch; want false")
+			err := migrateDeprecatedCodexHooks(path)
+			if !errors.Is(err, errCodexHooksExplicitlyDisabled) {
+				t.Errorf("err = %v, want errCodexHooksExplicitlyDisabled", err)
+			}
+			got, readErr := os.ReadFile(path)
+			if readErr != nil || string(got) != string(original) {
+				t.Errorf("config changed after refused migration: %q (%v)", got, readErr)
+			}
+		})
 	}
 }
 
@@ -340,21 +308,65 @@ func TestInitCodexEndToEnd(t *testing.T) {
 	}
 	entryHooks := preToolUse[0].(map[string]any)["hooks"].([]any)
 	cmd := entryHooks[0].(map[string]any)["command"].(string)
-	if !strings.HasSuffix(cmd, " hook codex") {
-		t.Errorf("hook command = %q, want suffix ' hook codex'", cmd)
+	if cmd != `'/usr/local/bin/snip' hook codex` {
+		t.Errorf("hook command = %q, want quoted binary path", cmd)
 	}
 
-	conf := readToml(t, codexConfigPath(home))
-	features := conf["features"].(map[string]any)
-	if v, _ := features["codex_hooks"].(bool); !v {
-		t.Errorf("codex_hooks = %v, want true", features["codex_hooks"])
+	if _, err := os.Stat(codexConfigPath(home)); !os.IsNotExist(err) {
+		t.Error("init should not create config.toml: Codex hooks are enabled by default")
 	}
 }
 
-func TestInitCodexThenUninstallSymmetric(t *testing.T) {
+func TestInitCodexQuotesPathContainingSpaces(t *testing.T) {
+	home := t.TempDir()
+	filterDir := filepath.Join(home, ".config", "snip", "filters")
+	if err := initCodex("/tmp/bin with space/snip", home, filterDir); err != nil {
+		t.Fatalf("initCodex: %v", err)
+	}
+	hooks := readSettings(t, codexHooksPath(home))
+	cmd := hooks["hooks"].(map[string]any)["PreToolUse"].([]any)[0].(map[string]any)["hooks"].([]any)[0].(map[string]any)["command"]
+	if cmd != `'/tmp/bin with space/snip' hook codex` {
+		t.Errorf("hook command = %q, want quoted path", cmd)
+	}
+}
+
+func TestShellQuoteProtectsShellMetacharacters(t *testing.T) {
+	if got, want := shellQuote("/tmp/a $HOME 'quoted'/snip"), `'/tmp/a $HOME '"'"'quoted'"'"'/snip'`; got != want {
+		t.Errorf("shellQuote() = %q, want %q", got, want)
+	}
+}
+
+func TestInitCodexRefusesDisabledHooksBeforeWritingHook(t *testing.T) {
+	home := t.TempDir()
+	configPath := codexConfigPath(home)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte("[features]\nhooks = false\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := initCodex("/usr/local/bin/snip", home, filepath.Join(home, "filters"))
+	if !errors.Is(err, errCodexHooksExplicitlyDisabled) {
+		t.Fatalf("err = %v, want errCodexHooksExplicitlyDisabled", err)
+	}
+	if _, err := os.Stat(codexHooksPath(home)); !os.IsNotExist(err) {
+		t.Error("hooks.json was written despite an explicit hooks=false opt-out")
+	}
+}
+
+func TestInitCodexThenUninstallLeavesConfigUntouched(t *testing.T) {
 	home := t.TempDir()
 	filterDir := filepath.Join(home, ".config", "snip", "filters")
 	_ = os.MkdirAll(filterDir, 0o755)
+	configPath := codexConfigPath(home)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	original := []byte("# preserve this exact config\n[features]\nhooks = true\n")
+	if err := os.WriteFile(configPath, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := initCodex("/usr/local/bin/snip", home, filterDir); err != nil {
 		t.Fatalf("initCodex: %v", err)
@@ -372,13 +384,12 @@ func TestInitCodexThenUninstallSymmetric(t *testing.T) {
 		}
 	}
 
-	conf := readToml(t, codexConfigPath(home))
-	features, ok := conf["features"].(map[string]any)
-	if !ok {
-		t.Fatal("features should exist with codex_hooks=false")
+	got, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if v, _ := features["codex_hooks"].(bool); v {
-		t.Errorf("codex_hooks should be false after uninstall, got %v", v)
+	if string(got) != string(original) {
+		t.Errorf("config.toml changed during init/uninstall. got:\n%s", got)
 	}
 }
 
@@ -438,17 +449,4 @@ func TestRunRejectsUnknownMode(t *testing.T) {
 	if !strings.Contains(err.Error(), "unknown mode") {
 		t.Errorf("err = %q, want to contain 'unknown mode'", err.Error())
 	}
-}
-
-func readToml(t *testing.T, path string) map[string]any {
-	t.Helper()
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read toml: %v", err)
-	}
-	out := make(map[string]any)
-	if err := toml.Unmarshal(data, &out); err != nil {
-		t.Fatalf("parse toml: %v", err)
-	}
-	return out
 }

--- a/internal/initcmd/codex_test.go
+++ b/internal/initcmd/codex_test.go
@@ -164,182 +164,64 @@ func TestUnpatchCodexHooksRemovesOnlySnip(t *testing.T) {
 	}
 }
 
-func TestMigrateDeprecatedCodexHooksMissingConfigIsNoOp(t *testing.T) {
+func TestCheckCodexHooksEnabledMissingConfigIsAllowed(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")
 
-	if _, err := migrateDeprecatedCodexHooks(path); err != nil {
-		t.Fatalf("migrate: %v", err)
+	if err := checkCodexHooksEnabled(path); err != nil {
+		t.Fatalf("check: %v", err)
 	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Error("a missing config.toml must not be created")
 	}
 }
 
-func TestMigrateDeprecatedCodexHooksPreservesConfigFormatting(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.toml")
-
-	original := []byte(`# user comment
-model = 'gpt-5.6-terra'
-approval_policy = "never"
-
-[features]
-codex_hooks = true # keep this comment
-some_other_flag = true # preserve this
-
-[other]
-key = "value"
-`)
-	if err := os.WriteFile(path, original, 0o600); err != nil {
-		t.Fatal(err)
+func TestCheckCodexHooksEnabledNeverWritesConfig(t *testing.T) {
+	// Codex enables hooks by default and still honours the deprecated
+	// codex_hooks alias, so snip has nothing to add to any of these.
+	configs := map[string]string{
+		"no features section": "model = 'gpt-5.6-terra'\n",
+		"canonical key":       "# user comment\n[features]\nhooks = true\n",
+		"legacy alias":        "[features]\ncodex_hooks = true # keep this comment\n",
+		"both keys":           "[features]\nhooks = true\ncodex_hooks = true\n",
+		"dotted legacy key":   "features.codex_hooks = true\n",
+		"inline table":        "features = { codex_hooks = true }\n",
 	}
 
-	migrated, err := migrateDeprecatedCodexHooks(path)
-	if err != nil {
-		t.Fatalf("migrate: %v", err)
-	}
-	if !migrated {
-		t.Fatal("expected migration")
-	}
-	expected := strings.Replace(string(original), "codex_hooks = true", "hooks = true", 1)
-	got, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != expected {
-		t.Errorf("config was not minimally migrated. got:\n%s", got)
-	}
-	bak, err := os.ReadFile(path + ".bak")
-	if err != nil {
-		t.Fatalf("backup not written: %v", err)
-	}
-	if string(bak) != string(original) {
-		t.Error("backup does not match original")
+	for name, original := range configs {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "config.toml")
+			if err := os.WriteFile(path, []byte(original), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			before, err := os.Stat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err := checkCodexHooksEnabled(path); err != nil {
+				t.Fatalf("check: %v", err)
+			}
+
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != original {
+				t.Errorf("config.toml was rewritten:\n%s", got)
+			}
+			if after, err := os.Stat(path); err == nil && before.ModTime() != after.ModTime() {
+				t.Error("config.toml was touched")
+			}
+			if _, err := os.Stat(path + ".bak"); !os.IsNotExist(err) {
+				t.Error("no backup should be written: snip never edits config.toml")
+			}
+		})
 	}
 }
 
-func TestMigrateDeprecatedCodexHooksDottedKey(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.toml")
-	original := []byte("model = 'gpt-5.6-terra'\nfeatures.codex_hooks = true # preserve this\n")
-	if err := os.WriteFile(path, original, 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	migrated, err := migrateDeprecatedCodexHooks(path)
-	if err != nil {
-		t.Fatalf("migrate: %v", err)
-	}
-	if !migrated {
-		t.Fatal("expected migration")
-	}
-	got, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := "model = 'gpt-5.6-terra'\nfeatures.hooks = true # preserve this\n"
-	if string(got) != want {
-		t.Errorf("config = %q, want %q", got, want)
-	}
-}
-
-func TestMigrateDeprecatedCodexHooksSkipsUnsupportedFormatting(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.toml")
-	original := []byte("features = { codex_hooks = true }\n")
-	if err := os.WriteFile(path, original, 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	migrated, err := migrateDeprecatedCodexHooks(path)
-	if err != nil {
-		t.Fatalf("migrate: %v", err)
-	}
-	if migrated {
-		t.Fatal("inline table should not be rewritten")
-	}
-	got, err := os.ReadFile(path)
-	if err != nil || string(got) != string(original) {
-		t.Errorf("config changed after skipped migration: %q (%v)", got, err)
-	}
-}
-
-func TestMigrateDeprecatedCodexHooksAllowsWhitespaceInTableHeader(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.toml")
-	if err := os.WriteFile(path, []byte("[ features ]\ncodex_hooks = true\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	migrated, err := migrateDeprecatedCodexHooks(path)
-	if err != nil {
-		t.Fatalf("migrate: %v", err)
-	}
-	if !migrated {
-		t.Fatal("expected migration")
-	}
-	got, err := os.ReadFile(path)
-	if err != nil || string(got) != "[ features ]\nhooks = true\n" {
-		t.Errorf("config = %q (%v)", got, err)
-	}
-}
-
-func TestMigrateDeprecatedCodexHooksSkipsMultilineStrings(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.toml")
-	original := []byte("notes = \"\"\"\n[features]\ncodex_hooks = true\n\"\"\"\n\n[features]\ncodex_hooks = true\n")
-	if err := os.WriteFile(path, original, 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	migrated, err := migrateDeprecatedCodexHooks(path)
-	if err != nil {
-		t.Fatalf("migrate: %v", err)
-	}
-	if !migrated {
-		t.Fatal("expected migration")
-	}
-	want := "notes = \"\"\"\n[features]\ncodex_hooks = true\n\"\"\"\n\n[features]\nhooks = true\n"
-	got, err := os.ReadFile(path)
-	if err != nil || string(got) != want {
-		t.Errorf("config = %q, want %q (%v)", got, want, err)
-	}
-}
-
-func TestMigrateDeprecatedCodexHooksCanonicalSettingIsNoOp(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.toml")
-
-	original := []byte(`# user comment preserved
-[features]
-hooks = true
-`)
-	if err := os.WriteFile(path, original, 0o600); err != nil {
-		t.Fatal(err)
-	}
-	infoBefore, _ := os.Stat(path)
-
-	if _, err := migrateDeprecatedCodexHooks(path); err != nil {
-		t.Fatalf("migrate: %v", err)
-	}
-	infoAfter, _ := os.Stat(path)
-	if infoBefore.ModTime() != infoAfter.ModTime() {
-		t.Error("file should not have been rewritten")
-	}
-	got, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != string(original) {
-		t.Errorf("file was rewritten; comments lost. got:\n%s", got)
-	}
-	if _, err := os.Stat(path + ".bak"); !os.IsNotExist(err) {
-		t.Error("no backup should be written for no-op")
-	}
-}
-
-func TestMigrateDeprecatedCodexHooksExplicitOptOutRefused(t *testing.T) {
+func TestCheckCodexHooksEnabledExplicitOptOutRefused(t *testing.T) {
 	for _, setting := range []string{"hooks", "codex_hooks"} {
 		t.Run(setting, func(t *testing.T) {
 			dir := t.TempDir()
@@ -349,15 +231,60 @@ func TestMigrateDeprecatedCodexHooksExplicitOptOutRefused(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			_, err := migrateDeprecatedCodexHooks(path)
+			err := checkCodexHooksEnabled(path)
 			if !errors.Is(err, errCodexHooksExplicitlyDisabled) {
 				t.Errorf("err = %v, want errCodexHooksExplicitlyDisabled", err)
 			}
 			got, readErr := os.ReadFile(path)
 			if readErr != nil || string(got) != string(original) {
-				t.Errorf("config changed after refused migration: %q (%v)", got, readErr)
+				t.Errorf("config changed after a refused install: %q (%v)", got, readErr)
 			}
 		})
+	}
+}
+
+func TestCheckCodexHooksEnabledNonBooleanIsNotAnOptOut(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte("[features]\nhooks = \"false\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := checkCodexHooksEnabled(path); err != nil {
+		t.Errorf("a non-boolean value is not an opt-out, got %v", err)
+	}
+}
+
+// An unreadable or malformed config.toml must not be read as "no opt-out":
+// installing over an opt-out we simply failed to see is the outcome this
+// check exists to prevent.
+func TestCheckCodexHooksEnabledUnreadableConfigIsAnError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	// A directory in place of the file is an unreadable path on every OS,
+	// unlike chmod 000 which root and Windows both ignore.
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := checkCodexHooksEnabled(path)
+	if err == nil {
+		t.Fatal("expected an error for an unreadable config.toml")
+	}
+	if errors.Is(err, errCodexHooksExplicitlyDisabled) {
+		t.Errorf("err = %v, want a read error", err)
+	}
+}
+
+func TestCheckCodexHooksEnabledMalformedConfigIsAnError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte("oops =\n[features]\nhooks = false\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := checkCodexHooksEnabled(path); err == nil {
+		t.Fatal("expected an error for a config.toml that does not parse")
 	}
 }
 
@@ -420,13 +347,13 @@ func TestInitCodexRefusesDisabledHooksBeforeWritingHook(t *testing.T) {
 	}
 }
 
-func TestInitCodexContinuesWhenLegacySettingCannotBeMigrated(t *testing.T) {
+func TestInitCodexLeavesLegacyConfigUntouched(t *testing.T) {
 	home := t.TempDir()
 	configPath := codexConfigPath(home)
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	original := []byte("features = { codex_hooks = true }\n")
+	original := []byte("[features]\ncodex_hooks = true # still honoured by Codex\n")
 	if err := os.WriteFile(configPath, original, 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -439,33 +366,27 @@ func TestInitCodexContinuesWhenLegacySettingCannotBeMigrated(t *testing.T) {
 	}
 	got, err := os.ReadFile(configPath)
 	if err != nil || string(got) != string(original) {
-		t.Errorf("config changed after skipped migration: %q (%v)", got, err)
+		t.Errorf("config changed during install: %q (%v)", got, err)
+	}
+	if _, err := os.Stat(configPath + ".bak"); !os.IsNotExist(err) {
+		t.Error("install wrote a config.toml backup it does not need")
 	}
 }
 
-func TestInitCodexContinuesWhenConfigBackupFails(t *testing.T) {
+// An install must fail closed when config.toml cannot be read: an opt-out we
+// could not parse is still an opt-out.
+func TestInitCodexRefusesUnreadableConfigBeforeWritingHook(t *testing.T) {
 	home := t.TempDir()
 	configPath := codexConfigPath(home)
-	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	original := []byte("[features]\ncodex_hooks = true\n")
-	if err := os.WriteFile(configPath, original, 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Mkdir(configPath+".bak", 0o755); err != nil {
+	if err := os.MkdirAll(configPath, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := initCodex("/usr/local/bin/snip", home, filepath.Join(home, "filters")); err != nil {
-		t.Fatalf("initCodex: %v", err)
+	if err := initCodex("/usr/local/bin/snip", home, filepath.Join(home, "filters")); err == nil {
+		t.Fatal("expected an error for an unreadable config.toml")
 	}
-	if _, err := os.Stat(codexHooksPath(home)); err != nil {
-		t.Fatalf("hooks.json was not installed: %v", err)
-	}
-	got, err := os.ReadFile(configPath)
-	if err != nil || string(got) != string(original) {
-		t.Errorf("config changed after failed backup: %q (%v)", got, err)
+	if _, err := os.Stat(codexHooksPath(home)); !os.IsNotExist(err) {
+		t.Error("hooks.json was written despite an unreadable config.toml")
 	}
 }
 

--- a/internal/initcmd/codex_test.go
+++ b/internal/initcmd/codex_test.go
@@ -168,7 +168,7 @@ func TestMigrateDeprecatedCodexHooksMissingConfigIsNoOp(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")
 
-	if err := migrateDeprecatedCodexHooks(path); err != nil {
+	if _, err := migrateDeprecatedCodexHooks(path); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
@@ -195,8 +195,12 @@ key = "value"
 		t.Fatal(err)
 	}
 
-	if err := migrateDeprecatedCodexHooks(path); err != nil {
+	migrated, err := migrateDeprecatedCodexHooks(path)
+	if err != nil {
 		t.Fatalf("migrate: %v", err)
+	}
+	if !migrated {
+		t.Fatal("expected migration")
 	}
 	expected := strings.Replace(string(original), "codex_hooks = true", "hooks = true", 1)
 	got, err := os.ReadFile(path)
@@ -223,8 +227,12 @@ func TestMigrateDeprecatedCodexHooksDottedKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := migrateDeprecatedCodexHooks(path); err != nil {
+	migrated, err := migrateDeprecatedCodexHooks(path)
+	if err != nil {
 		t.Fatalf("migrate: %v", err)
+	}
+	if !migrated {
+		t.Fatal("expected migration")
 	}
 	got, err := os.ReadFile(path)
 	if err != nil {
@@ -233,6 +241,69 @@ func TestMigrateDeprecatedCodexHooksDottedKey(t *testing.T) {
 	want := "model = 'gpt-5.6-terra'\nfeatures.hooks = true # preserve this\n"
 	if string(got) != want {
 		t.Errorf("config = %q, want %q", got, want)
+	}
+}
+
+func TestMigrateDeprecatedCodexHooksSkipsUnsupportedFormatting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	original := []byte("features = { codex_hooks = true }\n")
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	migrated, err := migrateDeprecatedCodexHooks(path)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if migrated {
+		t.Fatal("inline table should not be rewritten")
+	}
+	got, err := os.ReadFile(path)
+	if err != nil || string(got) != string(original) {
+		t.Errorf("config changed after skipped migration: %q (%v)", got, err)
+	}
+}
+
+func TestMigrateDeprecatedCodexHooksAllowsWhitespaceInTableHeader(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte("[ features ]\ncodex_hooks = true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	migrated, err := migrateDeprecatedCodexHooks(path)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if !migrated {
+		t.Fatal("expected migration")
+	}
+	got, err := os.ReadFile(path)
+	if err != nil || string(got) != "[ features ]\nhooks = true\n" {
+		t.Errorf("config = %q (%v)", got, err)
+	}
+}
+
+func TestMigrateDeprecatedCodexHooksSkipsMultilineStrings(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	original := []byte("notes = \"\"\"\n[features]\ncodex_hooks = true\n\"\"\"\n\n[features]\ncodex_hooks = true\n")
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	migrated, err := migrateDeprecatedCodexHooks(path)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if !migrated {
+		t.Fatal("expected migration")
+	}
+	want := "notes = \"\"\"\n[features]\ncodex_hooks = true\n\"\"\"\n\n[features]\nhooks = true\n"
+	got, err := os.ReadFile(path)
+	if err != nil || string(got) != want {
+		t.Errorf("config = %q, want %q (%v)", got, want, err)
 	}
 }
 
@@ -249,7 +320,7 @@ hooks = true
 	}
 	infoBefore, _ := os.Stat(path)
 
-	if err := migrateDeprecatedCodexHooks(path); err != nil {
+	if _, err := migrateDeprecatedCodexHooks(path); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
 	infoAfter, _ := os.Stat(path)
@@ -278,7 +349,7 @@ func TestMigrateDeprecatedCodexHooksExplicitOptOutRefused(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err := migrateDeprecatedCodexHooks(path)
+			_, err := migrateDeprecatedCodexHooks(path)
 			if !errors.Is(err, errCodexHooksExplicitlyDisabled) {
 				t.Errorf("err = %v, want errCodexHooksExplicitlyDisabled", err)
 			}
@@ -308,7 +379,7 @@ func TestInitCodexEndToEnd(t *testing.T) {
 	}
 	entryHooks := preToolUse[0].(map[string]any)["hooks"].([]any)
 	cmd := entryHooks[0].(map[string]any)["command"].(string)
-	if cmd != `'/usr/local/bin/snip' hook codex` {
+	if cmd != `"/usr/local/bin/snip" hook codex` {
 		t.Errorf("hook command = %q, want quoted binary path", cmd)
 	}
 
@@ -325,14 +396,8 @@ func TestInitCodexQuotesPathContainingSpaces(t *testing.T) {
 	}
 	hooks := readSettings(t, codexHooksPath(home))
 	cmd := hooks["hooks"].(map[string]any)["PreToolUse"].([]any)[0].(map[string]any)["hooks"].([]any)[0].(map[string]any)["command"]
-	if cmd != `'/tmp/bin with space/snip' hook codex` {
+	if cmd != `"/tmp/bin with space/snip" hook codex` {
 		t.Errorf("hook command = %q, want quoted path", cmd)
-	}
-}
-
-func TestShellQuoteProtectsShellMetacharacters(t *testing.T) {
-	if got, want := shellQuote("/tmp/a $HOME 'quoted'/snip"), `'/tmp/a $HOME '"'"'quoted'"'"'/snip'`; got != want {
-		t.Errorf("shellQuote() = %q, want %q", got, want)
 	}
 }
 
@@ -352,6 +417,55 @@ func TestInitCodexRefusesDisabledHooksBeforeWritingHook(t *testing.T) {
 	}
 	if _, err := os.Stat(codexHooksPath(home)); !os.IsNotExist(err) {
 		t.Error("hooks.json was written despite an explicit hooks=false opt-out")
+	}
+}
+
+func TestInitCodexContinuesWhenLegacySettingCannotBeMigrated(t *testing.T) {
+	home := t.TempDir()
+	configPath := codexConfigPath(home)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	original := []byte("features = { codex_hooks = true }\n")
+	if err := os.WriteFile(configPath, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := initCodex("/usr/local/bin/snip", home, filepath.Join(home, "filters")); err != nil {
+		t.Fatalf("initCodex: %v", err)
+	}
+	if _, err := os.Stat(codexHooksPath(home)); err != nil {
+		t.Fatalf("hooks.json was not installed: %v", err)
+	}
+	got, err := os.ReadFile(configPath)
+	if err != nil || string(got) != string(original) {
+		t.Errorf("config changed after skipped migration: %q (%v)", got, err)
+	}
+}
+
+func TestInitCodexContinuesWhenConfigBackupFails(t *testing.T) {
+	home := t.TempDir()
+	configPath := codexConfigPath(home)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	original := []byte("[features]\ncodex_hooks = true\n")
+	if err := os.WriteFile(configPath, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(configPath+".bak", 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := initCodex("/usr/local/bin/snip", home, filepath.Join(home, "filters")); err != nil {
+		t.Fatalf("initCodex: %v", err)
+	}
+	if _, err := os.Stat(codexHooksPath(home)); err != nil {
+		t.Fatalf("hooks.json was not installed: %v", err)
+	}
+	got, err := os.ReadFile(configPath)
+	if err != nil || string(got) != string(original) {
+		t.Errorf("config changed after failed backup: %q (%v)", got, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Stop writing the deprecated `[features].codex_hooks` setting on new Codex hook installations.
- Migrate plain legacy `codex_hooks = true` settings to `hooks = true` with a minimal line-level edit; leave non-standard TOML layouts unchanged because the legacy alias still works.
- Reuse Snip's platform-aware command quoting, preserving Windows `cmd.exe` compatibility.
- Validate an explicit `hooks = false` / `codex_hooks = false` opt-out before modifying `hooks.json`.
- Make uninstall remove only Snip’s `PreToolUse` entry and leave `config.toml` untouched.

## Root cause

Codex hooks are enabled by default. The previous setup rewrote the entire `config.toml` merely to enable the deprecated feature flag, which removed comments and normalized quote styles. Uninstall then set that global feature to `false`, disabling all Codex lifecycle hooks rather than only Snip.

## Compatibility

Codex CLI 0.131.0 or later is required for `PreToolUse` command rewriting with `updatedInput`. Earlier releases should use `snip init --agent codex --mode prompt`.

## Validation

- [x] `make test`
- [x] `make test-race`
- [x] `make lint`
- [x] `make build`, `make build-lite`, `make build-windows`
- [x] `go test -tags lite ./...`
- [x] `snip verify` — 55/55
- [x] Regression coverage for Windows quoting, opt-out atomicity, inline and whitespace TOML layouts, multiline strings, backup failures, config preservation, and uninstall