### PR TITLE
fix(config): merge filters.transparent_prefixes from the project layer

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -526,6 +526,12 @@ func LoadMergedWithSources() (*Config, []Source, error) {
 	merged.Filters.Bypass.Commands = append(merged.Filters.Bypass.Commands,
 		project.Filters.Bypass.Commands...)
 
+	// Transparent prefixes accumulate from both sides too (issue #178); the
+	// plugin layer already merged its own into user's.
+	merged.Filters.TransparentPrefixes = append([]string{}, user.Filters.TransparentPrefixes...)
+	merged.Filters.TransparentPrefixes = append(merged.Filters.TransparentPrefixes,
+		project.Filters.TransparentPrefixes...)
+
 	return merged, sources, nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -1929,5 +1930,60 @@ func TestLoadMergedWithSourcesInvalidProjectTOML(t *testing.T) {
 	project := sourceByLayer(sources, "project")
 	if project == nil || project.Applied || !strings.Contains(project.Reason, "invalid TOML") {
 		t.Errorf("project source = %+v, want skipped as invalid TOML", project)
+	}
+}
+
+// TestLoadMergedTransparentPrefixesMerge: transparent_prefixes accumulates
+// from user + project like bypass does, regardless of mode (issue #178).
+func TestLoadMergedTransparentPrefixesMerge(t *testing.T) {
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	if err := os.MkdirAll(filepath.Join(home, ".config", "snip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	userPath := filepath.Join(home, ".config", "snip", "config.toml")
+	userContent := `[filters]
+transparent_prefixes = ["poetry run"]
+`
+	if err := os.WriteFile(userPath, []byte(userContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectDir := canonicalTempDir(t)
+	if err := os.MkdirAll(filepath.Join(projectDir, ".snip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	projectCfgPath := filepath.Join(projectDir, ".snip", "config.toml")
+	// No mode = "project": the additive list must merge like bypass anyway.
+	projectContent := `[filters]
+transparent_prefixes = ["docker exec app"]
+`
+	if err := os.WriteFile(projectCfgPath, []byte(projectContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store := make(trust.Store)
+	hash, err := trust.HashFile(projectCfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store[projectCfgPath] = hash
+	if err := trust.SaveTo(store, filepath.Join(home, ".config", "snip", "trusted.json")); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("SNIP_CONFIG", userPath)
+	t.Setenv("SNIP_PLUGIN_CONFIG", "")
+	oldWd, _ := os.Getwd()
+	_ = os.Chdir(projectDir)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	cfg, err := LoadMerged()
+	if err != nil {
+		t.Fatalf("LoadMerged: %v", err)
+	}
+	want := []string{"poetry run", "docker exec app"}
+	if !reflect.DeepEqual(cfg.Filters.TransparentPrefixes, want) {
+		t.Errorf("TransparentPrefixes = %v, want %v", cfg.Filters.TransparentPrefixes, want)
 	}
 }


### PR DESCRIPTION
## Summary
- A project `.snip/config.toml` declaring `transparent_prefixes` was parsed but silently ignored: `LoadMergedWithSources` only merged `enable`, `global`, `override` (mode=project) and `bypass` (always) from the project layer.
- Accumulate user + project like `filters.bypass.commands`, regardless of `mode`: it is an additive list and the project layer is already trust-gated. The plugin layer keeps its existing accumulation.

Fixes #178

## Test plan
- New `TestLoadMergedTransparentPrefixesMerge` (user + trusted project, no `mode = "project"`): fails on master, passes here
- `make test-race` and `make lint` green