### PR TITLE
fix(config): keep every section when filters.dir is an array

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -166,12 +166,20 @@ func Load() (*Config, error) {
 }
 
 // tryUnmarshalArrayDir handles the case where filters.dir is a TOML array.
+// The alternative structs must mirror Config and FiltersConfig field for
+// field (only Dir changes type): any section missing here is silently lost
+// whenever filters.dir is an array (#158).
 func tryUnmarshalArrayDir(data []byte, cfg *Config) bool {
 	type filtersArray struct {
-		Dir    []string        `toml:"dir"`
-		Enable map[string]bool `toml:"enable"`
+		Dir                 []string                  `toml:"dir"`
+		Enable              map[string]bool           `toml:"enable"`
+		TransparentPrefixes []string                  `toml:"transparent_prefixes"`
+		Global              FilterGlobalConfig        `toml:"global"`
+		Override            map[string]FilterOverride `toml:"override"`
+		Bypass              FilterBypassConfig        `toml:"bypass"`
 	}
 	type configArray struct {
+		Mode     string         `toml:"mode"`
 		Tracking TrackingConfig `toml:"tracking"`
 		Display  DisplayConfig  `toml:"display"`
 		Filters  filtersArray   `toml:"filters"`
@@ -180,6 +188,7 @@ func tryUnmarshalArrayDir(data []byte, cfg *Config) bool {
 
 	def := DefaultConfig()
 	alt := configArray{
+		Mode:     def.Mode,
 		Tracking: def.Tracking,
 		Display:  def.Display,
 		Filters:  filtersArray{Dir: def.Filters.Dirs()},
@@ -190,10 +199,15 @@ func tryUnmarshalArrayDir(data []byte, cfg *Config) bool {
 		return false
 	}
 
+	cfg.Mode = alt.Mode
 	cfg.Tracking = alt.Tracking
 	cfg.Display = alt.Display
 	cfg.Filters.Dir = alt.Filters.Dir
 	cfg.Filters.Enable = alt.Filters.Enable
+	cfg.Filters.TransparentPrefixes = alt.Filters.TransparentPrefixes
+	cfg.Filters.Global = alt.Filters.Global
+	cfg.Filters.Override = alt.Filters.Override
+	cfg.Filters.Bypass = alt.Filters.Bypass
 	cfg.Tee = alt.Tee
 	return true
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -224,6 +224,63 @@ dir = ["~/.config/snip/filters", "/project/.snip"]
 	}
 }
 
+func TestLoadConfigArrayDirKeepsAllSections(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	content := `
+mode = "project"
+
+[filters]
+dir = ["~/.config/snip/filters", "/project/.snip"]
+transparent_prefixes = ["direnv exec ."]
+
+[filters.enable]
+git-diff = false
+
+[filters.global]
+max_lines = 500
+
+[filters.override.dotnet-test]
+head = 200
+
+[filters.bypass]
+commands = ["dotnet publish"]
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("SNIP_CONFIG", path)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(cfg.Filters.Dirs()) != 2 {
+		t.Fatalf("expected 2 dirs, got %v", cfg.Filters.Dirs())
+	}
+	if cfg.Mode != "project" {
+		t.Errorf("Mode: got %q, want %q", cfg.Mode, "project")
+	}
+	if enabled, ok := cfg.Filters.Enable["git-diff"]; !ok || enabled {
+		t.Errorf("Enable[git-diff]: got %v/%v, want false/true", enabled, ok)
+	}
+	if cfg.Filters.Global.MaxLines != 500 {
+		t.Errorf("Global.MaxLines: got %d, want 500", cfg.Filters.Global.MaxLines)
+	}
+	if o, ok := cfg.Filters.Override["dotnet-test"]; !ok || o.Head != 200 {
+		t.Errorf("Override[dotnet-test].Head: got %+v/%v, want 200", o, ok)
+	}
+	if len(cfg.Filters.Bypass.Commands) != 1 || cfg.Filters.Bypass.Commands[0] != "dotnet publish" {
+		t.Errorf("Bypass.Commands: got %v, want [dotnet publish]", cfg.Filters.Bypass.Commands)
+	}
+	if len(cfg.Filters.TransparentPrefixes) != 1 || cfg.Filters.TransparentPrefixes[0] != "direnv exec ." {
+		t.Errorf("TransparentPrefixes: got %v, want [direnv exec .]", cfg.Filters.TransparentPrefixes)
+	}
+}
+
 func TestLoadConfigEnvVarExpansion(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")


### PR DESCRIPTION
## Summary
- `Load()` falls back to `tryUnmarshalArrayDir` when `filters.dir` is a TOML array (go-toml/v2 cannot decode an array into `any`). The fallback structs only mirrored `dir` and `enable`, silently dropping `mode`, `[filters.global]`, `[filters.override.*]`, `[filters.bypass]` and `transparent_prefixes`.
- Mirror `Config` and `FiltersConfig` field for field in the fallback structs, with a comment making the invariant explicit.

Closes #158

## Test plan
- New `TestLoadConfigArrayDirKeepsAllSections` reproduces the loss (fails on master, passes here).
- `make ci` green locally (test-race + verify + lint + vulncheck).
- End-to-end repro from the issue: with `dir` as an array, `[filters.bypass] commands = ["ls"]` is now honored.