### PR TITLE
feat(economics): configurable pricing tiers with current provider defaults

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -132,7 +132,7 @@ func Run(args []string) int {
 			return 1
 		}
 		defer func() { _ = tracker.Close() }()
-		if err := economics.Run(tracker, cmdArgs); err != nil {
+		if err := economics.Run(tracker, cfg.Economics, cmdArgs); err != nil {
 			display.PrintError(err.Error())
 			return 1
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,11 +15,19 @@ import (
 var envVarRe = regexp.MustCompile(`\$\{env\.(\w+)\}`)
 
 type Config struct {
-	Mode     string         `toml:"mode"` // "user" (default) or "project"
-	Tracking TrackingConfig `toml:"tracking"`
-	Display  DisplayConfig  `toml:"display"`
-	Filters  FiltersConfig  `toml:"filters"`
-	Tee      TeeConfig      `toml:"tee"`
+	Mode      string          `toml:"mode"` // "user" (default) or "project"
+	Tracking  TrackingConfig  `toml:"tracking"`
+	Display   DisplayConfig   `toml:"display"`
+	Filters   FiltersConfig   `toml:"filters"`
+	Tee       TeeConfig       `toml:"tee"`
+	Economics EconomicsConfig `toml:"economics"`
+}
+
+// EconomicsConfig holds the pricing tiers used by cc-economics. Keys are
+// tier names, values are $ per 1M input tokens. Empty means the built-in
+// defaults (current Anthropic list prices) apply.
+type EconomicsConfig struct {
+	Tiers map[string]float64 `toml:"tiers"`
 }
 
 type TrackingConfig struct {
@@ -179,11 +187,12 @@ func tryUnmarshalArrayDir(data []byte, cfg *Config) bool {
 		Bypass              FilterBypassConfig        `toml:"bypass"`
 	}
 	type configArray struct {
-		Mode     string         `toml:"mode"`
-		Tracking TrackingConfig `toml:"tracking"`
-		Display  DisplayConfig  `toml:"display"`
-		Filters  filtersArray   `toml:"filters"`
-		Tee      TeeConfig      `toml:"tee"`
+		Mode      string          `toml:"mode"`
+		Tracking  TrackingConfig  `toml:"tracking"`
+		Display   DisplayConfig   `toml:"display"`
+		Filters   filtersArray    `toml:"filters"`
+		Tee       TeeConfig       `toml:"tee"`
+		Economics EconomicsConfig `toml:"economics"`
 	}
 
 	def := DefaultConfig()
@@ -209,7 +218,14 @@ func tryUnmarshalArrayDir(data []byte, cfg *Config) bool {
 	cfg.Filters.Override = alt.Filters.Override
 	cfg.Filters.Bypass = alt.Filters.Bypass
 	cfg.Tee = alt.Tee
+	cfg.Economics = alt.Economics
 	return true
+}
+
+// Path returns the user config file location: SNIP_CONFIG when set,
+// otherwise ~/.config/snip/config.toml.
+func Path() string {
+	return configPath()
 }
 
 // expandPaths expands ${env.VAR} references and leading "~/" in all path fields.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1674,3 +1674,58 @@ dir = "filters"
 		t.Errorf("Dirs: got %v, want first entry %q", dirs, want)
 	}
 }
+
+func TestLoadConfigEconomicsTiers(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	content := `
+[economics.tiers]
+haiku = 1.0
+opus = 4.20
+negotiated = 2.75
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("SNIP_CONFIG", path)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Economics.Tiers) != 3 {
+		t.Fatalf("Tiers: got %v, want 3 entries", cfg.Economics.Tiers)
+	}
+	if cfg.Economics.Tiers["negotiated"] != 2.75 {
+		t.Errorf("Tiers[negotiated]: got %v, want 2.75", cfg.Economics.Tiers["negotiated"])
+	}
+}
+
+func TestLoadConfigEconomicsSurvivesArrayDir(t *testing.T) {
+	// The array-dir fallback structs must mirror every section (#158).
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	content := `
+[filters]
+dir = ["/tmp/a", "/tmp/b"]
+
+[economics.tiers]
+opus = 4.20
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("SNIP_CONFIG", path)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Economics.Tiers["opus"] != 4.20 {
+		t.Errorf("Tiers[opus] after array-dir fallback: got %v, want 4.20", cfg.Economics.Tiers["opus"])
+	}
+}

--- a/internal/economics/economics.go
+++ b/internal/economics/economics.go
@@ -2,7 +2,9 @@ package economics
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/edouard-claude/snip/internal/config"
 	"github.com/edouard-claude/snip/internal/display"
 	"github.com/edouard-claude/snip/internal/tracking"
 	"github.com/edouard-claude/snip/internal/utils"
@@ -12,23 +14,6 @@ import (
 type Tier struct {
 	Name   string
 	PriceM float64 // price per 1M input tokens
-}
-
-// Tiers lists all supported pricing tiers in display order.
-var Tiers = []Tier{
-	{Name: "Haiku", PriceM: 0.25},
-	{Name: "Sonnet", PriceM: 3.00},
-	{Name: "Opus", PriceM: 15.00},
-}
-
-// TierByName returns the tier matching name (case-insensitive), or nil.
-func TierByName(name string) *Tier {
-	for i := range Tiers {
-		if eqFold(Tiers[i].Name, name) {
-			return &Tiers[i]
-		}
-	}
-	return nil
 }
 
 // CostForTokens returns the dollar cost for the given token count at the tier price.
@@ -47,12 +32,15 @@ func FormatCost(amount float64) string {
 	return fmt.Sprintf("$%.2f", amount)
 }
 
-// Run executes the cc-economics subcommand.
-func Run(tracker *tracking.Tracker, args []string) error {
+// Run executes the cc-economics subcommand. ecoCfg supplies the pricing
+// tiers ([economics.tiers] in config.toml, or the built-in defaults).
+func Run(tracker *tracking.Tracker, ecoCfg config.EconomicsConfig, args []string) error {
 	if tracker == nil {
 		display.PrintError("no tracking data (run some commands first)")
 		return nil
 	}
+
+	activeTiers := ActiveTiers(ecoCfg)
 
 	// Parse --tier flag
 	var filterTier string
@@ -63,8 +51,8 @@ func Run(tracker *tracking.Tracker, args []string) error {
 		}
 	}
 
-	if filterTier != "" && TierByName(filterTier) == nil {
-		return fmt.Errorf("unknown tier %q (valid: haiku, sonnet, opus)", filterTier)
+	if filterTier != "" && FindTier(activeTiers, filterTier) == nil {
+		return fmt.Errorf("unknown tier %q (valid: %s)", filterTier, strings.Join(TierNames(activeTiers), ", "))
 	}
 
 	summary, err := tracker.GetSummary()
@@ -109,15 +97,21 @@ func Run(tracker *tracking.Tracker, args []string) error {
 		fmt.Println("  Estimated savings by model tier:")
 	}
 
-	tiers := Tiers
+	tiers := activeTiers
 	if filterTier != "" {
-		t := TierByName(filterTier)
+		t := FindTier(activeTiers, filterTier)
 		tiers = []Tier{*t}
 	}
 
+	nameWidth := 8
+	for _, t := range tiers {
+		if len(t.Name) > nameWidth {
+			nameWidth = len(t.Name)
+		}
+	}
 	for _, t := range tiers {
 		cost := CostForTokens(summary.TotalSaved, t.PriceM)
-		label := fmt.Sprintf("    %-8s", t.Name)
+		label := fmt.Sprintf("    %-*s", nameWidth, t.Name)
 		value := FormatCost(cost)
 		if tty {
 			fmt.Printf("  %s %s\n", display.DimStyle.Render(label), display.GreenStyle.Render(value))
@@ -137,24 +131,4 @@ func Run(tracker *tracking.Tracker, args []string) error {
 	fmt.Println()
 
 	return nil
-}
-
-// eqFold is a simple case-insensitive string comparison.
-func eqFold(a, b string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		ca, cb := a[i], b[i]
-		if ca >= 'A' && ca <= 'Z' {
-			ca += 'a' - 'A'
-		}
-		if cb >= 'A' && cb <= 'Z' {
-			cb += 'a' - 'A'
-		}
-		if ca != cb {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/economics/economics_test.go
+++ b/internal/economics/economics_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/edouard-claude/snip/internal/config"
 	"github.com/edouard-claude/snip/internal/tracking"
 )
 
@@ -98,33 +99,36 @@ func TestTierByName(t *testing.T) {
 		{"opus", "Opus"},
 	}
 
+	defaults := ActiveTiers(config.EconomicsConfig{})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tier := TierByName(tt.name)
+			tier := FindTier(defaults, tt.name)
 			if tier == nil {
-				t.Fatalf("TierByName(%q) returned nil", tt.name)
+				t.Fatalf("FindTier(%q) returned nil", tt.name)
 			}
 			if tier.Name != tt.want {
-				t.Errorf("TierByName(%q).Name = %q, want %q", tt.name, tier.Name, tt.want)
+				t.Errorf("FindTier(%q).Name = %q, want %q", tt.name, tier.Name, tt.want)
 			}
 		})
 	}
 }
 
 func TestTierByNameUnknown(t *testing.T) {
-	tier := TierByName("unknown")
+	tier := FindTier(ActiveTiers(config.EconomicsConfig{}), "unknown")
 	if tier != nil {
-		t.Errorf("TierByName(\"unknown\") = %v, want nil", tier)
+		t.Errorf("FindTier(\"unknown\") = %v, want nil", tier)
 	}
 }
 
 func TestTierPricing(t *testing.T) {
+	// Current Anthropic list prices, $ per 1M input tokens (2026-08).
 	expected := map[string]float64{
-		"Haiku":  0.25,
+		"Haiku":  1.00,
 		"Sonnet": 3.00,
-		"Opus":   15.00,
+		"Opus":   5.00,
+		"Fable":  10.00,
 	}
-	for _, tier := range Tiers {
+	for _, tier := range ActiveTiers(config.EconomicsConfig{}) {
 		want, ok := expected[tier.Name]
 		if !ok {
 			t.Errorf("unexpected tier %q", tier.Name)
@@ -137,7 +141,7 @@ func TestTierPricing(t *testing.T) {
 }
 
 func TestRunNilTracker(t *testing.T) {
-	err := Run(nil, nil)
+	err := Run(nil, config.EconomicsConfig{}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -155,7 +159,7 @@ func TestRunWithData(t *testing.T) {
 	}
 	os.Stdout = w
 
-	runErr := Run(tracker, nil)
+	runErr := Run(tracker, config.EconomicsConfig{}, nil)
 
 	_ = w.Close()
 	var buf bytes.Buffer
@@ -193,7 +197,7 @@ func TestRunWithTierFilter(t *testing.T) {
 	}
 	os.Stdout = w
 
-	runErr := Run(tracker, []string{"--tier", "sonnet"})
+	runErr := Run(tracker, config.EconomicsConfig{}, []string{"--tier", "sonnet"})
 
 	_ = w.Close()
 	var buf bytes.Buffer
@@ -220,30 +224,11 @@ func TestRunUnknownTier(t *testing.T) {
 	tracker := newTestTracker(t)
 	seedTracker(t, tracker)
 
-	err := Run(tracker, []string{"--tier", "gpt4"})
+	err := Run(tracker, config.EconomicsConfig{}, []string{"--tier", "gpt4"})
 	if err == nil {
 		t.Fatal("expected error for unknown tier")
 	}
 	if !strings.Contains(err.Error(), "unknown tier") {
 		t.Errorf("expected 'unknown tier' error, got: %v", err)
-	}
-}
-
-func TestEqFold(t *testing.T) {
-	tests := []struct {
-		a, b string
-		want bool
-	}{
-		{"Haiku", "haiku", true},
-		{"HAIKU", "haiku", true},
-		{"haiku", "haiku", true},
-		{"haiku", "sonnet", false},
-		{"abc", "abcd", false},
-	}
-	for _, tt := range tests {
-		got := eqFold(tt.a, tt.b)
-		if got != tt.want {
-			t.Errorf("eqFold(%q, %q) = %v, want %v", tt.a, tt.b, got, tt.want)
-		}
 	}
 }

--- a/internal/economics/tiers.go
+++ b/internal/economics/tiers.go
@@ -1,0 +1,57 @@
+package economics
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/edouard-claude/snip/internal/config"
+)
+
+// defaultTiers are current Anthropic list prices, $ per 1M input tokens
+// (as of 2026-08). Overridable via [economics.tiers] in config.toml for
+// negotiated or non-Anthropic rates.
+var defaultTiers = []Tier{
+	{Name: "Haiku", PriceM: 1.00},
+	{Name: "Sonnet", PriceM: 3.00},
+	{Name: "Opus", PriceM: 5.00},
+	{Name: "Fable", PriceM: 10.00},
+}
+
+// ActiveTiers returns the pricing tiers to report on: the [economics.tiers]
+// entries from the config when present (sorted by ascending price), the
+// built-in defaults otherwise.
+func ActiveTiers(cfg config.EconomicsConfig) []Tier {
+	if len(cfg.Tiers) == 0 {
+		return defaultTiers
+	}
+	tiers := make([]Tier, 0, len(cfg.Tiers))
+	for name, price := range cfg.Tiers {
+		tiers = append(tiers, Tier{Name: name, PriceM: price})
+	}
+	sort.Slice(tiers, func(i, j int) bool {
+		if tiers[i].PriceM != tiers[j].PriceM {
+			return tiers[i].PriceM < tiers[j].PriceM
+		}
+		return tiers[i].Name < tiers[j].Name
+	})
+	return tiers
+}
+
+// FindTier returns the tier matching name (case-insensitive), or nil.
+func FindTier(tiers []Tier, name string) *Tier {
+	for i := range tiers {
+		if strings.EqualFold(tiers[i].Name, name) {
+			return &tiers[i]
+		}
+	}
+	return nil
+}
+
+// TierNames returns the lowercase tier names, for error messages.
+func TierNames(tiers []Tier) []string {
+	names := make([]string, len(tiers))
+	for i, t := range tiers {
+		names[i] = strings.ToLower(t.Name)
+	}
+	return names
+}

--- a/internal/economics/tiers_test.go
+++ b/internal/economics/tiers_test.go
@@ -1,0 +1,42 @@
+package economics
+
+import (
+	"testing"
+
+	"github.com/edouard-claude/snip/internal/config"
+)
+
+func TestActiveTiersDefaults(t *testing.T) {
+	tiers := ActiveTiers(config.EconomicsConfig{})
+	if len(tiers) != 4 {
+		t.Fatalf("expected 4 default tiers, got %v", tiers)
+	}
+	want := map[string]float64{"Haiku": 1.00, "Sonnet": 3.00, "Opus": 5.00, "Fable": 10.00}
+	for _, tier := range tiers {
+		if want[tier.Name] != tier.PriceM {
+			t.Errorf("%s: got %v, want %v", tier.Name, tier.PriceM, want[tier.Name])
+		}
+	}
+}
+
+func TestActiveTiersFromConfigSortedByPrice(t *testing.T) {
+	tiers := ActiveTiers(config.EconomicsConfig{Tiers: map[string]float64{
+		"premium": 9.99, "budget": 0.50, "standard": 2.00,
+	}})
+	if len(tiers) != 3 {
+		t.Fatalf("expected 3 tiers, got %v", tiers)
+	}
+	if tiers[0].Name != "budget" || tiers[1].Name != "standard" || tiers[2].Name != "premium" {
+		t.Errorf("expected price-ascending order, got %v", tiers)
+	}
+}
+
+func TestFindTierCaseInsensitive(t *testing.T) {
+	tiers := ActiveTiers(config.EconomicsConfig{Tiers: map[string]float64{"Negotiated": 2.75}})
+	if tier := FindTier(tiers, "negotiated"); tier == nil || tier.PriceM != 2.75 {
+		t.Errorf("FindTier(negotiated): got %v", tier)
+	}
+	if tier := FindTier(tiers, "nope"); tier != nil {
+		t.Errorf("FindTier(nope): got %v, want nil", tier)
+	}
+}

--- a/internal/initcmd/economics_section.go
+++ b/internal/initcmd/economics_section.go
@@ -1,0 +1,79 @@
+package initcmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/edouard-claude/snip/internal/config"
+)
+
+// anthropicAgents are the agents whose provider is Anthropic, so the
+// economics template can carry real list prices. Every other agent gets a
+// generic template rather than invented provider rates.
+var anthropicAgents = map[string]bool{
+	"claude-code": true,
+}
+
+const anthropicEconomicsTemplate = `
+[economics.tiers]
+# Prices in $ per 1M input tokens, used by ` + "`snip cc-economics`" + `.
+# Anthropic list prices as of 2026-08; uncomment and adjust to your
+# negotiated rates. Names are free-form.
+# haiku = 1.00
+# sonnet = 3.00
+# opus = 5.00
+# fable = 10.00
+`
+
+const genericEconomicsTemplate = `
+[economics.tiers]
+# Prices in $ per 1M input tokens, used by ` + "`snip cc-economics`" + `.
+# Rates vary by provider and contract: uncomment and adjust to the models
+# you actually use. Names are free-form.
+# budget = 1.00
+# standard = 3.00
+# premium = 5.00
+`
+
+// ensureEconomicsSection appends a commented [economics.tiers] template to
+// the user config so cc-economics pricing is discoverable and adjustable.
+// Existing content is preserved verbatim; a config that already has an
+// economics section is left untouched.
+func ensureEconomicsSection(agent string) error {
+	path := config.Path()
+
+	data, err := os.ReadFile(path)
+	switch {
+	case err == nil:
+		if strings.Contains(string(data), "[economics") {
+			return nil
+		}
+	case os.IsNotExist(err):
+		if mkErr := os.MkdirAll(filepath.Dir(path), 0o755); mkErr != nil {
+			return fmt.Errorf("create config dir: %w", mkErr)
+		}
+	default:
+		return fmt.Errorf("read config: %w", err)
+	}
+
+	tmpl := genericEconomicsTemplate
+	if anthropicAgents[agent] {
+		tmpl = anthropicEconomicsTemplate
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open config: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if len(data) > 0 && !strings.HasSuffix(string(data), "\n") {
+		tmpl = "\n" + tmpl
+	}
+	if _, err := f.WriteString(tmpl); err != nil {
+		return fmt.Errorf("append economics section: %w", err)
+	}
+	return nil
+}

--- a/internal/initcmd/economics_section_test.go
+++ b/internal/initcmd/economics_section_test.go
@@ -1,0 +1,70 @@
+package initcmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEnsureEconomicsSectionCreatesFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	t.Setenv("SNIP_CONFIG", path)
+
+	if err := ensureEconomicsSection("claude-code"); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	if !strings.Contains(s, "[economics.tiers]") || !strings.Contains(s, "# opus = 5.00") {
+		t.Errorf("expected commented Anthropic tiers template, got:\n%s", s)
+	}
+	if !strings.Contains(s, "adjust") {
+		t.Errorf("expected an adjust-your-rates note, got:\n%s", s)
+	}
+}
+
+func TestEnsureEconomicsSectionAppendsWithoutTouchingExisting(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	existing := "[display]\ncolor = true\n"
+	if err := os.WriteFile(path, []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SNIP_CONFIG", path)
+
+	if err := ensureEconomicsSection("gemini"); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(path)
+	s := string(data)
+	if !strings.HasPrefix(s, existing) {
+		t.Errorf("existing content must be preserved verbatim, got:\n%s", s)
+	}
+	if !strings.Contains(s, "[economics.tiers]") {
+		t.Errorf("expected appended economics section, got:\n%s", s)
+	}
+	// Non-Anthropic agent: generic template, no invented provider rates.
+	if strings.Contains(s, "fable") {
+		t.Errorf("generic template must not carry Anthropic tier names, got:\n%s", s)
+	}
+}
+
+func TestEnsureEconomicsSectionIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	t.Setenv("SNIP_CONFIG", path)
+
+	if err := ensureEconomicsSection("claude-code"); err != nil {
+		t.Fatal(err)
+	}
+	first, _ := os.ReadFile(path)
+	if err := ensureEconomicsSection("claude-code"); err != nil {
+		t.Fatal(err)
+	}
+	second, _ := os.ReadFile(path)
+	if string(first) != string(second) {
+		t.Error("second call must be a no-op")
+	}
+}

--- a/internal/initcmd/init.go
+++ b/internal/initcmd/init.go
@@ -136,6 +136,12 @@ func Run(args []string) error {
 		return fmt.Errorf("create filter dir: %w", err)
 	}
 
+	// Best-effort: seed a commented [economics.tiers] template so pricing
+	// is discoverable. Never blocks the install.
+	if err := ensureEconomicsSection(agent); err != nil {
+		fmt.Fprintf(os.Stderr, "snip: could not write economics template: %v\n", err)
+	}
+
 	switch agent {
 	case "claude-code":
 		return initClaudeCode(snipBin, filterDir)


### PR DESCRIPTION
## Summary
Raised by @jspelletier: Ubisoft pays negotiated rates, so the hardcoded cc-economics tiers (which were also outdated) made the report meaningless for them.

- **`[economics.tiers]`** in `config.toml`: free-form `name = price` ($/1M input tokens) pairs override the built-in tiers; report rows sort by ascending price, `--tier` accepts any configured name, and the unknown-tier error lists the valid names dynamically.
- **Defaults refreshed** to current Anthropic list prices (Haiku 4.5 \$1, Sonnet 5 \$3, Opus 5 \$5, Fable 5 \$10 per 1M input tokens) — the old 0.25/3/15 trio predates several model generations.
- **`snip init` seeds a commented template**: real Anthropic prices when installing for claude-code, a generic "adjust to your rates" template for other agents (no invented third-party prices). Appends only; never touches existing settings; no-op when an `[economics]` section exists; never blocks the install.
- Fallback parser structs mirror the new section so it survives `filters.dir` arrays (#158 guard, with test).

Closes #171

## Test plan
- New tests: TOML parsing (incl. array-dir fallback survival), custom tiers sorted by price, case-insensitive lookup, init template creation/append/idempotence + generic-vs-anthropic selection; existing tier tests updated to the new defaults.
- `make ci` green locally.
- E2E: custom config shows `haiku $12.5` / `negotiated_opus $38.8` on real tracking data; `--tier bogus` lists the configured names.