### PR TITLE
docs(cli): document init --mode in printUsage

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -512,6 +512,9 @@ Init flags:
   --agent <name>  Agent to configure:
                   claude-code (default), cursor, codex, pi, windsurf, cline,
                   copilot, gemini, kilocode, antigravity, grok
+  --mode <mode>   Integration mode for codex, copilot, grok:
+                  hook (default) or prompt (instructions-file injection
+                  for releases without PreToolUse hook support)
   --uninstall     Remove snip integration for the agent
 
 Flags:

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -22,6 +22,30 @@ func captureStderr(fn func()) string {
 	return buf.String()
 }
 
+// captureStdout captures stdout during fn execution and returns the captured output.
+func captureStdout(fn func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	fn()
+	_ = w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	return buf.String()
+}
+
+// TestUsageDocumentsInitFlags guards against init flags implemented in
+// initcmd but missing from the help text (issue #162).
+func TestUsageDocumentsInitFlags(t *testing.T) {
+	out := captureStdout(printUsage)
+	for _, flag := range []string{"--agent", "--mode", "--uninstall"} {
+		if !strings.Contains(out, flag) {
+			t.Errorf("printUsage does not document init flag %s", flag)
+		}
+	}
+}
+
 func TestUnproxyableCommands(t *testing.T) {
 	tests := []struct {
 		command string


### PR DESCRIPTION
## Summary
- `snip init --agent codex/copilot/grok --mode prompt` is implemented and in the README, but the `Init flags` section of `printUsage` only listed `--agent` and `--uninstall`. Add `--mode` with its two values and scope.
- Regression test `TestUsageDocumentsInitFlags` asserts every implemented init flag appears in the help text (fails on master, passes here).

Fixes #162

## Test plan
- `make test-race` green
- `make lint` green
- Reverted the usage hunk: the new test fails, confirming it guards the fix