### PR TITLE
fix(config): remove the dead filters.global.stream_mode field

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,10 +60,9 @@ type FiltersConfig struct {
 
 // FilterGlobalConfig applies to all filters in the pipeline.
 type FilterGlobalConfig struct {
-	MaxLines       int    `toml:"max_lines"`        // 0 = unlimited
-	MaxLineLength  int    `toml:"max_line_length"`  // 0 = unlimited
-	MaxOutputBytes int    `toml:"max_output_bytes"` // 0 = unlimited
-	StreamMode     string `toml:"stream_mode"`      // "filter" | "full"
+	MaxLines       int `toml:"max_lines"`        // 0 = unlimited
+	MaxLineLength  int `toml:"max_line_length"`  // 0 = unlimited
+	MaxOutputBytes int `toml:"max_output_bytes"` // 0 = unlimited
 }
 
 // FilterOverride overrides specific pipeline action parameters for a named filter.
@@ -458,7 +457,7 @@ func LoadMerged() (*Config, error) {
 			merged.Filters.Enable[k] = v
 		}
 		// Global limits: project wins entirely
-		if project.Filters.Global.MaxLines > 0 || project.Filters.Global.MaxLineLength > 0 || project.Filters.Global.MaxOutputBytes > 0 || project.Filters.Global.StreamMode != "" {
+		if project.Filters.Global != (FilterGlobalConfig{}) {
 			merged.Filters.Global = project.Filters.Global
 		}
 		// Per-filter overrides: project wins

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -635,7 +635,7 @@ stream_mode = "full"
 }
 
 func TestLoadMergedGlobalOverrideGate(t *testing.T) {
-	// When project config only sets max_line_length (no max_lines, no stream_mode),
+	// When project config only sets max_line_length (no max_lines),
 	// the global override should still apply.
 	dir := t.TempDir()
 	home := filepath.Join(dir, "home")


### PR DESCRIPTION
## Summary
- `FilterGlobalConfig.StreamMode` was decoded and checked in the `LoadMerged` gate but never applied: the engine gate at `pipeline.go` only reads `max_lines`, `max_line_length`, `max_output_bytes`. Only the per-filter `filters.override.<name>.stream_mode` is implemented (kept as is).
- The key was already removed from the docs, so this drops it rather than wiring it, same treatment as the dead `OnError` field (#159/#173).
- The merge gate now compares against the zero struct, matching the plugin-layer merge style.
- Not breaking: unknown TOML keys are ignored on decode, existing configs keep loading.

Fixes #160

## Test plan
- `make test-race` green
- `make lint` green