### PR TITLE
fix(learn): report the real command behind shell scaffolding

### DIFF
--- a/internal/learn/learn.go
+++ b/internal/learn/learn.go
@@ -380,21 +380,103 @@ func extractCommandEntries(path string, cutoff time.Time) []commandEntry {
 	return entries
 }
 
-// extractBaseCommand parses a shell command string to extract the base command name.
+// navigationPrefixes are commands that only move around or set up the shell.
+// They carry no failure of their own, so attributing an error to them hides
+// the command that actually ran (e.g. "cd /path && npx ..." is about npx).
+var navigationPrefixes = map[string]bool{
+	"cd":     true,
+	"pushd":  true,
+	"popd":   true,
+	"export": true,
+	"source": true,
+	".":      true,
+}
+
+// extractBaseCommand parses a shell command string to extract the base command
+// name. It walks past leading segments that carry no command, so a chained
+// command reports the tool that really ran rather than its shell scaffolding.
+// The walk crosses newlines only while no command has been seen yet, which
+// keeps heredoc bodies out: they always follow the command that opens them.
 func extractBaseCommand(cmd string) string {
-	firstLine := cmd
-	if idx := strings.IndexByte(firstLine, '\n'); idx >= 0 {
-		firstLine = firstLine[:idx]
+	var first string
+	rest := cmd
+	for {
+		segment := hook.ExtractFirstSegment(rest)
+		base := segmentBase(segment)
+		if isCommandName(base) {
+			if first == "" {
+				first = base
+			}
+			if !navigationPrefixes[base] {
+				return base
+			}
+		}
+		if len(segment) >= len(rest) {
+			break
+		}
+		rest = strings.TrimLeft(rest[len(segment):], ";|&\n \t")
+		if rest == "" {
+			break
+		}
 	}
-	firstSegment := hook.ExtractFirstSegment(firstLine)
-	_, _, bareCmd := hook.ParseSegment(firstSegment)
+
+	// Every segment was scaffolding: keep the first one rather than nothing.
+	return first
+}
+
+// segmentBase reduces a single command segment to its executable name, or to
+// the empty string when the segment holds no command at all.
+func segmentBase(segment string) string {
+	_, _, bareCmd := hook.ParseSegment(segment)
 	base := hook.BaseCommand(bareCmd)
+	if looksLikeAssignment(base) {
+		return ""
+	}
 
 	if idx := strings.LastIndexByte(base, '/'); idx >= 0 {
 		base = base[idx+1:]
 	}
-	base = strings.Trim(base, "'\"")
-	return base
+	return strings.Trim(base, "'\"")
+}
+
+// isCommandName reports whether a word can be an executable name. Walking past
+// scaffolding can land in the middle of a command substitution or a redirection
+// (e.g. "$(cat /tmp/jwt.txt)"), and such fragments must not be reported as
+// commands.
+func isCommandName(word string) bool {
+	if word == "" {
+		return false
+	}
+	for i := 0; i < len(word); i++ {
+		c := word[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+		case c == '.', c == '_', c == '-', c == '+':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// looksLikeAssignment reports whether a word is a KEY=VALUE assignment rather
+// than a command. ParseSegment only strips assignments followed by a command,
+// so a segment made of assignments alone reaches here intact.
+func looksLikeAssignment(word string) bool {
+	eq := strings.IndexByte(word, '=')
+	if eq <= 0 {
+		return false
+	}
+	for i := 0; i < eq; i++ {
+		c := word[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c == '_':
+		case c >= '0' && c <= '9' && i > 0:
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // looksLikeError checks if command output contains common error indicators.
@@ -416,7 +498,7 @@ func detectPatterns(entries []commandEntry) []ErrorPattern {
 	var patterns []ErrorPattern
 
 	for i, entry := range entries {
-		if !entry.IsError {
+		if !entry.IsError || entry.BaseCmd == "" {
 			continue
 		}
 

--- a/internal/learn/learn_test.go
+++ b/internal/learn/learn_test.go
@@ -457,6 +457,20 @@ func TestExtractBaseCommand(t *testing.T) {
 		{"CGO_ENABLED=0 go build", "go"},
 		{"/usr/bin/git status", "git"},
 		{"npm install", "npm"},
+		// Navigation prefixes and standalone assignments hide the real command.
+		{"cd /Users/e/app && npx react-native run-ios", "npx"},
+		{"cd ~/Code/app && sed -i '' 's|a|b|' f.yaml", "sed"},
+		{"SCRATCH=/tmp/x/scratchpad && python3 -c 'print(1)'", "python3"},
+		{"SP=/tmp/y/scratchpad; git diff --stat", "git"},
+		{"cd /tmp && gh pr view 18 --repo o/r", "gh"},
+		{"pushd /tmp && make build", "make"},
+		{"git log | grep x", "git"},
+		{"cd /tmp", "cd"},
+		{"SP=/tmp/x/scratchpad\npython3 - <<'PY'\nimport io\nPY", "python3"},
+		{"go test ./... 2>&1 | tail -3", "go"},
+		{"TOKEN=$(cat /tmp/jwt.txt) && curl -s http://x", "curl"},
+		{"SP=/tmp/x; TOKEN=$(cat $SP/jwt.txt)", ""},
+		{"", ""},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem

`snip learn` attributed failures to shell scaffolding instead of the command that ran.

On a real project, 27 of the 42 detected patterns were noise:

```
  cd (16 occurrences)
    Error: Exit code 7 -> fixed by cd /Users/e/app && npx react-native ...
  scratchpad (11 occurrences)
    Error: ... -> fixed by SCRATCH=/private/tmp/.../scratchpad && python3 -c ...
```

Two causes in `extractBaseCommand`:

- it only looked at the first segment of the first line, so `cd /path && npx ...` was counted as a `cd` failure;
- `ParseSegment` only strips assignments that are followed by a command, so a segment made of assignments alone (`SCRATCH=/tmp/x/scratchpad`) reached `BaseCommand` intact and was then truncated to its last path element, inventing a `scratchpad` command.

Beyond the misleading group names, pairing on those bases matched unrelated commands with each other: every `cd X && ...` failure could be "fixed" by any later `cd Y && ...`.

## Fix

Walk the segments, skipping the ones that carry no command (navigation prefixes and standalone assignments), and accept a base only when it can be an executable name, so landing inside a command substitution does not surface a fragment like `jwt.txt)`. Entries with no identifiable base command no longer produce patterns.

The walk crosses newlines only while no command has been seen, which keeps heredoc bodies out: they always follow the command that opens them.

## Result

Same sessions, same window:

```
before: cd (16), scratchpad (11), grep (5), sed (3), docker (2), make (2), git (1), ls (1), psql (1)
after:  sed (8), grep (5), cat (4), docker (2), make (2), python3 (2), gh (1), git (1), ls (1), maestro (1), psql (1)
```

## Tests

`TestExtractBaseCommand` covers chained navigation prefixes, standalone assignments, multiline commands, pipelines and command substitution. Reverting the production hunk makes the new cases fail.

`make test-race` and `make lint` pass locally.