### PR TITLE
fix(hook): carry the plugin config into rewritten commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,7 +570,7 @@ An agent plugin (for example a Claude Code plugin) can ship a snip config that a
 SNIP_PLUGIN_CONFIG=${CLAUDE_PLUGIN_ROOT}/snip/config.toml
 ```
 
-The file is a regular snip TOML restricted to the filter sections (`filters.enable`, `filters.global`, `filters.override`, `filters.bypass`, `transparent_prefixes`, and `filters.dir` so the plugin can ship its own filter YAMLs; plugin filters load first, so user filters win by name). Like a project config, it must be trusted once:
+The file is a regular snip TOML restricted to the filter sections (`filters.enable`, `filters.global`, `filters.override`, `filters.bypass`, `transparent_prefixes`, and `filters.dir` so the plugin can ship its own filter YAMLs; plugin filters load first, so user filters win by name). A relative `filters.dir` resolves against the TOML's own directory, so `dir = "filters"` just works. The variable only needs to exist in the hook's environment: rewritten commands carry the path along as a `--plugin-config` flag, so the agent's shell needs no special environment. Like a project config, it must be trusted once:
 
 ```bash
 snip trust "$SNIP_PLUGIN_CONFIG"               # the config itself

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -46,6 +46,13 @@ func Run(args []string) int {
 		return 0
 	}
 
+	// A hook-rewritten command carries the plugin config as a flag because
+	// the agent's shell does not inherit the hook's environment (#169).
+	// Export it so every config.Load* call below sees the plugin layer.
+	if flags.PluginConfig != "" {
+		_ = os.Setenv("SNIP_PLUGIN_CONFIG", flags.PluginConfig)
+	}
+
 	command := remaining[0]
 	cmdArgs := remaining[1:]
 

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -9,6 +9,10 @@ type Flags struct {
 	SkipEnv      bool
 	Version      bool
 	Help         bool
+	// PluginConfig is the --plugin-config value: a plugin-provided snip
+	// config path embedded in rewritten commands by the hook (issue #169).
+	// Applied by exporting SNIP_PLUGIN_CONFIG before config loading.
+	PluginConfig string
 }
 
 // ParseFlags extracts global flags from args and returns remaining args.
@@ -19,13 +23,23 @@ func ParseFlags(args []string) (Flags, []string) {
 	var flags Flags
 	var remaining []string
 
+	skipNext := false
 	for i, arg := range args {
+		if skipNext {
+			skipNext = false
+			continue
+		}
 		if arg == "--" {
 			// Everything after "--" belongs to the underlying command.
 			remaining = append(remaining, args[i+1:]...)
 			break
 		}
 		switch {
+		case arg == "--plugin-config" && i+1 < len(args):
+			flags.PluginConfig = args[i+1]
+			skipNext = true
+		case arg == "--plugin-config":
+			// Missing value: ignore the dangling flag.
 		case arg == "-vv":
 			flags.Verbose = 2
 		case arg == "-v":

--- a/internal/cli/flags_test.go
+++ b/internal/cli/flags_test.go
@@ -165,3 +165,23 @@ func TestParseFlags(t *testing.T) {
 		})
 	}
 }
+
+func TestParseFlagsPluginConfig(t *testing.T) {
+	flags, remaining := ParseFlags([]string{"--plugin-config", "/plug/config.toml", "run", "--", "git", "status"})
+	if flags.PluginConfig != "/plug/config.toml" {
+		t.Errorf("PluginConfig: got %q, want /plug/config.toml", flags.PluginConfig)
+	}
+	if len(remaining) != 4 || remaining[0] != "run" || remaining[1] != "--" {
+		t.Errorf("remaining: got %v, want [run -- git status]", remaining)
+	}
+}
+
+func TestParseFlagsPluginConfigMissingValue(t *testing.T) {
+	flags, remaining := ParseFlags([]string{"--plugin-config"})
+	if flags.PluginConfig != "" {
+		t.Errorf("PluginConfig: got %q, want empty", flags.PluginConfig)
+	}
+	if len(remaining) != 0 {
+		t.Errorf("remaining: got %v, want empty", remaining)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -323,6 +323,19 @@ func applyPluginLayer(user *Config) {
 	}
 	plugin.expandPaths()
 
+	// Relative filter dirs resolve against the plugin config's own directory,
+	// so a plugin ships `dir = "filters"` with no env dependency (#169).
+	// DefaultConfig pre-fills Dir with the absolute user filters dir, so only
+	// paths the plugin actually wrote can be relative here.
+	pluginBase := filepath.Dir(path)
+	pluginDirs := plugin.Filters.Dirs()
+	for i, d := range pluginDirs {
+		if !filepath.IsAbs(d) {
+			pluginDirs[i] = filepath.Join(pluginBase, d)
+		}
+	}
+	plugin.Filters.Dir = pluginDirs
+
 	// Enable and Override: plugin provides the base, user keys win.
 	if len(plugin.Filters.Enable) > 0 {
 		merged := make(map[string]bool, len(plugin.Filters.Enable)+len(user.Filters.Enable))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1652,3 +1652,25 @@ head = 999
 		t.Errorf("plugin key untouched by project must survive: got head=%d, want 50", o.Head)
 	}
 }
+
+func TestPluginRelativeDirsResolveAgainstConfigFile(t *testing.T) {
+	// A plugin ships `dir = "filters"` next to its config.toml; the path must
+	// resolve against the TOML's own directory, so the plugin needs no
+	// ${env.CLAUDE_PLUGIN_ROOT} in the file (issue #169).
+	content := `
+[filters]
+dir = "filters"
+`
+	pluginPath, _ := pluginTestSetup(t, content, true)
+
+	cfg, err := LoadWithPlugin()
+	if err != nil {
+		t.Fatalf("LoadWithPlugin: %v", err)
+	}
+
+	want := filepath.Join(filepath.Dir(pluginPath), "filters")
+	dirs := cfg.Filters.Dirs()
+	if len(dirs) < 1 || dirs[0] != want {
+		t.Errorf("Dirs: got %v, want first entry %q", dirs, want)
+	}
+}

--- a/internal/hook/quote.go
+++ b/internal/hook/quote.go
@@ -2,9 +2,25 @@ package hook
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 	"strings"
 )
+
+// runInvocation renders `<quotedBin> [--plugin-config <path>] run -- ` for a
+// rewritten or suggested command. The hook process may carry a plugin
+// configuration through SNIP_PLUGIN_CONFIG (set by an agent plugin's hook
+// entry), but the rewritten command executes later in the agent's shell,
+// which does not inherit the hook's environment. Embedding the path as a
+// flag keeps the plugin layer alive at run time (issue #169). A flag is
+// used instead of a `VAR=x` env prefix so PowerShell keeps working (#150).
+func runInvocation(quotedBin string) string {
+	inv := quotedBin
+	if p := os.Getenv("SNIP_PLUGIN_CONFIG"); p != "" {
+		inv += " --plugin-config " + quoteSnipBin(p)
+	}
+	return inv + " run -- "
+}
 
 // quoteSnipBin renders the snip binary path for inclusion in a rewritten
 // command, so a path containing spaces still executes as one word.

--- a/internal/hook/rewrite.go
+++ b/internal/hook/rewrite.go
@@ -281,7 +281,7 @@ func rewriteGroup(group string, cmdSet map[string]struct{}, prefixes []Transpare
 			if feedsConsumer {
 				return group, true, hasTail
 			}
-			wrappedHead := prefix + envVars + tp.Prefix + " " + before + quotedBin + " run -- " + rest[len(before):]
+			wrappedHead := prefix + envVars + tp.Prefix + " " + before + runInvocation(quotedBin) + rest[len(before):]
 			return wrappedHead + tail, true, hasTail
 		}
 	}
@@ -295,7 +295,7 @@ func rewriteGroup(group string, cmdSet map[string]struct{}, prefixes []Transpare
 		return group, true, hasTail
 	}
 
-	wrappedHead := prefix + envVars + quotedBin + " run -- " + bareCmd
+	wrappedHead := prefix + envVars + runInvocation(quotedBin) + bareCmd
 	return wrappedHead + tail, true, hasTail
 }
 

--- a/internal/hook/rewrite_test.go
+++ b/internal/hook/rewrite_test.go
@@ -290,3 +290,36 @@ func TestHasUnverifiableConstruct(t *testing.T) {
 		}
 	}
 }
+
+func TestRewriteEmbedsPluginConfigFlag(t *testing.T) {
+	// Issue #169: the rewritten command runs in the agent's shell, which does
+	// not inherit the hook's environment. When the hook itself was started
+	// with SNIP_PLUGIN_CONFIG, the path must travel inside the rewritten
+	// command as a portable flag, or the plugin layer silently vanishes at
+	// run time.
+	t.Setenv("SNIP_PLUGIN_CONFIG", "/plug/snip/config.toml")
+
+	cmdSet := map[string]struct{}{"git": {}}
+	res := RewriteCommand("git status", cmdSet, nil, "/usr/local/bin/snip")
+	if !res.Changed {
+		t.Fatal("expected rewrite")
+	}
+	want := `"/usr/local/bin/snip" --plugin-config "/plug/snip/config.toml" run -- git status`
+	if res.Command != want {
+		t.Errorf("got  %q\nwant %q", res.Command, want)
+	}
+}
+
+func TestRewriteNoPluginConfigFlagWhenUnset(t *testing.T) {
+	t.Setenv("SNIP_PLUGIN_CONFIG", "")
+
+	cmdSet := map[string]struct{}{"git": {}}
+	res := RewriteCommand("git status", cmdSet, nil, "/usr/local/bin/snip")
+	if !res.Changed {
+		t.Fatal("expected rewrite")
+	}
+	want := `"/usr/local/bin/snip" run -- git status`
+	if res.Command != want {
+		t.Errorf("got  %q\nwant %q", res.Command, want)
+	}
+}

--- a/internal/hook/suggest.go
+++ b/internal/hook/suggest.go
@@ -46,7 +46,7 @@ func suggestSnipRerun(command string, cmdSet map[string]struct{}, prefixes []Tra
 	var suggested string
 	if tp, restAfter, ok := matchTransparentPrefix(bareCmd, prefixes); ok {
 		if before, _, found := LocateInner(restAfter, cmdSet, tp.ValueFlags, tp.SkipFlags); found {
-			suggested = prefix + envVars + tp.Prefix + " " + before + quotedBin + " run -- " + restAfter[len(before):] + restOfCmd
+			suggested = prefix + envVars + tp.Prefix + " " + before + runInvocation(quotedBin) + restAfter[len(before):] + restOfCmd
 		}
 	}
 
@@ -54,7 +54,7 @@ func suggestSnipRerun(command string, cmdSet map[string]struct{}, prefixes []Tra
 		if _, ok := cmdSet[base]; !ok {
 			return snipSuggestion{base: base}
 		}
-		suggested = prefix + envVars + quotedBin + " run -- " + bareCmd + restOfCmd
+		suggested = prefix + envVars + runInvocation(quotedBin) + bareCmd + restOfCmd
 	}
 
 	return snipSuggestion{command: suggested, base: base}


### PR DESCRIPTION
## Summary
End-to-end testing of a realistic Claude Code plugin (#157/#167) exposed a gap (#169): the hook sees `SNIP_PLUGIN_CONFIG` and rewrites the command, but the rewritten command runs in the agent's shell, which does not inherit the hook's environment — so the plugin layer silently vanished at run time.

- Rewrites and Grok suggestions now embed the path as a flag: `"snip" --plugin-config "<path>" run -- <cmd>`. A flag, not a `VAR=x` prefix, so PowerShell keeps working (#150). Emitted only when the hook itself runs with `SNIP_PLUGIN_CONFIG` set.
- `--plugin-config <path>` is a new global flag: exported as `SNIP_PLUGIN_CONFIG` before config loading, so the existing plugin layer picks it up.
- Relative `filters.dir` entries in a plugin TOML resolve against the TOML's own directory: a plugin ships `dir = "filters"`, no `${env.CLAUDE_PLUGIN_ROOT}` needed in the file.

Closes #169

## Test plan
- `TestRewriteEmbedsPluginConfigFlag` / `TestRewriteNoPluginConfigFlagWhenUnset` (both red before the fix), `TestParseFlagsPluginConfig` (+ missing-value case), `TestPluginRelativeDirsResolveAgainstConfigFile`.
- Existing Windows-quoting rewrite test still green (the helper reuses the injected quoted bin).
- `make ci` green locally.
- Full plugin lifecycle replayed with a realistic fake plugin: SessionStart self-trust, PreToolUse rewrite embedding the flag, and the rewritten command executed in a **bare** env now applies the plugin's filters.