### PR TITLE
fix(learn): trust the tool result flag and skip commands that never ran

### DIFF
--- a/internal/learn/learn.go
+++ b/internal/learn/learn.go
@@ -31,7 +31,7 @@ type contentItem struct {
 	ID        string          `json:"id,omitempty"`
 	Input     json.RawMessage `json:"input,omitempty"`
 	Content   stringOrArray   `json:"content,omitempty"`
-	IsError   bool            `json:"is_error,omitempty"`
+	IsError   *bool           `json:"is_error,omitempty"`
 	ToolUseID string          `json:"tool_use_id,omitempty"`
 }
 
@@ -70,6 +70,14 @@ type bashInput struct {
 	Command string `json:"command"`
 }
 
+// notRunMarkers identify tool results for commands that never executed: the
+// user rejected the call or interrupted the turn. They are flagged is_error,
+// but nothing failed, so such an entry is neither a failure nor a fix.
+var notRunMarkers = []string{
+	"The user doesn't want to proceed with this tool use",
+	"[Request interrupted by user",
+}
+
 // commandEntry represents a Bash command extracted from a session with its result.
 type commandEntry struct {
 	Command   string // full command string
@@ -78,6 +86,7 @@ type commandEntry struct {
 	Output    string // tool result content (if found)
 	IsError   bool   // whether the tool result indicated an error
 	HasResult bool   // whether a result was matched
+	NotRun    bool   // whether the command was rejected or interrupted
 	Timestamp string // timestamp from the JSONL entry
 }
 
@@ -372,12 +381,45 @@ func extractCommandEntries(path string, cutoff time.Time) []commandEntry {
 				}
 				entries[idx].HasResult = true
 				entries[idx].Output = item.Content.Value
-				entries[idx].IsError = item.IsError || looksLikeError(item.Content.Value)
+				entries[idx].IsError = resultIsError(item)
+				entries[idx].NotRun = isNotRun(item.Content.Value)
 			}
 		}
 	}
 
-	return entries
+	return dropNotRun(entries)
+}
+
+// resultIsError reports whether a tool result describes a failed command. The
+// explicit is_error flag is authoritative when present; the output heuristic is
+// only a fallback, because it cannot tell a failure from a command that merely
+// prints an error message (a grep hit, a file listing).
+func resultIsError(item contentItem) bool {
+	if item.IsError != nil {
+		return *item.IsError
+	}
+	return looksLikeError(item.Content.Value)
+}
+
+// isNotRun reports whether a tool result means the command never executed.
+func isNotRun(output string) bool {
+	for _, marker := range notRunMarkers {
+		if strings.Contains(output, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// dropNotRun removes the commands that never executed, keeping session order.
+func dropNotRun(entries []commandEntry) []commandEntry {
+	kept := entries[:0]
+	for _, e := range entries {
+		if !e.NotRun {
+			kept = append(kept, e)
+		}
+	}
+	return kept
 }
 
 // extractBaseCommand parses a shell command string to extract the base command name.

--- a/internal/learn/learn_test.go
+++ b/internal/learn/learn_test.go
@@ -577,3 +577,65 @@ func writeLines(t *testing.T, path string, lines []string) {
 		t.Fatal(err)
 	}
 }
+
+func TestExtractCommandEntriesTrustsExplicitFlag(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+
+	// The output quotes an error marker, but the tool reported success.
+	writeLines(t, path, []string{
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"grep -n \"undefined:\" main.go"}}]},"timestamp":"2026-04-01T10:00:00.000Z"}`,
+		`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"12: // undefined: reflect","is_error":false}]},"timestamp":"2026-04-01T10:00:05.000Z"}`,
+	})
+
+	entries := extractCommandEntries(path, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].IsError {
+		t.Error("entries[0].IsError = true, want false: an explicit is_error:false must win over the output heuristic")
+	}
+}
+
+func TestExtractCommandEntriesFallsBackWithoutFlag(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+
+	// No is_error field at all: the output heuristic is the only signal left.
+	writeLines(t, path, []string{
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"foo --bar"}}]},"timestamp":"2026-04-01T10:00:00.000Z"}`,
+		`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"foo: command not found"}]},"timestamp":"2026-04-01T10:00:05.000Z"}`,
+	})
+
+	entries := extractCommandEntries(path, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if !entries[0].IsError {
+		t.Error("entries[0].IsError = false, want true")
+	}
+}
+
+func TestExtractCommandEntriesDropsRejections(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+
+	// A rejected command never ran: it is neither a failure nor a fix.
+	writeLines(t, path, []string{
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"go test ./..."}}]},"timestamp":"2026-04-01T10:00:00.000Z"}`,
+		`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"The user doesn't want to proceed with this tool use. The tool use was rejected (e.g. if it was a file edit).","is_error":true}]},"timestamp":"2026-04-01T10:00:05.000Z"}`,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_2","name":"Bash","input":{"command":"go build ./..."}}]},"timestamp":"2026-04-01T10:00:10.000Z"}`,
+		`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_2","content":"ok"}]},"timestamp":"2026-04-01T10:00:15.000Z"}`,
+	})
+
+	entries := extractCommandEntries(path, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	if len(entries) != 1 {
+		t.Fatalf("expected the rejected command to be dropped, got %d entries", len(entries))
+	}
+	if entries[0].Command != "go build ./..." {
+		t.Errorf("entries[0].Command = %q, want %q", entries[0].Command, "go build ./...")
+	}
+	if patterns := detectPatterns(entries); len(patterns) != 0 {
+		t.Errorf("expected no pattern from a rejection, got %d", len(patterns))
+	}
+}


### PR DESCRIPTION
## Problem

Error detection ORed the explicit `is_error` flag with a substring scan of the output:

```go
entries[idx].IsError = item.IsError || looksLikeError(item.Content.Value)
```

So a successful command whose output merely mentions an error was counted as a failure. On a real project this produced entries such as:

```
Error: ok -> fixed by ...
Error: if err != nil { -> fixed by ...
Error: import {useQuery} from '@apollo/client'; -> fixed by ...
```

A `grep` hit on `undefined:`, a file listing, a test log quoting `FAIL`: all became failures.

Rejected and interrupted commands had the opposite problem. They carry `is_error: true`, but nothing ran:

```
Error: The user doesn't want to proceed with this tool use. The tool use was rejected (...
```

## Fix

The flag is present on nearly every Bash `tool_result` (44 false / 1 true in a sample session of 54 results), so make it authoritative: `is_error` decides when set, and `looksLikeError` stays as the fallback for results that carry no flag. This requires `*bool`, since a missing field and an explicit `false` are otherwise indistinguishable.

Commands that never ran are dropped from the entry list entirely, not just unmarked, so they cannot pair with a neighbouring command as a "fix" either.

## Result

Same sessions, same window: 42 detected patterns -> 10, with the remaining ones all backed by a real non-zero exit.

## Tests

Three cases: an explicit `is_error:false` beats the output heuristic, the heuristic still applies when the flag is absent, and a rejection is dropped and yields no pattern. Reverting the production hunk makes them fail.

`make test-race` and `make lint` pass locally.