### PR TITLE
fix(cli): show the effective merged configuration in snip config

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -139,34 +139,7 @@ func Run(args []string) int {
 		return 0
 
 	case "config":
-		cfg, err := config.Load()
-		if err != nil {
-			display.PrintError(err.Error())
-			return 1
-		}
-		fmt.Printf("tracking.db_path: %s\n", cfg.Tracking.DBPath)
-		fmt.Printf("tracking.track_unfiltered: %v\n", cfg.Tracking.TrackUnfiltered)
-		fmt.Printf("filters.dir: %s\n", strings.Join(cfg.Filters.Dirs(), ", "))
-		fmt.Printf("tee.mode: %s\n", cfg.Tee.Mode)
-		fmt.Printf("tee.max_files: %d\n", cfg.Tee.MaxFiles)
-		fmt.Printf("tee.project_marker: %s\n", cfg.Tee.ProjectMarker)
-		fmt.Printf("display.color: %v\n", cfg.Display.Color)
-		fmt.Printf("display.emoji: %v\n", cfg.Display.Emoji)
-		fmt.Printf("display.quiet_no_filter: %v\n", cfg.Display.QuietNoFilter)
-		fmt.Printf("display.summary: %v\n", cfg.Display.Summary)
-		if len(cfg.Filters.Enable) == 0 {
-			fmt.Println("filters.enable: (all enabled)")
-		} else {
-			names := make([]string, 0, len(cfg.Filters.Enable))
-			for k := range cfg.Filters.Enable {
-				names = append(names, k)
-			}
-			sort.Strings(names)
-			for _, name := range names {
-				fmt.Printf("filters.enable.%s: %v\n", name, cfg.Filters.Enable[name])
-			}
-		}
-		return 0
+		return runConfigCmd()
 
 	case "discover":
 		if err := discover.Run(cmdArgs); err != nil {
@@ -479,6 +452,108 @@ func isFilterEnabled(cfg *config.Config, name string) bool {
 		return true
 	}
 	return enabled
+}
+
+// runConfigCmd prints the effective merged configuration (plugin < user <
+// project) and labels where each layer came from (issue #161).
+func runConfigCmd() int {
+	cfg, sources, err := config.LoadMergedWithSources()
+	if err != nil {
+		display.PrintError(err.Error())
+		return 1
+	}
+
+	fmt.Println("sources:")
+	if len(sources) == 0 {
+		fmt.Println("  (built-in defaults only)")
+	}
+	for _, s := range sources {
+		status := "applied"
+		if !s.Applied {
+			status = "ignored: " + s.Reason
+		}
+		fmt.Printf("  %s: %s (%s)\n", s.Layer, s.Path, status)
+	}
+	fmt.Println()
+
+	mode := cfg.Mode
+	if mode == "" {
+		mode = "user"
+	}
+	fmt.Printf("mode: %s\n", mode)
+	fmt.Printf("tracking.db_path: %s\n", cfg.Tracking.DBPath)
+	fmt.Printf("tracking.track_unfiltered: %v\n", cfg.Tracking.TrackUnfiltered)
+	fmt.Printf("display.color: %v\n", cfg.Display.Color)
+	fmt.Printf("display.emoji: %v\n", cfg.Display.Emoji)
+	fmt.Printf("display.quiet_no_filter: %v\n", cfg.Display.QuietNoFilter)
+	fmt.Printf("display.summary: %v\n", cfg.Display.Summary)
+	fmt.Printf("filters.dir: %s\n", strings.Join(cfg.Filters.Dirs(), ", "))
+	if len(cfg.Filters.Enable) == 0 {
+		fmt.Println("filters.enable: (all enabled)")
+	} else {
+		names := make([]string, 0, len(cfg.Filters.Enable))
+		for k := range cfg.Filters.Enable {
+			names = append(names, k)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			fmt.Printf("filters.enable.%s: %v\n", name, cfg.Filters.Enable[name])
+		}
+	}
+	fmt.Printf("filters.global.max_lines: %d\n", cfg.Filters.Global.MaxLines)
+	fmt.Printf("filters.global.max_line_length: %d\n", cfg.Filters.Global.MaxLineLength)
+	fmt.Printf("filters.global.max_output_bytes: %d\n", cfg.Filters.Global.MaxOutputBytes)
+	if len(cfg.Filters.Override) > 0 {
+		names := make([]string, 0, len(cfg.Filters.Override))
+		for k := range cfg.Filters.Override {
+			names = append(names, k)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			fmt.Printf("filters.override.%s: %s\n", name, overrideSummary(cfg.Filters.Override[name]))
+		}
+	}
+	fmt.Printf("filters.bypass.commands: %s\n", listOrNone(cfg.Filters.Bypass.Commands))
+	fmt.Printf("filters.transparent_prefixes: %s\n", listOrNone(cfg.Filters.TransparentPrefixes))
+	fmt.Printf("tee.enabled: %v\n", cfg.Tee.Enabled)
+	fmt.Printf("tee.mode: %s\n", cfg.Tee.Mode)
+	fmt.Printf("tee.max_files: %d\n", cfg.Tee.MaxFiles)
+	fmt.Printf("tee.max_file_size: %d\n", cfg.Tee.MaxFileSize)
+	fmt.Printf("tee.project_marker: %s\n", cfg.Tee.ProjectMarker)
+	return 0
+}
+
+// overrideSummary renders the non-zero fields of a filter override as
+// "key=value" pairs, in the field order of the TOML section.
+func overrideSummary(o config.FilterOverride) string {
+	var parts []string
+	if o.Head > 0 {
+		parts = append(parts, fmt.Sprintf("head=%d", o.Head))
+	}
+	if o.Tail > 0 {
+		parts = append(parts, fmt.Sprintf("tail=%d", o.Tail))
+	}
+	if o.TruncateLines > 0 {
+		parts = append(parts, fmt.Sprintf("truncate_lines=%d", o.TruncateLines))
+	}
+	if o.KeepLines != "" {
+		parts = append(parts, "keep_lines="+o.KeepLines)
+	}
+	if o.RemoveLines != "" {
+		parts = append(parts, "remove_lines="+o.RemoveLines)
+	}
+	if o.StreamMode != "" {
+		parts = append(parts, "stream_mode="+o.StreamMode)
+	}
+	return strings.Join(parts, " ")
+}
+
+// listOrNone joins values with commas, or "(none)" for an empty list.
+func listOrNone(values []string) string {
+	if len(values) == 0 {
+		return "(none)"
+	}
+	return strings.Join(values, ", ")
 }
 
 func printUsage() {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -514,12 +514,30 @@ func runConfigCmd() int {
 		}
 	}
 	fmt.Printf("filters.bypass.commands: %s\n", listOrNone(cfg.Filters.Bypass.Commands))
-	fmt.Printf("filters.transparent_prefixes: %s\n", listOrNone(cfg.Filters.TransparentPrefixes))
+	// Built-in prefixes (uv run, poetry run, ...) always apply on top of the
+	// configured ones, so "(none)" alone would misstate effective behavior.
+	if len(cfg.Filters.TransparentPrefixes) == 0 {
+		fmt.Println("filters.transparent_prefixes: (none configured; built-ins always apply)")
+	} else {
+		fmt.Printf("filters.transparent_prefixes: %s (+ built-ins)\n", strings.Join(cfg.Filters.TransparentPrefixes, ", "))
+	}
 	fmt.Printf("tee.enabled: %v\n", cfg.Tee.Enabled)
 	fmt.Printf("tee.mode: %s\n", cfg.Tee.Mode)
 	fmt.Printf("tee.max_files: %d\n", cfg.Tee.MaxFiles)
 	fmt.Printf("tee.max_file_size: %d\n", cfg.Tee.MaxFileSize)
 	fmt.Printf("tee.project_marker: %s\n", cfg.Tee.ProjectMarker)
+	if len(cfg.Economics.Tiers) == 0 {
+		fmt.Println("economics.tiers: (built-in defaults)")
+	} else {
+		names := make([]string, 0, len(cfg.Economics.Tiers))
+		for k := range cfg.Economics.Tiers {
+			names = append(names, k)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			fmt.Printf("economics.tiers.%s: %g\n", name, cfg.Economics.Tiers[name])
+		}
+	}
 	return 0
 }
 
@@ -536,14 +554,19 @@ func overrideSummary(o config.FilterOverride) string {
 	if o.TruncateLines > 0 {
 		parts = append(parts, fmt.Sprintf("truncate_lines=%d", o.TruncateLines))
 	}
+	// Regex values may contain spaces; quote them so field boundaries stay
+	// unambiguous.
 	if o.KeepLines != "" {
-		parts = append(parts, "keep_lines="+o.KeepLines)
+		parts = append(parts, fmt.Sprintf("keep_lines=%q", o.KeepLines))
 	}
 	if o.RemoveLines != "" {
-		parts = append(parts, "remove_lines="+o.RemoveLines)
+		parts = append(parts, fmt.Sprintf("remove_lines=%q", o.RemoveLines))
 	}
 	if o.StreamMode != "" {
 		parts = append(parts, "stream_mode="+o.StreamMode)
+	}
+	if len(parts) == 0 {
+		return "(empty)"
 	}
 	return strings.Join(parts, " ")
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/edouard-claude/snip/internal/trust"
 )
 
 // captureStderr captures stderr during fn execution and returns the captured output.
@@ -964,5 +966,97 @@ func TestRunCommandHelpAfterSeparator(t *testing.T) {
 	code := Run([]string{"snip", "run", "--", "git", "--help"})
 	if code != 0 {
 		t.Errorf("Run(run -- git --help) = %d, want 0", code)
+	}
+}
+
+// TestConfigShowsMergedConfig verifies that `snip config` prints the
+// effective merged configuration with its layer sources (issue #161).
+func TestConfigShowsMergedConfig(t *testing.T) {
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	if err := os.MkdirAll(filepath.Join(home, ".config", "snip", "filters"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	userPath := filepath.Join(home, ".config", "snip", "config.toml")
+	userContent := `[filters]
+transparent_prefixes = ["poetry run"]
+
+[filters.global]
+max_lines = 100
+`
+	if err := os.WriteFile(userPath, []byte(userContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	projectCfgPath := filepath.Join(projectDir, ".snip", "config.toml")
+	projectContent := `mode = "project"
+
+[filters.global]
+max_lines = 50
+
+[filters.override.pyright]
+stream_mode = "full"
+
+[filters.bypass]
+commands = ["terraform"]
+`
+	if err := os.WriteFile(projectCfgPath, []byte(projectContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store := make(trust.Store)
+	hash, err := trust.HashFile(projectCfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store[projectCfgPath] = hash
+	if err := trust.SaveTo(store, filepath.Join(home, ".config", "snip", "trusted.json")); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", userPath)
+	t.Setenv("SNIP_PLUGIN_CONFIG", "")
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	var buf bytes.Buffer
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	code := Run([]string{"snip", "config"})
+	_ = w.Close()
+	os.Stdout = old
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+	out := buf.String()
+
+	if code != 0 {
+		t.Fatalf("Run(config) = %d, want 0", code)
+	}
+	for _, want := range []string{
+		"mode: project",
+		"filters.global.max_lines: 50",
+		"filters.override.pyright: stream_mode=full",
+		"filters.bypass.commands: terraform",
+		"filters.transparent_prefixes: poetry run",
+		"tee.enabled: true",
+		"tee.max_file_size: 1048576",
+		"user: " + userPath,
+		"project: " + projectCfgPath,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\noutput:\n%s", want, out)
+		}
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -483,7 +483,11 @@ func LoadMergedWithSources() (*Config, []Source, error) {
 		return user, append(sources, projSrc), nil
 	}
 	if err := toml.Unmarshal(data, project); err != nil {
-		return nil, nil, fmt.Errorf("parse project config %s: %w", projectPath, err)
+		// Degrade like the plugin layer does: keep the user config running and
+		// report the broken layer instead of failing the whole load.
+		fmt.Fprintf(os.Stderr, "snip: ignoring invalid project config %s: %v\n", projectPath, err)
+		projSrc.Reason = "invalid TOML"
+		return user, append(sources, projSrc), nil
 	}
 	projSrc.Applied = true
 	sources = append(sources, projSrc)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -307,33 +307,39 @@ func LoadWithPlugin() (*Config, error) {
 
 // applyPluginLayer merges the SNIP_PLUGIN_CONFIG file underneath the user
 // config in place. The user's explicit settings win over the plugin's.
-func applyPluginLayer(user *Config) {
+// Returns the layer's Source, or nil when no plugin layer is declared.
+func applyPluginLayer(user *Config) *Source {
 	path := pluginConfigPath()
 	if path == "" {
-		return
+		return nil
 	}
+	src := &Source{Layer: "plugin", Path: path}
 
 	store, err := trust.Load()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "snip: ignoring untrusted plugin config %s (trust store unreadable: %v)\n", path, err)
-		return
+		src.Reason = "untrusted (trust store unreadable)"
+		return src
 	}
 	if !trust.IsTrusted(store, path) {
 		fmt.Fprintf(os.Stderr, "snip: ignoring untrusted plugin config %s (run 'snip trust %s' to trust)\n", path, path)
-		return
+		src.Reason = fmt.Sprintf("untrusted, run 'snip trust %s'", path)
+		return src
 	}
 
 	data, err := os.ReadFile(path)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "snip: ignoring unreadable plugin config %s: %v\n", path, err)
-		return
+		src.Reason = "unreadable"
+		return src
 	}
 	plugin := DefaultConfig()
 	if err := toml.Unmarshal(data, plugin); err != nil {
 		plugin = DefaultConfig()
 		if !tryUnmarshalArrayDir(data, plugin) {
 			fmt.Fprintf(os.Stderr, "snip: ignoring invalid plugin config %s: %v\n", path, err)
-			return
+			src.Reason = "invalid TOML"
+			return src
 		}
 	}
 	plugin.expandPaths()
@@ -397,6 +403,18 @@ func applyPluginLayer(user *Config) {
 		}
 	}
 	user.Filters.Dir = dirs
+
+	src.Applied = true
+	return src
+}
+
+// Source describes one configuration layer considered by LoadMerged and
+// whether it made it into the effective config.
+type Source struct {
+	Layer   string // "plugin", "user" or "project"
+	Path    string
+	Applied bool
+	Reason  string // why the layer was skipped; empty when applied
 }
 
 // LoadMerged loads the user config (with the plugin layer underneath, see
@@ -405,21 +423,43 @@ func applyPluginLayer(user *Config) {
 // config's filter settings override the user's. When mode == "user"
 // (default), user settings take priority.
 func LoadMerged() (*Config, error) {
-	user, err := LoadWithPlugin()
+	cfg, _, err := LoadMergedWithSources()
+	return cfg, err
+}
+
+// LoadMergedWithSources is LoadMerged keeping per-layer provenance, so
+// `snip config` can label where each effective setting comes from (#161).
+// Sources are listed in precedence order: plugin < user < project.
+func LoadMergedWithSources() (*Config, []Source, error) {
+	user, err := Load()
 	if err != nil {
 		// If user config file is missing, use defaults (normal for new installs).
 		// Other errors (permission, corrupt TOML) propagate to the caller so the
 		// user knows something is wrong with their config.
 		if os.IsNotExist(err) {
-			return DefaultConfig(), nil
+			return DefaultConfig(), nil, nil
 		}
-		return nil, fmt.Errorf("load user config: %w", err)
+		return nil, nil, fmt.Errorf("load user config: %w", err)
 	}
+
+	var sources []Source
+	if src := applyPluginLayer(user); src != nil {
+		sources = append(sources, *src)
+	}
+
+	userSrc := Source{Layer: "user", Path: configPath()}
+	if _, statErr := os.Stat(userSrc.Path); statErr == nil {
+		userSrc.Applied = true
+	} else {
+		userSrc.Reason = "not found (defaults apply)"
+	}
+	sources = append(sources, userSrc)
 
 	projectPath := projectConfigPath()
 	if projectPath == "" {
-		return user, nil // no project config — user only
+		return user, sources, nil // no project config — user only
 	}
+	projSrc := Source{Layer: "project", Path: projectPath}
 
 	// Trust gate: project configs must be explicitly trusted via `snip trust`.
 	// Without this guard, any cloned repo could ship a .snip/config.toml that
@@ -427,21 +467,26 @@ func LoadMerged() (*Config, error) {
 	store, err := trust.Load()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "snip: ignoring untrusted project config %s (trust store unreadable: %v)\n", projectPath, err)
-		return user, nil // no trust store = no project configs trusted
+		projSrc.Reason = "untrusted (trust store unreadable)"
+		return user, append(sources, projSrc), nil // no trust store = no project configs trusted
 	}
 	if !trust.IsTrusted(store, projectPath) {
 		fmt.Fprintf(os.Stderr, "snip: ignoring untrusted project config %s (run 'snip trust %s' to trust)\n", projectPath, projectPath)
-		return user, nil // untrusted: fall back to user config only
+		projSrc.Reason = fmt.Sprintf("untrusted, run 'snip trust %s'", projectPath)
+		return user, append(sources, projSrc), nil // untrusted: fall back to user config only
 	}
 
 	project := DefaultConfig()
 	data, err := os.ReadFile(projectPath)
 	if err != nil {
-		return user, nil
+		projSrc.Reason = "unreadable"
+		return user, append(sources, projSrc), nil
 	}
 	if err := toml.Unmarshal(data, project); err != nil {
-		return nil, fmt.Errorf("parse project config %s: %w", projectPath, err)
+		return nil, nil, fmt.Errorf("parse project config %s: %w", projectPath, err)
 	}
+	projSrc.Applied = true
+	sources = append(sources, projSrc)
 
 	// Default mode is "user" — developer's personal config wins conflicts
 	merged := user
@@ -477,7 +522,7 @@ func LoadMerged() (*Config, error) {
 	merged.Filters.Bypass.Commands = append(merged.Filters.Bypass.Commands,
 		project.Filters.Bypass.Commands...)
 
-	return merged, nil
+	return merged, sources, nil
 }
 
 func configPath() string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1729,3 +1729,146 @@ opus = 4.20
 		t.Errorf("Tiers[opus] after array-dir fallback: got %v, want 4.20", cfg.Economics.Tiers["opus"])
 	}
 }
+
+// sourceByLayer returns the Source entry for the given layer, or nil.
+func sourceByLayer(sources []Source, layer string) *Source {
+	for i := range sources {
+		if sources[i].Layer == layer {
+			return &sources[i]
+		}
+	}
+	return nil
+}
+
+func TestLoadMergedWithSourcesTrustedProject(t *testing.T) {
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	if err := os.MkdirAll(filepath.Join(home, ".config", "snip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	userPath := filepath.Join(home, ".config", "snip", "config.toml")
+	if err := os.WriteFile(userPath, []byte("[filters.global]\nmax_lines = 100\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectDir := canonicalTempDir(t)
+	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	projectCfgPath := filepath.Join(projectDir, ".snip", "config.toml")
+	if err := os.WriteFile(projectCfgPath, []byte("mode = \"project\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store := make(trust.Store)
+	hash, err := trust.HashFile(projectCfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store[projectCfgPath] = hash
+	if err := trust.SaveTo(store, filepath.Join(home, ".config", "snip", "trusted.json")); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", userPath)
+	t.Setenv("SNIP_PLUGIN_CONFIG", "")
+	oldWd, _ := os.Getwd()
+	_ = os.Chdir(projectDir)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	cfg, sources, err := LoadMergedWithSources()
+	if err != nil {
+		t.Fatalf("LoadMergedWithSources: %v", err)
+	}
+	if cfg.Mode != "project" {
+		t.Errorf("mode = %q, want project", cfg.Mode)
+	}
+
+	user := sourceByLayer(sources, "user")
+	if user == nil || !user.Applied || user.Path != userPath {
+		t.Errorf("user source = %+v, want applied at %s", user, userPath)
+	}
+	project := sourceByLayer(sources, "project")
+	if project == nil || !project.Applied || project.Path != projectCfgPath {
+		t.Errorf("project source = %+v, want applied at %s", project, projectCfgPath)
+	}
+	if plugin := sourceByLayer(sources, "plugin"); plugin != nil {
+		t.Errorf("plugin source = %+v, want none", plugin)
+	}
+}
+
+func TestLoadMergedWithSourcesUntrustedProject(t *testing.T) {
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	if err := os.MkdirAll(filepath.Join(home, ".config", "snip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	userPath := filepath.Join(home, ".config", "snip", "config.toml")
+
+	projectDir := canonicalTempDir(t)
+	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	projectCfgPath := filepath.Join(projectDir, ".snip", "config.toml")
+	if err := os.WriteFile(projectCfgPath, []byte("mode = \"project\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", userPath)
+	t.Setenv("SNIP_PLUGIN_CONFIG", "")
+	oldWd, _ := os.Getwd()
+	_ = os.Chdir(projectDir)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	cfg, sources, err := LoadMergedWithSources()
+	if err != nil {
+		t.Fatalf("LoadMergedWithSources: %v", err)
+	}
+	if cfg.Mode == "project" {
+		t.Error("untrusted project config must not apply")
+	}
+
+	user := sourceByLayer(sources, "user")
+	if user == nil || user.Applied {
+		t.Errorf("user source = %+v, want present and not applied (missing file)", user)
+	}
+	project := sourceByLayer(sources, "project")
+	if project == nil || project.Applied || !strings.Contains(project.Reason, "untrusted") {
+		t.Errorf("project source = %+v, want skipped as untrusted", project)
+	}
+}
+
+func TestLoadMergedWithSourcesPluginLayer(t *testing.T) {
+	pluginPath, _ := pluginTestSetup(t, "[filters.enable]\ngit-diff = false\n", true)
+
+	cfg, sources, err := LoadMergedWithSources()
+	if err != nil {
+		t.Fatalf("LoadMergedWithSources: %v", err)
+	}
+	if cfg.Filters.Enable["git-diff"] != false {
+		t.Error("plugin layer should disable git-diff")
+	}
+
+	plugin := sourceByLayer(sources, "plugin")
+	if plugin == nil || !plugin.Applied || plugin.Path != pluginPath {
+		t.Errorf("plugin source = %+v, want applied at %s", plugin, pluginPath)
+	}
+}
+
+func TestLoadMergedWithSourcesUntrustedPlugin(t *testing.T) {
+	pluginPath, _ := pluginTestSetup(t, "[filters.enable]\ngit-diff = false\n", false)
+
+	cfg, sources, err := LoadMergedWithSources()
+	if err != nil {
+		t.Fatalf("LoadMergedWithSources: %v", err)
+	}
+	if _, ok := cfg.Filters.Enable["git-diff"]; ok {
+		t.Error("untrusted plugin layer must not apply")
+	}
+
+	plugin := sourceByLayer(sources, "plugin")
+	if plugin == nil || plugin.Applied || !strings.Contains(plugin.Reason, "untrusted") {
+		t.Errorf("plugin source = %+v, want skipped as untrusted at %s", plugin, pluginPath)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1014,7 +1014,10 @@ func TestLoadMergedMissingTrustStoreReturnsUserOnly(t *testing.T) {
 	}
 }
 
-func TestLoadMergedMalformedTrustedConfigReturnsError(t *testing.T) {
+// A malformed trusted project config degrades to the user config with a
+// stderr warning, like the plugin layer, instead of failing the whole load
+// (snip config must keep printing provenance to point at the broken layer).
+func TestLoadMergedMalformedTrustedConfigDegrades(t *testing.T) {
 	baseDir := canonicalTempDir(t)
 	home := filepath.Join(baseDir, "home")
 	projectDir := filepath.Join(baseDir, "project")
@@ -1057,11 +1060,17 @@ func TestLoadMergedMalformedTrustedConfigReturnsError(t *testing.T) {
 	t.Cleanup(func() { _ = os.Chdir(oldWd) })
 
 	cfg, err := LoadMerged()
-	if err == nil {
-		t.Fatal("expected error for malformed trusted project config")
+	if err != nil {
+		t.Fatalf("malformed project config must degrade, not fail: %v", err)
 	}
-	if cfg != nil {
-		t.Error("expected nil config on malformed project config")
+	if cfg == nil {
+		t.Fatal("expected user config on malformed project config")
+	}
+	if !cfg.Display.QuietNoFilter {
+		t.Error("user config must survive a malformed project layer")
+	}
+	if v, ok := cfg.Filters.Enable["git-diff"]; ok && !v {
+		t.Error("malformed project config must not contribute settings")
 	}
 }
 
@@ -1846,7 +1855,8 @@ func TestLoadMergedWithSourcesPluginLayer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadMergedWithSources: %v", err)
 	}
-	if cfg.Filters.Enable["git-diff"] != false {
+	v, ok := cfg.Filters.Enable["git-diff"]
+	if !ok || v {
 		t.Error("plugin layer should disable git-diff")
 	}
 
@@ -1870,5 +1880,54 @@ func TestLoadMergedWithSourcesUntrustedPlugin(t *testing.T) {
 	plugin := sourceByLayer(sources, "plugin")
 	if plugin == nil || plugin.Applied || !strings.Contains(plugin.Reason, "untrusted") {
 		t.Errorf("plugin source = %+v, want skipped as untrusted at %s", plugin, pluginPath)
+	}
+}
+
+func TestLoadMergedWithSourcesInvalidProjectTOML(t *testing.T) {
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	if err := os.MkdirAll(filepath.Join(home, ".config", "snip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	userPath := filepath.Join(home, ".config", "snip", "config.toml")
+	if err := os.WriteFile(userPath, []byte("[filters.global]\nmax_lines = 100\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectDir := canonicalTempDir(t)
+	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	projectCfgPath := filepath.Join(projectDir, ".snip", "config.toml")
+	if err := os.WriteFile(projectCfgPath, []byte("mode = [unclosed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store := make(trust.Store)
+	hash, err := trust.HashFile(projectCfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store[projectCfgPath] = hash
+	if err := trust.SaveTo(store, filepath.Join(home, ".config", "snip", "trusted.json")); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", userPath)
+	t.Setenv("SNIP_PLUGIN_CONFIG", "")
+	oldWd, _ := os.Getwd()
+	_ = os.Chdir(projectDir)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	cfg, sources, err := LoadMergedWithSources()
+	if err != nil {
+		t.Fatalf("invalid project TOML must degrade, not fail: %v", err)
+	}
+	if cfg.Filters.Global.MaxLines != 100 {
+		t.Errorf("user config must survive a broken project layer, MaxLines = %d", cfg.Filters.Global.MaxLines)
+	}
+	project := sourceByLayer(sources, "project")
+	if project == nil || project.Applied || !strings.Contains(project.Reason, "invalid TOML") {
+		t.Errorf("project source = %+v, want skipped as invalid TOML", project)
 	}
 }


### PR DESCRIPTION
## Summary
- `snip config` called `config.Load()`, so a trusted project `.snip/config.toml` never appeared in its output; `mode`, `filters.global`, `filters.override`, `filters.bypass`, `transparent_prefixes`, `tee.enabled` and `tee.max_file_size` were missing from the printout too.
- New `config.LoadMergedWithSources()`: `LoadMerged` keeping per-layer provenance (plugin < user < project, each with path and applied/ignored + reason). `LoadMerged` is now a thin wrapper, so runtime behavior is unchanged; `applyPluginLayer` reports its outcome instead of returning nothing.
- `snip config` prints a `sources:` header, then the full effective config.

Example output:
```
sources:
  user: /home/me/.config/snip/config.toml (applied)
  project: /repo/.snip/config.toml (ignored: untrusted, run 'snip trust /repo/.snip/config.toml')

mode: user
...
filters.global.max_lines: 100
filters.bypass.commands: terraform
tee.enabled: true
tee.max_file_size: 1048576
```

Noticed while testing, left out of scope: the project layer never merges `filters.transparent_prefixes` (only the plugin layer does). Will file separately.

Fixes #161

## Test plan
- 4 new unit tests on `LoadMergedWithSources` (trusted/untrusted project, trusted/untrusted plugin)
- `TestConfigShowsMergedConfig` runs the full `snip config` command against a user+trusted-project setup; it fails against the old implementation
- `make test-race` and `make lint` green