### PR TITLE
fix(filter): remove the dead OnError field

### DIFF
--- a/internal/engine/pipeline_test.go
+++ b/internal/engine/pipeline_test.go
@@ -227,7 +227,6 @@ func TestPipelineRunSilentWhenFilterExcludedByFlags(t *testing.T) {
 		Name:    "true-json",
 		Version: 1,
 		Match:   filter.Match{Command: "true", RequireFlags: []string{"--json"}},
-		OnError: "passthrough",
 		Pipeline: filter.Pipeline{
 			{ActionName: "keep_lines", Params: map[string]any{"pattern": `.`}},
 		},
@@ -272,7 +271,6 @@ func TestPipelineRunSilentWhenSiblingSubcommandHasFilter(t *testing.T) {
 		Name:    "true-foo",
 		Version: 1,
 		Match:   filter.Match{Command: "true", Subcommand: filter.NewSubcommand("foo")},
-		OnError: "passthrough",
 		Pipeline: filter.Pipeline{
 			{ActionName: "keep_lines", Params: map[string]any{"pattern": `.`}},
 		},
@@ -445,7 +443,6 @@ func filterForTest(name string, pipeline filter.Pipeline) filter.Filter {
 		Version:  1,
 		Match:    filter.Match{Command: name},
 		Pipeline: pipeline,
-		OnError:  "passthrough",
 	}
 }
 
@@ -599,7 +596,6 @@ func TestPipelineRunFallsBackWhenCommandNeverRan(t *testing.T) {
 		Name:    "missing-tool",
 		Version: 1,
 		Match:   filter.Match{Command: missing},
-		OnError: "passthrough",
 		Pipeline: filter.Pipeline{
 			{ActionName: "keep_lines", Params: map[string]any{"pattern": `.`}},
 		},
@@ -670,7 +666,6 @@ func shPassthroughFilter() filter.Filter {
 		Name:    "sh-passthrough",
 		Version: 1,
 		Match:   filter.Match{Command: "sh"},
-		OnError: "passthrough",
 		Pipeline: filter.Pipeline{
 			{ActionName: "keep_lines", Params: map[string]any{"pattern": `.`}},
 		},

--- a/internal/filter/registry_test.go
+++ b/internal/filter/registry_test.go
@@ -160,7 +160,6 @@ func makeFilter(name, cmd, subcmd string) Filter {
 		Name:    name,
 		Version: 1,
 		Match:   match,
-		OnError: "passthrough",
 	}
 }
 
@@ -211,7 +210,6 @@ func TestRegistryMatchMultiSubcommands(t *testing.T) {
 		Name:    "npm-install",
 		Version: 1,
 		Match:   Match{Command: "npm", Subcommand: NewSubcommands("install", "add", "i")},
-		OnError: "passthrough",
 	}})
 
 	for _, subcommand := range []string{"install", "add", "i"} {
@@ -234,7 +232,6 @@ func TestRegistryMatchExplicitBareSubcommand(t *testing.T) {
 		Name:    "yarn-install",
 		Version: 1,
 		Match:   Match{Command: "yarn", Subcommand: NewSubcommands("", "install", "add")},
-		OnError: "passthrough",
 	}})
 
 	if got := reg.Match("yarn", "", nil); got == nil || got.Name != "yarn-install" {
@@ -256,7 +253,6 @@ func TestRegistryOmittedSubcommandIsWildcard(t *testing.T) {
 		Name:    "legacy-npm",
 		Version: 1,
 		Match:   Match{Command: "npm"},
-		OnError: "passthrough",
 	}})
 
 	for _, subcommand := range []string{"", "install", "view"} {
@@ -271,7 +267,6 @@ func TestRegistryExactSubcommandExcludeFlags(t *testing.T) {
 		Name:    "npm-install",
 		Version: 1,
 		Match:   Match{Command: "npm", Subcommand: NewSubcommands("install", "i"), ExcludeFlags: []string{"--version", "-v"}},
-		OnError: "passthrough",
 	}})
 
 	if got := reg.Match("npm", "i", []string{"left-pad"}); got == nil || got.Name != "npm-install" {
@@ -290,7 +285,6 @@ func TestRegistryMatchExcludeFlags(t *testing.T) {
 		Name:    "git-log",
 		Version: 1,
 		Match:   Match{Command: "git", Subcommand: NewSubcommand("log"), ExcludeFlags: []string{"--format", "--pretty"}},
-		OnError: "passthrough",
 	}
 	reg := NewRegistry([]Filter{f})
 
@@ -313,7 +307,6 @@ func TestRegistryMatchRequireFlags(t *testing.T) {
 		Name:    "special",
 		Version: 1,
 		Match:   Match{Command: "cmd", RequireFlags: []string{"--json"}},
-		OnError: "passthrough",
 	}
 	reg := NewRegistry([]Filter{f})
 
@@ -361,7 +354,6 @@ func TestHasAnyFilter(t *testing.T) {
 		Name:    "go-test",
 		Version: 1,
 		Match:   Match{Command: "go", Subcommand: NewSubcommand("test"), ExcludeFlags: []string{"-v"}},
-		OnError: "passthrough",
 	}
 	reg := NewRegistry([]Filter{f})
 
@@ -390,7 +382,6 @@ func TestHasAnyFilterCommandOnly(t *testing.T) {
 		Name:    "npm-filter",
 		Version: 1,
 		Match:   Match{Command: "npm"},
-		OnError: "passthrough",
 	}
 	reg := NewRegistry([]Filter{f})
 
@@ -414,8 +405,8 @@ func TestHasAnyFilterForCommand(t *testing.T) {
 	// so that running "git checkout" doesn't print the misleading
 	// "no filter for git" hint.
 	filters := []Filter{
-		{Name: "git-add", Version: 1, Match: Match{Command: "git", Subcommand: NewSubcommand("add")}, OnError: "passthrough"},
-		{Name: "git-commit", Version: 1, Match: Match{Command: "git", Subcommand: NewSubcommand("commit")}, OnError: "passthrough"},
+		{Name: "git-add", Version: 1, Match: Match{Command: "git", Subcommand: NewSubcommand("add")}},
+		{Name: "git-commit", Version: 1, Match: Match{Command: "git", Subcommand: NewSubcommand("commit")}},
 	}
 	reg := NewRegistry(filters)
 
@@ -428,7 +419,7 @@ func TestHasAnyFilterForCommand(t *testing.T) {
 
 	// Command-only filter must also be recognized.
 	regCmdOnly := NewRegistry([]Filter{
-		{Name: "npm", Version: 1, Match: Match{Command: "npm"}, OnError: "passthrough"},
+		{Name: "npm", Version: 1, Match: Match{Command: "npm"}},
 	})
 	if !regCmdOnly.HasAnyFilterForCommand("npm") {
 		t.Error("HasAnyFilterForCommand should return true for npm (command-only filter)")
@@ -439,7 +430,7 @@ func TestRegistryDotSlashWrapper(t *testing.T) {
 	// Wrapper scripts invoked from the project root (./gradlew, ./mvnw) must
 	// match filters keyed on the bare name.
 	filters := []Filter{
-		{Name: "gradlew", Version: 1, Match: Match{Command: "gradlew"}, OnError: "passthrough"},
+		{Name: "gradlew", Version: 1, Match: Match{Command: "gradlew"}},
 	}
 	reg := NewRegistry(filters)
 

--- a/internal/filter/types.go
+++ b/internal/filter/types.go
@@ -16,7 +16,6 @@ type Filter struct {
 	Inject      *Inject      `yaml:"inject,omitempty"`
 	Streams     []string     `yaml:"streams,omitempty"`
 	Pipeline    Pipeline     `yaml:"pipeline"`
-	OnError     string       // parsed from YAML, hardcoded to passthrough in pipeline
 	Tests       []FilterTest `yaml:"tests,omitempty"`
 }
 

--- a/internal/filter/types_test.go
+++ b/internal/filter/types_test.go
@@ -197,7 +197,6 @@ func TestFilterCloneDeepCopy(t *testing.T) {
 		Name:    "test-clone",
 		Version: 2,
 		Match:   Match{Command: "git", Subcommand: NewSubcommand("log")},
-		OnError: "passthrough",
 		Pipeline: Pipeline{
 			{ActionName: "head", Params: map[string]any{"n": 10}},
 			{ActionName: "keep_lines", Params: map[string]any{"pattern": `\S`}},
@@ -292,8 +291,9 @@ func TestFilterClonePreservesNilParams(t *testing.T) {
 }
 
 func TestYAMLBackwardCompatUntaggedFields(t *testing.T) {
-	// Verify that removing yaml:"description" and yaml:"on_error" tags
-	// does not break YAML parsing — yaml.v3 silently ignores unknown keys.
+	// Bundled filters keep their descriptive `on_error:` lines and the
+	// Filter struct has no matching field: yaml.v3 must silently ignore
+	// unknown keys (same for `description`, whose field has no yaml tag).
 	input := `
 name: "backward-compat"
 version: 1

--- a/internal/inspect/deadfields_test.go
+++ b/internal/inspect/deadfields_test.go
@@ -39,10 +39,6 @@ func TestDeadFields_KnownCases(t *testing.T) {
 		t.Errorf("Version should NOT be flagged — used in tests and config")
 	}
 
-	// Known: OnError tag removed — yaml:"on_error" was parsed but hardcoded to passthrough
-	if foundFields["OnError"] {
-		t.Errorf("OnError should NOT be flagged — yaml tag removed, field is just a struct comment")
-	}
 }
 
 func TestTypeString(t *testing.T) {


### PR DESCRIPTION
Closes #159.

## Problem

`Filter.OnError` (internal/filter/types.go) had no yaml tag, so yaml.v3 expected `onerror` and every bundled filter's `on_error: "passthrough"` line parsed to `""`. Nothing in production read the field either: the engine hardcodes raw-output fallback on any pipeline failure.

## Fix

Remove the field rather than wire it:

- all 132 bundled filters carry the same value, which is already the engine's only behavior;
- graceful degradation is a design constraint, not a per-filter knob, so a configurable `on_error` has no second value to offer.

The `on_error:` lines stay in the filter YAMLs as the descriptive convention SKILL.md documents. `TestYAMLBackwardCompatUntaggedFields` pins that yaml.v3 keeps ignoring the now-unknown key, and the obsolete `OnError` block in `deadfields_test.go` is dropped.

## Testing

- `make ci`: test-race, verify (filters), lint green. govulncheck fails only on GO-2026-4602 (local go1.26 stdlib, fixed in go1.26.1), the documented local-toolchain case; CI pinned to go.mod stays green.
- No behavior change: the field was never populated and never read.