### PR TITLE
feat(config): plugin configuration layer via SNIP_PLUGIN_CONFIG

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -340,7 +340,10 @@ func loadHookContext() (snipBin string, commands []string, prefixes []hook.Trans
 		return "", nil, nil, false
 	}
 
-	cfg, err := config.Load()
+	// Plugin layer included: a filter shipped by an agent plugin must be
+	// visible here, or its commands would never be rewritten. Project
+	// configs stay out of the hook path (no directory walk-up).
+	cfg, err := config.LoadWithPlugin()
 	if err != nil {
 		cfg = config.DefaultConfig()
 	}
@@ -364,8 +367,9 @@ func runPipeline(command string, args []string, flags Flags) int {
 		cfg = config.DefaultConfig()
 	}
 
-	// Load merged user+project config for filter overrides, bypass, and global
-	// limits. Gracefully defaults to user-only if no .snip/config.toml exists.
+	// Load merged plugin+user+project config for filter overrides, bypass,
+	// and global limits. Gracefully defaults to user-only if no plugin or
+	// .snip/config.toml exists.
 	projectCfg, err := config.LoadMerged()
 	if err != nil && flags.Verbose > 0 {
 		fmt.Fprintf(os.Stderr, "snip: project config error: %v\n", err)
@@ -374,7 +378,8 @@ func runPipeline(command string, args []string, flags Flags) int {
 		projectCfg = cfg
 	}
 
-	filters, err := filter.LoadAll(cfg.Filters.Dirs())
+	// Merged dirs so plugin-shipped filters load too (plugin < user by name).
+	filters, err := filter.LoadAll(projectCfg.Filters.Dirs())
 	if err != nil {
 		display.PrintError(fmt.Sprintf("load filters: %v", err))
 		return 1

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -252,11 +252,118 @@ func projectConfigPath() string {
 	return ""
 }
 
-// LoadMerged loads the user config, then layers the project config on top.
-// When mode == "project", the project config's filter settings override the
-// user's. When mode == "user" (default), user settings take priority.
-func LoadMerged() (*Config, error) {
+// pluginConfigPath returns the config path provided by an agent plugin
+// through SNIP_PLUGIN_CONFIG (e.g. a Claude Code plugin hook exporting
+// SNIP_PLUGIN_CONFIG=${CLAUDE_PLUGIN_ROOT}/snip/config.toml), or "" when
+// no plugin layer is present.
+func pluginConfigPath() string {
+	return os.Getenv("SNIP_PLUGIN_CONFIG")
+}
+
+// LoadWithPlugin returns the user config with the plugin layer, if any,
+// merged underneath it: plugin < user. Only the filter sections participate
+// (enable, global, override, bypass, transparent_prefixes, dir), matching
+// what a project config can influence. filters.dir concatenates plugin
+// directories before the user's, so user filters override plugin filters
+// by name. The plugin file must be trusted (`snip trust <path>`); an
+// untrusted or unreadable plugin layer is skipped with a stderr warning.
+func LoadWithPlugin() (*Config, error) {
 	user, err := Load()
+	if err != nil {
+		return nil, err
+	}
+	applyPluginLayer(user)
+	return user, nil
+}
+
+// applyPluginLayer merges the SNIP_PLUGIN_CONFIG file underneath the user
+// config in place. The user's explicit settings win over the plugin's.
+func applyPluginLayer(user *Config) {
+	path := pluginConfigPath()
+	if path == "" {
+		return
+	}
+
+	store, err := trust.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "snip: ignoring untrusted plugin config %s (trust store unreadable: %v)\n", path, err)
+		return
+	}
+	if !trust.IsTrusted(store, path) {
+		fmt.Fprintf(os.Stderr, "snip: ignoring untrusted plugin config %s (run 'snip trust %s' to trust)\n", path, path)
+		return
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "snip: ignoring unreadable plugin config %s: %v\n", path, err)
+		return
+	}
+	plugin := DefaultConfig()
+	if err := toml.Unmarshal(data, plugin); err != nil {
+		plugin = DefaultConfig()
+		if !tryUnmarshalArrayDir(data, plugin) {
+			fmt.Fprintf(os.Stderr, "snip: ignoring invalid plugin config %s: %v\n", path, err)
+			return
+		}
+	}
+	plugin.expandPaths()
+
+	// Enable and Override: plugin provides the base, user keys win.
+	if len(plugin.Filters.Enable) > 0 {
+		merged := make(map[string]bool, len(plugin.Filters.Enable)+len(user.Filters.Enable))
+		for k, v := range plugin.Filters.Enable {
+			merged[k] = v
+		}
+		for k, v := range user.Filters.Enable {
+			merged[k] = v
+		}
+		user.Filters.Enable = merged
+	}
+	if len(plugin.Filters.Override) > 0 {
+		merged := make(map[string]FilterOverride, len(plugin.Filters.Override)+len(user.Filters.Override))
+		for k, v := range plugin.Filters.Override {
+			merged[k] = v
+		}
+		for k, v := range user.Filters.Override {
+			merged[k] = v
+		}
+		user.Filters.Override = merged
+	}
+
+	// Global caps: the user's own block wins entirely when set at all.
+	if user.Filters.Global == (FilterGlobalConfig{}) {
+		user.Filters.Global = plugin.Filters.Global
+	}
+
+	// Bypass and transparent prefixes accumulate from both layers.
+	user.Filters.Bypass.Commands = append(
+		append([]string{}, plugin.Filters.Bypass.Commands...),
+		user.Filters.Bypass.Commands...)
+	user.Filters.TransparentPrefixes = append(
+		append([]string{}, plugin.Filters.TransparentPrefixes...),
+		user.Filters.TransparentPrefixes...)
+
+	// Filter directories: plugin dirs first, user dirs last (later dirs
+	// win by filter name in the loader). Skip duplicates.
+	seen := make(map[string]bool)
+	var dirs []string
+	for _, d := range append(plugin.Filters.Dirs(), user.Filters.Dirs()...) {
+		if d != "" && !seen[d] {
+			seen[d] = true
+			dirs = append(dirs, d)
+		}
+	}
+	user.Filters.Dir = dirs
+}
+
+// LoadMerged loads the user config (with the plugin layer underneath, see
+// LoadWithPlugin), then layers the project config on top. The resulting
+// precedence is plugin < user < project. When mode == "project", the project
+// config's filter settings override the user's. When mode == "user"
+// (default), user settings take priority.
+func LoadMerged() (*Config, error) {
+	user, err := LoadWithPlugin()
 	if err != nil {
 		// If user config file is missing, use defaults (normal for new installs).
 		// Other errors (permission, corrupt TOML) propagate to the caller so the

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1389,3 +1389,209 @@ func TestClaudeProjectsDirFallsBackToHome(t *testing.T) {
 		t.Errorf("ClaudeProjectsDir() = %q, want %q", got, want)
 	}
 }
+
+// pluginTestSetup writes a plugin config, optionally trusts it, and points
+// SNIP_PLUGIN_CONFIG at it. Returns the plugin config path and the temp home.
+func pluginTestSetup(t *testing.T, pluginContent string, trusted bool) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	if err := os.MkdirAll(filepath.Join(home, ".config", "snip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	pluginDir := canonicalTempDir(t)
+	pluginPath := filepath.Join(pluginDir, "config.toml")
+	if err := os.WriteFile(pluginPath, []byte(pluginContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if trusted {
+		store := make(trust.Store)
+		hash, err := trust.HashFile(pluginPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		store[pluginPath] = hash
+		if err := trust.SaveTo(store, filepath.Join(home, ".config", "snip", "trusted.json")); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_PLUGIN_CONFIG", pluginPath)
+	// Point the user config at a missing file: defaults, no interference.
+	t.Setenv("SNIP_CONFIG", filepath.Join(home, ".config", "snip", "config.toml"))
+
+	// Run from a directory without any .snip/ so no project layer applies.
+	workDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	_ = os.Chdir(workDir)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	return pluginPath, home
+}
+
+func TestLoadWithPluginAppliesTrustedLayer(t *testing.T) {
+	pluginDirFilters := t.TempDir()
+	content := `
+[filters]
+dir = "` + pluginDirFilters + `"
+
+[filters.enable]
+git-diff = false
+
+[filters.override.dotnet-test]
+head = 500
+
+[filters.bypass]
+commands = ["dotnet publish"]
+`
+	pluginTestSetup(t, content, true)
+
+	cfg, err := LoadWithPlugin()
+	if err != nil {
+		t.Fatalf("LoadWithPlugin: %v", err)
+	}
+
+	if enabled := cfg.Filters.Enable["git-diff"]; enabled {
+		t.Error("expected git-diff disabled by plugin layer")
+	}
+	if o := cfg.Filters.Override["dotnet-test"]; o.Head != 500 {
+		t.Errorf("Override[dotnet-test].Head: got %d, want 500", o.Head)
+	}
+	if len(cfg.Filters.Bypass.Commands) != 1 || cfg.Filters.Bypass.Commands[0] != "dotnet publish" {
+		t.Errorf("Bypass: got %v", cfg.Filters.Bypass.Commands)
+	}
+	dirs := cfg.Filters.Dirs()
+	if len(dirs) != 2 || dirs[0] != pluginDirFilters {
+		t.Errorf("Dirs: got %v, want plugin dir first then user default", dirs)
+	}
+}
+
+func TestLoadWithPluginUserWins(t *testing.T) {
+	content := `
+[filters.enable]
+git-diff = false
+git-log = false
+
+[filters.global]
+max_lines = 100
+`
+	_, home := pluginTestSetup(t, content, true)
+
+	// User config overrides one plugin key and sets its own global cap.
+	userPath := filepath.Join(home, ".config", "snip", "config.toml")
+	userContent := `
+[filters.enable]
+git-diff = true
+
+[filters.global]
+max_lines = 900
+`
+	if err := os.WriteFile(userPath, []byte(userContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadWithPlugin()
+	if err != nil {
+		t.Fatalf("LoadWithPlugin: %v", err)
+	}
+
+	if enabled := cfg.Filters.Enable["git-diff"]; !enabled {
+		t.Error("user must win over plugin for git-diff")
+	}
+	if enabled := cfg.Filters.Enable["git-log"]; enabled {
+		t.Error("plugin key not overridden by user must survive")
+	}
+	if cfg.Filters.Global.MaxLines != 900 {
+		t.Errorf("Global.MaxLines: got %d, want user's 900", cfg.Filters.Global.MaxLines)
+	}
+}
+
+func TestLoadWithPluginUntrustedWarnsAndIgnores(t *testing.T) {
+	content := `
+[filters.enable]
+git-diff = false
+`
+	pluginPath, _ := pluginTestSetup(t, content, false)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldStderr := os.Stderr
+	os.Stderr = w
+	cfg, loadErr := LoadWithPlugin()
+	os.Stderr = oldStderr
+	_ = w.Close()
+	captured, _ := io.ReadAll(r)
+	_ = r.Close()
+
+	if loadErr != nil {
+		t.Fatalf("LoadWithPlugin: %v", loadErr)
+	}
+	if _, ok := cfg.Filters.Enable["git-diff"]; ok {
+		t.Error("untrusted plugin config must not apply")
+	}
+	msg := string(captured)
+	if !strings.Contains(msg, "untrusted plugin config") || !strings.Contains(msg, "snip trust "+pluginPath) {
+		t.Errorf("expected stderr warning naming the snip trust command, got %q", msg)
+	}
+}
+
+func TestLoadMergedPluginUserProjectCascade(t *testing.T) {
+	content := `
+[filters.override.dotnet-test]
+head = 100
+
+[filters.override.rg]
+head = 50
+`
+	_, home := pluginTestSetup(t, content, true)
+
+	// Project config overrides dotnet-test; rg must survive from the plugin.
+	projectDir := canonicalTempDir(t)
+	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	projectCfgPath := filepath.Join(projectDir, ".snip", "config.toml")
+	projectContent := `mode = "project"
+
+[filters.override.dotnet-test]
+head = 999
+`
+	if err := os.WriteFile(projectCfgPath, []byte(projectContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Trust both plugin and project files in the same store.
+	pluginPath := os.Getenv("SNIP_PLUGIN_CONFIG")
+	store := make(trust.Store)
+	for _, p := range []string{pluginPath, projectCfgPath} {
+		hash, err := trust.HashFile(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		store[p] = hash
+	}
+	if err := trust.SaveTo(store, filepath.Join(home, ".config", "snip", "trusted.json")); err != nil {
+		t.Fatal(err)
+	}
+
+	oldWd, _ := os.Getwd()
+	_ = os.Chdir(projectDir)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	cfg, err := LoadMerged()
+	if err != nil {
+		t.Fatalf("LoadMerged: %v", err)
+	}
+
+	if o := cfg.Filters.Override["dotnet-test"]; o.Head != 999 {
+		t.Errorf("project must win over plugin: got head=%d, want 999", o.Head)
+	}
+	if o := cfg.Filters.Override["rg"]; o.Head != 50 {
+		t.Errorf("plugin key untouched by project must survive: got head=%d, want 50", o.Head)
+	}
+}


### PR DESCRIPTION
## Summary
Implements the snip side of #157: a Claude Code (or other agent) plugin can ship a snip configuration that applies on every machine as the **base** of the cascade `plugin < user < project`.

- `SNIP_PLUGIN_CONFIG=<path>` (exported by the plugin's hook, e.g. `${CLAUDE_PLUGIN_ROOT}/snip/config.toml`) adds the layer; unset means zero change.
- Scope matches the project layer: `filters.enable`, `filters.global`, `filters.override`, `filters.bypass`, `transparent_prefixes`, plus `filters.dir` so a plugin can **ship its own filters**. Plugin dirs load before user dirs, so user filters win by name.
- Trust gate identical to project configs: the file must be `snip trust`ed; untrusted/unreadable/invalid layers are skipped with a stderr warning naming the exact command. (`snip trust <file>.toml` already works for explicit files, no trust-store change needed.)
- `runPipeline` and `loadHookContext` now load filters from the merged dirs; the hook stays free of any directory walk-up.

Stacked on #165 (shares the trust-warning groundwork); merge that one first.

## Test plan
- 4 new tests: trusted layer applies (incl. dir concat), user wins over plugin, untrusted layer warns and is ignored, full `plugin < user < project` cascade through `LoadMerged`.
- `make ci` green locally.
- End-to-end with the real binary: untrusted warning, `snip trust` of the plugin `.toml` + filters dir, plugin filter active, plugin override active, `snip hook` rewrites a plugin-covered command, and 50-run hook latency shows no measurable delta vs baseline.

## Follow-ups (not in this PR)
- Docs: README + wiki Configuration section for the plugin layer, once merged.
- The official example plugin (plugin.json + hooks + self-trust on SessionStart) lives outside this repo.