### PR TITLE
fix(discover,learn): match Claude Code's project-directory naming

### DIFF
--- a/internal/discover/discover.go
+++ b/internal/discover/discover.go
@@ -126,11 +126,17 @@ func parseArgs(args []string) Options {
 }
 
 // cwdToProjectName converts a working directory path to the Claude Code
-// project directory name format: slashes become dashes, leading slash stripped.
+// project directory name format: every non-alphanumeric rune becomes a dash.
+// e.g. /Users/edouard/Code/go/snip -> -Users-edouard-Code-go-snip
+//
+//	C:\dev\acme\agentic-acme-polishing -> C--dev-acme-agentic-acme-polishing
 func cwdToProjectName(cwd string) string {
-	// Claude Code uses the absolute path with "/" replaced by "-"
-	// e.g. /Users/edouard/Code/go/snip -> -Users-edouard-Code-go-snip
-	return strings.ReplaceAll(cwd, string(os.PathSeparator), "-")
+	return strings.Map(func(r rune) rune {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' {
+			return r
+		}
+		return '-'
+	}, cwd)
 }
 
 // findProjectDirs returns the list of Claude Code project directories to scan.

--- a/internal/discover/discover_test.go
+++ b/internal/discover/discover_test.go
@@ -266,10 +266,38 @@ func TestMapToStats(t *testing.T) {
 }
 
 func TestCwdToProjectName(t *testing.T) {
-	got := cwdToProjectName("/Users/edouard/Code/go/snip")
-	want := "-Users-edouard-Code-go-snip"
-	if got != want {
-		t.Errorf("cwdToProjectName() = %q, want %q", got, want)
+	tests := []struct {
+		name string
+		cwd  string
+		want string
+	}{
+		{
+			name: "unix path",
+			cwd:  "/Users/edouard/Code/go/snip",
+			want: "-Users-edouard-Code-go-snip",
+		},
+		{
+			name: "windows drive colon and dashes in project dir",
+			cwd:  `C:\dev\acme\agentic-acme-polishing`,
+			want: "C--dev-acme-agentic-acme-polishing",
+		},
+		{
+			name: "windows path with underscore and space",
+			cwd:  `C:\dev\_lab\my project`,
+			want: "C--dev--lab-my-project",
+		},
+		{
+			name: "windows home dir with whitespace and dot dir",
+			cwd:  `C:\Users\Jane Doe\.claude`,
+			want: "C--Users-Jane-Doe--claude",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cwdToProjectName(tt.cwd); got != tt.want {
+				t.Errorf("cwdToProjectName(%q) = %q, want %q", tt.cwd, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/learn/learn.go
+++ b/internal/learn/learn.go
@@ -198,9 +198,14 @@ func parseArgs(args []string) Options {
 }
 
 // cwdToProjectName converts a working directory path to the Claude Code
-// project directory name format.
+// project directory name format: every non-alphanumeric rune becomes a dash.
 func cwdToProjectName(cwd string) string {
-	return strings.ReplaceAll(cwd, string(os.PathSeparator), "-")
+	return strings.Map(func(r rune) rune {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' {
+			return r
+		}
+		return '-'
+	}, cwd)
 }
 
 // findProjectDirs returns the list of Claude Code project directories to scan.

--- a/internal/learn/learn_test.go
+++ b/internal/learn/learn_test.go
@@ -507,6 +507,42 @@ func TestStringOrArrayUnmarshal(t *testing.T) {
 	}
 }
 
+func TestCwdToProjectName(t *testing.T) {
+	tests := []struct {
+		name string
+		cwd  string
+		want string
+	}{
+		{
+			name: "unix path",
+			cwd:  "/Users/edouard/Code/go/snip",
+			want: "-Users-edouard-Code-go-snip",
+		},
+		{
+			name: "windows drive colon and dashes in project dir",
+			cwd:  `C:\dev\acme\agentic-acme-polishing`,
+			want: "C--dev-acme-agentic-acme-polishing",
+		},
+		{
+			name: "windows path with underscore and space",
+			cwd:  `C:\dev\_lab\my project`,
+			want: "C--dev--lab-my-project",
+		},
+		{
+			name: "windows home dir with whitespace and dot dir",
+			cwd:  `C:\Users\Jane Doe\.claude`,
+			want: "C--Users-Jane-Doe--claude",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cwdToProjectName(tt.cwd); got != tt.want {
+				t.Errorf("cwdToProjectName(%q) = %q, want %q", tt.cwd, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFindProjectDirsRespectsClaudeConfigDir(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	claudeDir := t.TempDir()


### PR DESCRIPTION
Hi,

I've had some issues using `snip discover` and `snip learn` on my windows machine (see below).
Never done any go so hooked up Claude to help me figure out the issue and fix it.

Thought it may be worth a PR and not found any remarks regarding AI contributions so created this one.

In case I've missed that AI contributions are not welcomed or this PR is does not meet your expectations feel free to close it.

In the hope I've not wasted your time

Khoff

---

## Problem

On Windows, `snip discover` and `snip learn` always report
"no Claude Code session directories found", even when sessions exist.

## Cause

`cwdToProjectName` (duplicated in `internal/discover` and
`internal/learn`) builds the Claude Code project-directory name by
replacing only `os.PathSeparator` with `-`. Claude Code replaces every
non-alphanumeric character.

For `C:\dev\acme\agentic-acme-polishing`:

- snip computed `C:-dev-acme-agentic-acme-polishing`
- Claude Code created `C--dev-acme-agentic-acme-polishing`

The drive colon survives, the `os.Stat` lookup misses, and the scan
ends before it starts. Paths containing `_`, `.`, or a space (e.g.
`C:\dev\_lab\my project`, `C:\Users\Jane Doe\.claude`) fail the same
way on every OS. The `os.PathSeparator` dependence also made
`/`-separated paths convert differently per host OS.

## Fix

Map every non-alphanumeric rune to `-` in both copies. Plain
alphanumeric Unix paths convert exactly as before.

## Testing

- Table-driven tests for `cwdToProjectName` in both packages: Unix
  path, Windows drive colon + dashes, underscore + space, home
  directory with whitespace and a dot dir. All four fail on master,
  all pass with the fix.
- `go test ./...`, `snip verify` (55/55), `go vet`, `govulncheck`: clean.
- Pre-existing and unrelated (fail on master too):
  `internal/initcmd` `TestInitPiThenUninstallSymmetric` and
  `internal/tee` `TestMaybeSaveProjectMarkerUnwritableFallsBack`.

Generated by: Claude Fable 5 <noreply@anthropic.com>