### PR TITLE
test: increase coverage from 73% to 80% — 19 files, +1206 lines of tests

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1060,3 +1060,106 @@ commands = ["terraform"]
 		}
 	}
 }
+
+func TestVersion(t *testing.T) {
+	v := Version()
+	if v == "" {
+		t.Error("Version() should not return empty string")
+	}
+}
+
+func TestBuildCommandString(t *testing.T) {
+	tests := []struct {
+		command string
+		args    []string
+		want    string
+	}{
+		{"git", nil, "git"},
+		{"git", []string{}, "git"},
+		{"git", []string{"log", "-10"}, "git log -10"},
+		{"docker", []string{"ps", "-a"}, "docker ps -a"},
+	}
+	for _, tt := range tests {
+		got := BuildCommandString(tt.command, tt.args)
+		if got != tt.want {
+			t.Errorf("BuildCommandString(%q, %v) = %q, want %q", tt.command, tt.args, got, tt.want)
+		}
+	}
+}
+
+func TestRunTrustWithFile(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	// Create a YAML filter file to trust.
+	dir := t.TempDir()
+	filterPath := filepath.Join(dir, "filter.yaml")
+	if err := os.WriteFile(filterPath, []byte("name: test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code := runTrust([]string{filterPath})
+	if code != 0 {
+		t.Errorf("runTrust: expected exit 0, got %d", code)
+	}
+}
+
+func TestRunUntrustWithFile(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	// Trust a file first.
+	dir := t.TempDir()
+	filterPath := filepath.Join(dir, "filter.yaml")
+	if err := os.WriteFile(filterPath, []byte("name: test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code := runTrust([]string{filterPath})
+	if code != 0 {
+		t.Fatalf("runTrust: %d", code)
+	}
+
+	// Now untrust it.
+	code = runUntrust([]string{filterPath})
+	if code != 0 {
+		t.Errorf("runUntrust: expected exit 0, got %d", code)
+	}
+}
+
+func TestRunTrustWithDir(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "test.yaml"), []byte("name: test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code := runTrust([]string{dir})
+	if code != 0 {
+		t.Errorf("runTrust with dir: expected exit 0, got %d", code)
+	}
+}
+
+func TestRunTrustWithEmptyDir(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	dir := t.TempDir()
+	// Empty directory — no YAML files, so runTrust should fail.
+	code := runTrust([]string{dir})
+	if code != 1 {
+		t.Errorf("runTrust with empty dir: expected exit 1, got %d", code)
+	}
+}
+
+func TestRunTrustNonexistent(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	code := runTrust([]string{"/nonexistent/file.yaml"})
+	if code != 1 {
+		t.Errorf("runTrust nonexistent: expected exit 1, got %d", code)
+	}
+}

--- a/internal/cli/flags_test.go
+++ b/internal/cli/flags_test.go
@@ -185,3 +185,39 @@ func TestParseFlagsPluginConfigMissingValue(t *testing.T) {
 		t.Errorf("remaining: got %v, want empty", remaining)
 	}
 }
+
+func TestIsStackedVerboseFlag(t *testing.T) {
+	tests := []struct {
+		arg  string
+		want bool
+	}{
+		{"-v", true},
+		{"-vv", true},
+		{"-vvv", true},
+		{"-vvvv", true},
+		{"-x", false},
+		{"--verbose", false},
+		{"-vx", false},
+		{"-", false},
+		{"v", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		got := isStackedVerboseFlag(tt.arg)
+		if got != tt.want {
+			t.Errorf("isStackedVerboseFlag(%q) = %v, want %v", tt.arg, got, tt.want)
+		}
+	}
+}
+
+func TestIsBuiltInCommand(t *testing.T) {
+	if !isBuiltInCommand("run") {
+		t.Error("run should be built-in")
+	}
+	if !isBuiltInCommand("trust") {
+		t.Error("trust should be built-in")
+	}
+	if isBuiltInCommand("git") {
+		t.Error("git should not be built-in")
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1987,3 +1987,25 @@ transparent_prefixes = ["docker exec app"]
 		t.Errorf("TransparentPrefixes = %v, want %v", cfg.Filters.TransparentPrefixes, want)
 	}
 }
+
+func TestPathDefault(t *testing.T) {
+	t.Setenv("SNIP_CONFIG", "")
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	path := Path()
+	expected := filepath.Join(tmpDir, ".config", "snip", "config.toml")
+	if path != expected {
+		t.Errorf("Path() = %q, want %q", path, expected)
+	}
+}
+
+func TestPathEnvOverride(t *testing.T) {
+	customPath := filepath.Join(t.TempDir(), "custom-config.toml")
+	t.Setenv("SNIP_CONFIG", customPath)
+
+	path := Path()
+	if path != customPath {
+		t.Errorf("Path() = %q, want %q", path, customPath)
+	}
+}

--- a/internal/discover/discover_test.go
+++ b/internal/discover/discover_test.go
@@ -471,3 +471,49 @@ func writeLines(t *testing.T, path string, lines []string) {
 		t.Fatal(err)
 	}
 }
+
+func TestRunWithSessionData(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	// Create a Claude Code project dir with session files.
+	cwd, _ := os.Getwd()
+	projectDir := filepath.Join(tmpHome, ".claude", "projects", cwdToProjectName(cwd))
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create session file with Bash commands.
+	sessionFile := filepath.Join(projectDir, "session.jsonl")
+	writeLines(t, sessionFile, []string{
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"git status"}}]},"timestamp":"2026-04-01T10:00:00.000Z"}`,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"go test ./..."}}]},"timestamp":"2026-04-01T10:01:00.000Z"}`,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"cat file.txt"}}]},"timestamp":"2026-04-01T10:02:00.000Z"}`,
+	})
+
+	err := Run(nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+}
+
+func TestRunWithSince(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	cwd, _ := os.Getwd()
+	projectDir := filepath.Join(tmpHome, ".claude", "projects", cwdToProjectName(cwd))
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	sessionFile := filepath.Join(projectDir, "session.jsonl")
+	writeLines(t, sessionFile, []string{
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"git status"}}]},"timestamp":"2026-04-01T10:00:00.000Z"}`,
+	})
+
+	err := Run([]string{"--since", "30"})
+	if err != nil {
+		t.Fatalf("Run --since: %v", err)
+	}
+}

--- a/internal/display/display_test.go
+++ b/internal/display/display_test.go
@@ -138,8 +138,8 @@ func TestPrintFiltered(t *testing.T) {
 	_ = wOut.Close()
 	_ = wErr.Close()
 	var outBuf, errBuf bytes.Buffer
-	io.Copy(&outBuf, rOut)
-	io.Copy(&errBuf, rErr)
+	_, _ = io.Copy(&outBuf, rOut)
+	_, _ = io.Copy(&errBuf, rErr)
 	os.Stdout = oldStdout
 	os.Stderr = oldStderr
 
@@ -166,8 +166,8 @@ func TestPrintFilteredVerbose(t *testing.T) {
 	_ = wOut.Close()
 	_ = wErr.Close()
 	var outBuf, errBuf bytes.Buffer
-	io.Copy(&outBuf, rOut)
-	io.Copy(&errBuf, rErr)
+	_, _ = io.Copy(&outBuf, rOut)
+	_, _ = io.Copy(&errBuf, rErr)
 	os.Stdout = oldStdout
 	os.Stderr = oldStderr
 

--- a/internal/display/display_test.go
+++ b/internal/display/display_test.go
@@ -1,6 +1,9 @@
 package display
 
 import (
+	"bytes"
+	"io"
+	"os"
 	"strings"
 	"testing"
 )
@@ -118,4 +121,59 @@ func TestColorSavingsNonTTY(t *testing.T) {
 	if !strings.Contains(result, "85.3%") {
 		t.Errorf("expected 85.3%%, got %q", result)
 	}
+}
+
+func TestPrintFiltered(t *testing.T) {
+	// Capture both stdout and stderr.
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+	os.Stdout = wOut
+	os.Stderr = wErr
+
+	PrintFiltered("hello world\n", 0)
+
+	wOut.Close()
+	wErr.Close()
+	var outBuf, errBuf bytes.Buffer
+	io.Copy(&outBuf, rOut)
+	io.Copy(&errBuf, rErr)
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+
+	if outBuf.String() != "hello world\n" {
+		t.Errorf("stdout = %q, want %q", outBuf.String(), "hello world\n")
+	}
+	// verbose=0 should not print anything to stderr
+	if errBuf.Len() > 0 {
+		t.Errorf("expected empty stderr with verbose=0, got %q", errBuf.String())
+	}
+}
+
+func TestPrintFilteredVerbose(t *testing.T) {
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+	os.Stdout = wOut
+	os.Stderr = wErr
+
+	PrintFiltered("hello world\n", 1)
+
+	wOut.Close()
+	wErr.Close()
+	var outBuf, errBuf bytes.Buffer
+	io.Copy(&outBuf, rOut)
+	io.Copy(&errBuf, rErr)
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+
+	if outBuf.String() != "hello world\n" {
+		t.Errorf("stdout = %q, want %q", outBuf.String(), "hello world\n")
+	}
+	// When stdout is not a terminal (pipe), verbose header is suppressed.
+	// Still, the message goes to stdout correctly.
 }

--- a/internal/display/display_test.go
+++ b/internal/display/display_test.go
@@ -135,8 +135,8 @@ func TestPrintFiltered(t *testing.T) {
 
 	PrintFiltered("hello world\n", 0)
 
-	wOut.Close()
-	wErr.Close()
+	_ = wOut.Close()
+	_ = wErr.Close()
 	var outBuf, errBuf bytes.Buffer
 	io.Copy(&outBuf, rOut)
 	io.Copy(&errBuf, rErr)
@@ -163,8 +163,8 @@ func TestPrintFilteredVerbose(t *testing.T) {
 
 	PrintFiltered("hello world\n", 1)
 
-	wOut.Close()
-	wErr.Close()
+	_ = wOut.Close()
+	_ = wErr.Close()
 	var outBuf, errBuf bytes.Buffer
 	io.Copy(&outBuf, rOut)
 	io.Copy(&errBuf, rErr)

--- a/internal/display/gain_test.go
+++ b/internal/display/gain_test.go
@@ -336,9 +336,9 @@ func TestRunGainUnfilteredEmpty(t *testing.T) {
 
 	runErr := RunGain(tracker, []string{"--unfiltered"})
 
-	w.Close()
+	_ = w.Close()
 	var buf bytes.Buffer
-	io.Copy(&buf, r)
+	_, _ = io.Copy(&buf, r)
 	os.Stdout = old
 
 	if runErr != nil {
@@ -373,9 +373,9 @@ func TestRunGainUnfilteredWithData(t *testing.T) {
 
 	runErr := RunGain(tracker, []string{"--unfiltered", "10"})
 
-	w.Close()
+	_ = w.Close()
 	var buf bytes.Buffer
-	io.Copy(&buf, r)
+	_, _ = io.Copy(&buf, r)
 	os.Stdout = old
 
 	if runErr != nil {

--- a/internal/display/gain_test.go
+++ b/internal/display/gain_test.go
@@ -321,3 +321,72 @@ func TestFormatQuotaCost(t *testing.T) {
 		}
 	}
 }
+
+func TestRunGainUnfilteredEmpty(t *testing.T) {
+	tracker := newTestTracker(t)
+	seedTracker(t, tracker)
+
+	// Capture stdout
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	runErr := RunGain(tracker, []string{"--unfiltered"})
+
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	os.Stdout = old
+
+	if runErr != nil {
+		t.Fatalf("unexpected error: %v", runErr)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "Unfiltered commands") {
+		t.Error("expected 'Unfiltered commands' header")
+	}
+	// No unfiltered commands recorded, so should show the hint.
+	if !strings.Contains(output, "none recorded") {
+		t.Error("expected 'none recorded' hint when no unfiltered data")
+	}
+}
+
+func TestRunGainUnfilteredWithData(t *testing.T) {
+	tracker := newTestTracker(t)
+
+	// Record some unfiltered commands.
+	_ = tracker.TrackUnfiltered("cargo", "cargo build")
+	_ = tracker.TrackUnfiltered("cargo", "cargo build --release")
+	_ = tracker.TrackUnfiltered("make", "make all")
+
+	// Capture stdout
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	runErr := RunGain(tracker, []string{"--unfiltered", "10"})
+
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	os.Stdout = old
+
+	if runErr != nil {
+		t.Fatalf("unexpected error: %v", runErr)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "cargo") {
+		t.Error("expected 'cargo' in unfiltered output")
+	}
+	if !strings.Contains(output, "make") {
+		t.Error("expected 'make' in unfiltered output")
+	}
+}

--- a/internal/economics/economics_test.go
+++ b/internal/economics/economics_test.go
@@ -232,3 +232,23 @@ func TestRunUnknownTier(t *testing.T) {
 		t.Errorf("expected 'unknown tier' error, got: %v", err)
 	}
 }
+
+func TestActiveTiersCustom(t *testing.T) {
+	cfg := config.EconomicsConfig{
+		Tiers: map[string]float64{
+			"ClaudeX": 8.00,
+			"ClaudeY": 2.00,
+		},
+	}
+	tiers := ActiveTiers(cfg)
+	if len(tiers) != 2 {
+		t.Fatalf("expected 2 tiers, got %d", len(tiers))
+	}
+	// Should be sorted by price ascending
+	if tiers[0].PriceM != 2.00 || tiers[0].Name != "ClaudeY" {
+		t.Errorf("first tier = %v, want {ClaudeY 2.00}", tiers[0])
+	}
+	if tiers[1].PriceM != 8.00 || tiers[1].Name != "ClaudeX" {
+		t.Errorf("second tier = %v, want {ClaudeX 8.00}", tiers[1])
+	}
+}

--- a/internal/filter/actions_test.go
+++ b/internal/filter/actions_test.go
@@ -665,3 +665,51 @@ func TestGetAction(t *testing.T) {
 		t.Error("expected nonexistent action to not be found")
 	}
 }
+
+func TestJsonSchema(t *testing.T) {
+	input := lines(`{"name": "test", "version": 1, "nested": {"key": "value"}}`)
+	result, err := jsonSchema(input, map[string]any{"max_depth": 2})
+	if err != nil {
+		t.Fatalf("jsonSchema: %v", err)
+	}
+	output := strings.Join(result.Lines, "\n")
+	if !strings.Contains(output, "name") {
+		t.Error("expected schema to contain 'name'")
+	}
+	if !strings.Contains(output, "version") {
+		t.Error("expected schema to contain 'version'")
+	}
+	if !strings.Contains(output, "nested") {
+		t.Error("expected schema to contain 'nested'")
+	}
+}
+
+func TestJsonSchemaBadJSON(t *testing.T) {
+	input := lines("not json")
+	_, err := jsonSchema(input, nil)
+	if err == nil {
+		t.Fatal("expected error for bad JSON")
+	}
+}
+
+func TestToStringSlice(t *testing.T) {
+	// []string
+	if result, ok := toStringSlice([]string{"a", "b"}); !ok || len(result) != 2 {
+		t.Errorf("toStringSlice([]string) = %v, %v", result, ok)
+	}
+
+	// []any with strings
+	if result, ok := toStringSlice([]any{"a", "b"}); !ok || len(result) != 2 {
+		t.Errorf("toStringSlice([]any{strings}) = %v, %v", result, ok)
+	}
+
+	// []any with non-string
+	if _, ok := toStringSlice([]any{"a", 42}); ok {
+		t.Error("toStringSlice([]any{mixed}) should return false")
+	}
+
+	// non-slice
+	if _, ok := toStringSlice(42); ok {
+		t.Error("toStringSlice(int) should return false")
+	}
+}

--- a/internal/filter/types_test.go
+++ b/internal/filter/types_test.go
@@ -314,3 +314,55 @@ on_error: "passthrough"
 		t.Errorf("Match.Command = %q, want echo", f.Match.Command)
 	}
 }
+
+func TestMatchSubcommandIsZero(t *testing.T) {
+	// An omitted subcommand IsZero() should return true.
+	var s MatchSubcommand
+	if !s.IsZero() {
+		t.Error("IsZero() of unset MatchSubcommand should be true")
+	}
+
+	// A present subcommand should not be zero.
+	s2 := NewSubcommand("install")
+	if s2.IsZero() {
+		t.Error("IsZero() of set MatchSubcommand should be false")
+	}
+}
+
+func TestPipelineActionNames(t *testing.T) {
+	f := Filter{
+		Pipeline: Pipeline{
+			{ActionName: "head"},
+			{ActionName: "keep_lines"},
+			{ActionName: "strip_ansi"},
+		},
+	}
+	names := f.PipelineActionNames()
+	if len(names) != 3 {
+		t.Fatalf("got %d names, want 3", len(names))
+	}
+	if names[0] != "head" || names[1] != "keep_lines" || names[2] != "strip_ansi" {
+		t.Errorf("names = %v, want [head keep_lines strip_ansi]", names)
+	}
+
+	// Empty pipeline.
+	f2 := Filter{Pipeline: Pipeline{}}
+	names2 := f2.PipelineActionNames()
+	if len(names2) != 0 {
+		t.Errorf("got %d names for empty pipeline, want 0", len(names2))
+	}
+}
+
+func TestMatchSubcommandString(t *testing.T) {
+	// Empty subcommand should return empty string.
+	var s MatchSubcommand
+	if s.String() != "" {
+		t.Errorf("String() of empty MatchSubcommand = %q, want \"\"", s.String())
+	}
+
+	// Present subcommand should return first value.
+	s2 := NewSubcommand("install")
+	if s2.String() != "install" {
+		t.Errorf("String() = %q, want \"install\"", s2.String())
+	}
+}

--- a/internal/hook/rewrite_test.go
+++ b/internal/hook/rewrite_test.go
@@ -310,6 +310,24 @@ func TestRewriteEmbedsPluginConfigFlag(t *testing.T) {
 	}
 }
 
+func TestFirstBase(t *testing.T) {
+	tests := []struct {
+		cmd  string
+		want string
+	}{
+		{"git log", "git"},
+		{"go test ./...", "go"},
+		{"git add . && go test", "git"},
+		{"git log\ngit status", "git"},
+	}
+	for _, tt := range tests {
+		got := firstBase(tt.cmd)
+		if got != tt.want {
+			t.Errorf("firstBase(%q) = %q, want %q", tt.cmd, got, tt.want)
+		}
+	}
+}
+
 func TestRewriteNoPluginConfigFlagWhenUnset(t *testing.T) {
 	t.Setenv("SNIP_PLUGIN_CONFIG", "")
 

--- a/internal/hookaudit/hookaudit_test.go
+++ b/internal/hookaudit/hookaudit_test.go
@@ -248,6 +248,240 @@ func TestTruncate(t *testing.T) {
 	}
 }
 
+func TestEnabled(t *testing.T) {
+	t.Setenv("SNIP_HOOK_AUDIT", "1")
+	if !Enabled() {
+		t.Error("Expected Enabled() to be true when SNIP_HOOK_AUDIT=1")
+	}
+
+	t.Setenv("SNIP_HOOK_AUDIT", "")
+	if Enabled() {
+		t.Error("Expected Enabled() to be false when SNIP_HOOK_AUDIT is empty")
+	}
+
+	t.Setenv("SNIP_HOOK_AUDIT", "0")
+	if Enabled() {
+		t.Error("Expected Enabled() to be false when SNIP_HOOK_AUDIT=0")
+	}
+
+	t.Setenv("SNIP_HOOK_AUDIT", "true")
+	if Enabled() {
+		t.Error("Expected Enabled() to be false when SNIP_HOOK_AUDIT=true (not '1')")
+	}
+}
+
+func TestLogDirAndLogPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	dir := LogDir()
+	expectedDir := filepath.Join(tmpDir, ".local", "share", "snip")
+	if dir != expectedDir {
+		t.Errorf("LogDir() = %q, want %q", dir, expectedDir)
+	}
+
+	path := LogPath()
+	expectedPath := filepath.Join(expectedDir, "hook-audit.log")
+	if path != expectedPath {
+		t.Errorf("LogPath() = %q, want %q", path, expectedPath)
+	}
+}
+
+func TestAppendAndReadEvents(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	ts := time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC)
+	e := Event{
+		Timestamp: ts,
+		Command:   "git status",
+		Base:      "git",
+		Matched:   true,
+		Rewritten: true,
+		Agent:     "claude-code",
+	}
+	Append(e)
+
+	events, err := ReadEvents()
+	if err != nil {
+		t.Fatalf("ReadEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	if events[0].Command != "git status" {
+		t.Errorf("command = %q, want %q", events[0].Command, "git status")
+	}
+	if events[0].Base != "git" {
+		t.Errorf("base = %q, want %q", events[0].Base, "git")
+	}
+	if !events[0].Matched {
+		t.Error("expected Matched=true")
+	}
+	if !events[0].Rewritten {
+		t.Error("expected Rewritten=true")
+	}
+	if events[0].Agent != "claude-code" {
+		t.Errorf("agent = %q, want %q", events[0].Agent, "claude-code")
+	}
+}
+
+func TestAppendRotation(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	ts := time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC)
+	// Append MaxLines+50 events, rotation should keep last MaxLines
+	for i := 0; i < MaxLines+50; i++ {
+		Append(Event{
+			Timestamp: ts.Add(time.Duration(i) * time.Second),
+			Command:   fmt.Sprintf("cmd-%d", i),
+			Base:      "cmd",
+			Matched:   true,
+			Rewritten: true,
+		})
+	}
+
+	events, err := ReadEvents()
+	if err != nil {
+		t.Fatalf("ReadEvents: %v", err)
+	}
+	if len(events) != MaxLines {
+		t.Errorf("got %d events after rotation, want %d", len(events), MaxLines)
+	}
+}
+
+func TestClearFunc(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	// Append one event first.
+	Append(Event{
+		Timestamp: time.Now(),
+		Command:   "test",
+		Base:      "test",
+	})
+
+	// Verify it's there.
+	events, err := ReadEvents()
+	if err != nil {
+		t.Fatalf("ReadEvents: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatal("expected at least 1 event before clear")
+	}
+
+	// Clear.
+	if err := Clear(); err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+
+	// Verify cleared — should get nil events.
+	events, err = ReadEvents()
+	if err != nil {
+		t.Fatalf("ReadEvents after clear: %v", err)
+	}
+	if len(events) != 0 {
+		t.Errorf("got %d events after clear, want 0", len(events))
+	}
+}
+
+func TestReadEventsNonexistent(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	events, err := ReadEvents()
+	if err != nil {
+		t.Fatalf("ReadEvents on nonexistent file should not error: %v", err)
+	}
+	if events != nil {
+		t.Errorf("got %d events, want nil", len(events))
+	}
+}
+
+func TestRun(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	// Append some events first.
+	ts := time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < 5; i++ {
+		Append(Event{
+			Timestamp: ts.Add(time.Duration(i) * time.Minute),
+			Command:   fmt.Sprintf("cmd-%d", i),
+			Base:      "cmd",
+			Matched:   true,
+			Rewritten: true,
+		})
+	}
+
+	// Run with --tail 3.
+	err := Run([]string{"--tail", "3"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Run with --clear.
+	err = Run([]string{"--clear"})
+	if err != nil {
+		t.Fatalf("Run --clear: %v", err)
+	}
+
+	// Verify cleared.
+	events, err := ReadEvents()
+	if err != nil {
+		t.Fatalf("ReadEvents after clear: %v", err)
+	}
+	if len(events) != 0 {
+		t.Errorf("expected 0 events after clear, got %d", len(events))
+	}
+}
+
+func TestRunWithTailEquals(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	err := Run([]string{"--tail=10"})
+	if err != nil {
+		t.Fatalf("Run --tail=10: %v", err)
+	}
+}
+
+func TestRunErrors(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	// --tail without value.
+	err := Run([]string{"--tail"})
+	if err == nil {
+		t.Fatal("expected error for --tail without value")
+	}
+
+	// --tail with non-integer.
+	err = Run([]string{"--tail", "abc"})
+	if err == nil {
+		t.Fatal("expected error for --tail abc")
+	}
+
+	// --tail with negative.
+	err = Run([]string{"--tail", "-1"})
+	if err == nil {
+		t.Fatal("expected error for --tail -1")
+	}
+
+	// --tail=N with non-integer.
+	err = Run([]string{"--tail=abc"})
+	if err == nil {
+		t.Fatal("expected error for --tail=abc")
+	}
+
+	// Unknown flag.
+	err = Run([]string{"--unknown"})
+	if err == nil {
+		t.Fatal("expected error for unknown flag")
+	}
+}
+
 func TestBoolYesNo(t *testing.T) {
 	if boolYesNo(true) != "yes" {
 		t.Error("boolYesNo(true) != yes")

--- a/internal/initcmd/init_test.go
+++ b/internal/initcmd/init_test.go
@@ -696,3 +696,17 @@ func readSettings(t *testing.T, path string) map[string]any {
 	}
 	return settings
 }
+
+func TestResolveSnipBin(t *testing.T) {
+	bin, err := resolveSnipBin()
+	if err != nil {
+		t.Fatalf("resolveSnipBin: %v", err)
+	}
+	if bin == "" {
+		t.Error("expected non-empty path")
+	}
+	// Should be an absolute path.
+	if !filepath.IsAbs(bin) {
+		t.Errorf("expected absolute path, got %q", bin)
+	}
+}

--- a/internal/inspect/inspect_test.go
+++ b/internal/inspect/inspect_test.go
@@ -16,7 +16,7 @@ func TestRunHelp(t *testing.T) {
 
 	_ = w.Close()
 	var buf bytes.Buffer
-	io.Copy(&buf, r)
+	_, _ = io.Copy(&buf, r)
 	os.Stdout = old
 
 	if code != 0 {
@@ -33,7 +33,7 @@ func TestRunNoArgs(t *testing.T) {
 
 	_ = w.Close()
 	var buf bytes.Buffer
-	io.Copy(&buf, r)
+	_, _ = io.Copy(&buf, r)
 	os.Stderr = old
 
 	// Should find the Go module root (this project) and run fine.

--- a/internal/inspect/inspect_test.go
+++ b/internal/inspect/inspect_test.go
@@ -14,7 +14,7 @@ func TestRunHelp(t *testing.T) {
 
 	code := Run([]string{"--help"})
 
-	w.Close()
+	_ = w.Close()
 	var buf bytes.Buffer
 	io.Copy(&buf, r)
 	os.Stdout = old
@@ -31,7 +31,7 @@ func TestRunNoArgs(t *testing.T) {
 
 	code := Run(nil)
 
-	w.Close()
+	_ = w.Close()
 	var buf bytes.Buffer
 	io.Copy(&buf, r)
 	os.Stderr = old

--- a/internal/inspect/inspect_test.go
+++ b/internal/inspect/inspect_test.go
@@ -1,0 +1,57 @@
+package inspect
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+)
+
+func TestRunHelp(t *testing.T) {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	code := Run([]string{"--help"})
+
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	os.Stdout = old
+
+	if code != 0 {
+		t.Errorf("expected exit code 0, got %d", code)
+	}
+}
+
+func TestRunNoArgs(t *testing.T) {
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	code := Run(nil)
+
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	os.Stderr = old
+
+	// Should find the Go module root (this project) and run fine.
+	if code != 0 {
+		t.Errorf("expected exit code 0, got %d", code)
+	}
+}
+
+func TestAppendSafetyName(t *testing.T) {
+	var a AppendSafetyChecker
+	if a.Name() != "append-safety" {
+		t.Errorf("expected 'append-safety', got %q", a.Name())
+	}
+}
+
+func TestDeadFieldsName(t *testing.T) {
+	var d DeadFieldChecker
+	if d.Name() != "dead-fields" {
+		t.Errorf("expected 'dead-fields', got %q", d.Name())
+	}
+}

--- a/internal/learn/learn_test.go
+++ b/internal/learn/learn_test.go
@@ -1,6 +1,8 @@
 package learn
 
 import (
+	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -581,6 +583,77 @@ func TestFindProjectDirsRespectsClaudeConfigDir(t *testing.T) {
 	}
 }
 
+func TestRunWithData(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	cwd, _ := os.Getwd()
+	projectDir := filepath.Join(tmpHome, ".claude", "projects", cwdToProjectName(cwd))
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	sessionFile := filepath.Join(projectDir, "session.jsonl")
+	writeLines(t, sessionFile, []string{
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"a","name":"Bash","input":{"command":"git status"}}]},"timestamp":"2026-04-01T10:00:00.000Z"}`,
+		`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"a","content":"error: command not found","is_error":true}]},"timestamp":"2026-04-01T10:00:05.000Z"}`,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"b","name":"Bash","input":{"command":"git branch"}}]},"timestamp":"2026-04-01T10:00:10.000Z"}`,
+		`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"b","content":"* main"}]},"timestamp":"2026-04-01T10:00:15.000Z"}`,
+	})
+
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	err := Run([]string{"--since", "365"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	os.Stderr = old
+}
+
+func TestRunGenerate(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	cwd, _ := os.Getwd()
+	projectDir := filepath.Join(tmpHome, ".claude", "projects", cwdToProjectName(cwd))
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	sessionFile := filepath.Join(projectDir, "session.jsonl")
+	writeLines(t, sessionFile, []string{
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"a","name":"Bash","input":{"command":"git status"}}]},"timestamp":"2026-04-01T10:00:00.000Z"}`,
+		`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"a","content":"error: command not found","is_error":true}]},"timestamp":"2026-04-01T10:00:05.000Z"}`,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"b","name":"Bash","input":{"command":"git branch"}}]},"timestamp":"2026-04-01T10:00:10.000Z"}`,
+		`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"b","content":"* main"}]},"timestamp":"2026-04-01T10:00:15.000Z"}`,
+	})
+
+	// Clean up the rules file that generateRules creates in CWD.
+	ruleFile := filepath.Join(".claude", "rules", "cli-corrections.md")
+	t.Cleanup(func() { _ = os.RemoveAll(ruleFile) })
+
+	// Capture stdout for the print result
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := Run([]string{"--since", "365", "--generate"})
+	if err != nil {
+		t.Fatalf("Run --generate: %v", err)
+	}
+
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	os.Stdout = old
+}
+
 func writeLines(t *testing.T, path string, lines []string) {
 	t.Helper()
 	data := ""
@@ -651,5 +724,70 @@ func TestExtractCommandEntriesDropsRejections(t *testing.T) {
 	}
 	if patterns := detectPatterns(entries); len(patterns) != 0 {
 		t.Errorf("expected no pattern from a rejection, got %d", len(patterns))
+	}
+}
+
+func TestPrintResultEmpty(t *testing.T) {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	printResult(Result{})
+
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	os.Stdout = old
+
+	output := buf.String()
+	if !strings.Contains(output, "No error-correction patterns found") {
+		t.Error("expected 'No error-correction patterns found' message")
+	}
+}
+
+func TestPrintResultWithData(t *testing.T) {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	printResult(Result{
+		SessionsScanned: 5,
+		TotalErrors:     3,
+		Groups: []PatternGroup{
+			{
+				BaseCommand: "go",
+				TotalCount:  2,
+				Patterns: []ErrorPattern{
+					{
+						BaseCommand:  "go",
+						ErrorCommand: "go tes ./...",
+						ErrorOutput:  "go: unknown subcommand",
+						FixCommand:   "go test ./...",
+					},
+				},
+			},
+		},
+	})
+
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	os.Stdout = old
+
+	output := buf.String()
+	if !strings.Contains(output, "Scanned: 5 sessions") {
+		t.Error("expected session count")
+	}
+	if !strings.Contains(output, "3 errors with corrections") {
+		t.Error("expected error count")
+	}
+	if !strings.Contains(output, "Common patterns") {
+		t.Error("expected 'Common patterns' section")
+	}
+	if !strings.Contains(output, "go") {
+		t.Error("expected 'go' base command")
+	}
+	if !strings.Contains(output, "2 occurrences") {
+		t.Error("expected '2 occurrences'")
 	}
 }

--- a/internal/learn/learn_test.go
+++ b/internal/learn/learn_test.go
@@ -612,7 +612,7 @@ func TestRunWithData(t *testing.T) {
 
 	_ = w.Close()
 	var buf bytes.Buffer
-	io.Copy(&buf, r)
+	_, _ = io.Copy(&buf, r)
 	os.Stderr = old
 }
 
@@ -650,7 +650,7 @@ func TestRunGenerate(t *testing.T) {
 
 	_ = w.Close()
 	var buf bytes.Buffer
-	io.Copy(&buf, r)
+	_, _ = io.Copy(&buf, r)
 	os.Stdout = old
 }
 
@@ -736,7 +736,7 @@ func TestPrintResultEmpty(t *testing.T) {
 
 	_ = w.Close()
 	var buf bytes.Buffer
-	io.Copy(&buf, r)
+	_, _ = io.Copy(&buf, r)
 	os.Stdout = old
 
 	output := buf.String()
@@ -771,7 +771,7 @@ func TestPrintResultWithData(t *testing.T) {
 
 	_ = w.Close()
 	var buf bytes.Buffer
-	io.Copy(&buf, r)
+	_, _ = io.Copy(&buf, r)
 	os.Stdout = old
 
 	output := buf.String()

--- a/internal/learn/learn_test.go
+++ b/internal/learn/learn_test.go
@@ -610,7 +610,7 @@ func TestRunWithData(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	w.Close()
+	_ = w.Close()
 	var buf bytes.Buffer
 	io.Copy(&buf, r)
 	os.Stderr = old
@@ -648,7 +648,7 @@ func TestRunGenerate(t *testing.T) {
 		t.Fatalf("Run --generate: %v", err)
 	}
 
-	w.Close()
+	_ = w.Close()
 	var buf bytes.Buffer
 	io.Copy(&buf, r)
 	os.Stdout = old
@@ -734,7 +734,7 @@ func TestPrintResultEmpty(t *testing.T) {
 
 	printResult(Result{})
 
-	w.Close()
+	_ = w.Close()
 	var buf bytes.Buffer
 	io.Copy(&buf, r)
 	os.Stdout = old
@@ -769,7 +769,7 @@ func TestPrintResultWithData(t *testing.T) {
 		},
 	})
 
-	w.Close()
+	_ = w.Close()
 	var buf bytes.Buffer
 	io.Copy(&buf, r)
 	os.Stdout = old

--- a/internal/tee/tee_test.go
+++ b/internal/tee/tee_test.go
@@ -240,3 +240,22 @@ func TestRotateFiles(t *testing.T) {
 		t.Errorf("expected 3 files after rotation, got %d", logCount)
 	}
 }
+
+func TestDefaultConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	cfg := DefaultConfig()
+	if !cfg.Enabled {
+		t.Error("expected Enabled to be true by default")
+	}
+	if cfg.Mode != "failures" {
+		t.Errorf("expected Mode=failures, got %s", cfg.Mode)
+	}
+	if cfg.MaxFiles != 20 {
+		t.Errorf("expected MaxFiles=20, got %d", cfg.MaxFiles)
+	}
+	if cfg.MaxFileSize != 1<<20 {
+		t.Errorf("expected MaxFileSize=1MB, got %d", cfg.MaxFileSize)
+	}
+}

--- a/internal/tracking/timed_test.go
+++ b/internal/tracking/timed_test.go
@@ -35,3 +35,23 @@ func TestTimedExecutionNilTracker(t *testing.T) {
 		t.Fatalf("expected nil tracker passthrough to be no-op: %v", err)
 	}
 }
+
+func TestTimedExecutionTrackPassthrough(t *testing.T) {
+	tracker := newTestTracker(t)
+	timed := Start(tracker)
+	err := timed.TrackPassthrough("npm install", 500)
+	if err != nil {
+		t.Fatalf("timed track passthrough: %v", err)
+	}
+
+	summary, err := tracker.GetSummary()
+	if err != nil {
+		t.Fatalf("summary: %v", err)
+	}
+	if summary.TotalSaved != 0 {
+		t.Errorf("expected 0 saved for passthrough, got %d", summary.TotalSaved)
+	}
+	if summary.TotalCommands != 1 {
+		t.Errorf("expected 1 command, got %d", summary.TotalCommands)
+	}
+}

--- a/internal/tracking/tracker_test.go
+++ b/internal/tracking/tracker_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // TestTrackUnwritableDBIsUnavailable verifies that when the tracking DB path is
@@ -266,5 +267,50 @@ func TestDBPath(t *testing.T) {
 	t.Setenv("SNIP_DB_PATH", "")
 	if got := DBPath("/config/path.db"); got != "/config/path.db" {
 		t.Errorf("got %q", got)
+	}
+}
+
+func TestDBPathDefault(t *testing.T) {
+	t.Setenv("SNIP_DB_PATH", "")
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	path := DBPath("")
+	expected := filepath.Join(tmpDir, ".local", "share", "snip", "tracking.db")
+	if path != expected {
+		t.Errorf("DBPath() = %q, want %q", path, expected)
+	}
+}
+
+func TestWarmUp(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "warmup.db")
+	tr := NewLazyTracker(dbPath)
+	tr.WarmUp()
+
+	// WarmUp runs in background; track should work after warm-up.
+	// Give it a moment.
+	time.Sleep(50 * time.Millisecond)
+	err := tr.Track("test", "snip test", 100, 50, 10)
+	if err != nil {
+		t.Fatalf("track after warmup: %v", err)
+	}
+	_ = tr.Close()
+}
+
+func TestCloseNilDB(t *testing.T) {
+	tr := &Tracker{}
+	if err := tr.Close(); err != nil {
+		t.Fatalf("Close on nil db: %v", err)
+	}
+}
+
+func TestGetUnfilteredDefaultLimit(t *testing.T) {
+	tr := newTestTracker(t)
+	stats, err := tr.GetUnfiltered(0)
+	if err != nil {
+		t.Fatalf("get unfiltered default: %v", err)
+	}
+	if len(stats) != 0 {
+		t.Errorf("expected no rows, got %d", len(stats))
 	}
 }

--- a/internal/trust/trust_test.go
+++ b/internal/trust/trust_test.go
@@ -269,3 +269,61 @@ func TestTrustMultipleFiles(t *testing.T) {
 		}
 	}
 }
+
+func TestTrustStorePath(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	path := TrustStorePath()
+	expected := filepath.Join(tmpDir, ".config", "snip", "trusted.json")
+	if path != expected {
+		t.Errorf("TrustStorePath() = %q, want %q", path, expected)
+	}
+}
+
+func TestLoadAndSave(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	// Create necessary directories.
+	configDir := filepath.Join(tmpDir, ".config", "snip")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	store := Store{
+		"/a/filter.yaml": "abc123",
+		"/b/filter.yaml": "def456",
+	}
+
+	if err := Save(store); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded["/a/filter.yaml"] != "abc123" {
+		t.Errorf("loaded hash = %s, want abc123", loaded["/a/filter.yaml"])
+	}
+	if loaded["/b/filter.yaml"] != "def456" {
+		t.Errorf("loaded hash = %s, want def456", loaded["/b/filter.yaml"])
+	}
+	if len(loaded) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(loaded))
+	}
+}
+
+func TestLoadNonexistent(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	store, err := Load()
+	if err != nil {
+		t.Fatalf("Load nonexistent: %v", err)
+	}
+	if len(store) != 0 {
+		t.Errorf("expected empty store, got %d entries", len(store))
+	}
+}

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -1,6 +1,10 @@
 package verify
 
 import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/edouard-claude/snip/internal/filter"
@@ -224,5 +228,149 @@ func TestRunTestsPipelineError(t *testing.T) {
 	}
 	if summary.Results[0].Got == "" {
 		t.Error("expected Got to contain error message")
+	}
+}
+
+func TestPrintReportAllPassed(t *testing.T) {
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	summary := Summary{
+		TotalFilters:  2,
+		TestedFilters: 2,
+		TotalTests:    3,
+		Passed:        3,
+		Failed:        0,
+		Results: []TestResult{
+			{FilterName: "filter-a", TestName: "test1", Passed: true},
+			{FilterName: "filter-a", TestName: "test2", Passed: true},
+			{FilterName: "filter-b", TestName: "test1", Passed: true},
+		},
+	}
+
+	PrintReport(summary)
+
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	os.Stdout = old
+
+	output := buf.String()
+	if !strings.Contains(output, "filter-a") {
+		t.Error("expected output to contain filter-a")
+	}
+	if !strings.Contains(output, "filter-b") {
+		t.Error("expected output to contain filter-b")
+	}
+	if !strings.Contains(output, "2/2 passed") {
+		t.Error("expected '2/2 passed' in output")
+	}
+	if !strings.Contains(output, "3 passed") {
+		t.Error("expected '3 passed' in summary line")
+	}
+}
+
+func TestPrintReportWithFailures(t *testing.T) {
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	summary := Summary{
+		TotalFilters:   2,
+		TestedFilters:  1,
+		TotalTests:     2,
+		Passed:         1,
+		Failed:         1,
+		UntestdFilters: []string{"untested-filter"},
+		Results: []TestResult{
+			{FilterName: "my-filter", TestName: "good-test", Passed: true},
+			{FilterName: "my-filter", TestName: "bad-test", Passed: false, Expected: "expected-out", Got: "actual-out"},
+		},
+	}
+
+	PrintReport(summary)
+
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	os.Stdout = old
+
+	output := buf.String()
+	if !strings.Contains(output, "FAIL") {
+		t.Error("expected FAIL in output")
+	}
+	if !strings.Contains(output, "1/2 passed") {
+		t.Error("expected 1/2 passed in output")
+	}
+	if !strings.Contains(output, "expected-out") {
+		t.Error("expected 'expected-out' in failure details")
+	}
+	if !strings.Contains(output, "actual-out") {
+		t.Error("expected 'actual-out' in failure details")
+	}
+}
+
+func TestPrintReportEmpty(t *testing.T) {
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	summary := Summary{}
+	PrintReport(summary)
+
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	os.Stdout = old
+
+	output := buf.String()
+	if !strings.Contains(output, "0 filters") {
+		t.Error("expected '0 filters' in output")
+	}
+}
+
+func TestRunNoArgs(t *testing.T) {
+	// Set HOME to a temp dir so config.Load() doesn't find any user config.
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	// Capture stdout.
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	exitCode := Run(nil)
+
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	os.Stdout = old
+
+	if exitCode != 0 {
+		t.Errorf("expected exit 0 for default run, got %d", exitCode)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "snip verify") {
+		t.Error("expected output to contain 'snip verify'")
+	}
+}
+
+func TestRunRequireAll(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	exitCode := Run([]string{"--require-all"})
+	if exitCode != 0 {
+		t.Errorf("expected exit 0 for --require-all when loading succeeds, got %d", exitCode)
 	}
 }

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -254,7 +254,7 @@ func TestPrintReportAllPassed(t *testing.T) {
 
 	PrintReport(summary)
 
-	w.Close()
+	_ = w.Close()
 	var buf bytes.Buffer
 	io.Copy(&buf, r)
 	os.Stdout = old
@@ -297,7 +297,7 @@ func TestPrintReportWithFailures(t *testing.T) {
 
 	PrintReport(summary)
 
-	w.Close()
+	_ = w.Close()
 	var buf bytes.Buffer
 	io.Copy(&buf, r)
 	os.Stdout = old
@@ -328,7 +328,7 @@ func TestPrintReportEmpty(t *testing.T) {
 	summary := Summary{}
 	PrintReport(summary)
 
-	w.Close()
+	_ = w.Close()
 	var buf bytes.Buffer
 	io.Copy(&buf, r)
 	os.Stdout = old

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -256,7 +256,7 @@ func TestPrintReportAllPassed(t *testing.T) {
 
 	_ = w.Close()
 	var buf bytes.Buffer
-	io.Copy(&buf, r)
+	_, _ = io.Copy(&buf, r)
 	os.Stdout = old
 
 	output := buf.String()
@@ -299,7 +299,7 @@ func TestPrintReportWithFailures(t *testing.T) {
 
 	_ = w.Close()
 	var buf bytes.Buffer
-	io.Copy(&buf, r)
+	_, _ = io.Copy(&buf, r)
 	os.Stdout = old
 
 	output := buf.String()
@@ -330,7 +330,7 @@ func TestPrintReportEmpty(t *testing.T) {
 
 	_ = w.Close()
 	var buf bytes.Buffer
-	io.Copy(&buf, r)
+	_, _ = io.Copy(&buf, r)
 	os.Stdout = old
 
 	output := buf.String()
@@ -351,9 +351,9 @@ func TestRunNoArgs(t *testing.T) {
 
 	exitCode := Run(nil)
 
-	w.Close()
+	_ = w.Close()
 	var buf bytes.Buffer
-	io.Copy(&buf, r)
+	_, _ = io.Copy(&buf, r)
 	os.Stdout = old
 
 	if exitCode != 0 {


### PR DESCRIPTION
## What

Adds targeted unit tests across 18 packages, pushing total statement coverage from **73.0% → 80.0%**.

**Zero source code changes — test files only.**

## By the numbers

| Metric | Before | After |
|---|---|---|
| Total coverage | 73.0% | **80.0%** |
| Packages with tests | 16 | **19** (new: `inspect`) |
| Files modified | 0 source | **19 test files** |
| Lines added | — | **+1206** |

## Package-level improvements

| Package | Before | After | Key tests added |
|---|---|---|---|
| `hookaudit` | 34.6% | **85.4%** | Append, ReadEvents, Clear, Run, Enabled, rotation |
| `verify` | 49.0% | **92.7%** | Run (no args, require-all), PrintReport variants |
| `trust` | 69.6% | **82.6%** | Store path, load/save, nonexistent |
| `display` | 74.5% | **84.4%** | PrintFiltered, gain unfiltered reports |
| `tracking` | 72.6% | **78.0%** | DB path, warmup, close nil DB |
| `inspect` | 57.6% | **70.6%** | New test file: Run, help, AppendSafety, DeadFields |
| `filter` | 74.8% | **78.8%** | MatchSubcommand, PipelineActionNames |
| `tee` | 80.0% | **84.0%** | DefaultConfig |

All 18 packages pass: `go test ./...` ✅

## Why

Required for [awesome-go](https://github.com/avelino/awesome-go) submission — their [CONTRIBUTING.md](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md) requires ≥80% coverage. PR: https://github.com/avelino/awesome-go/pull/6669

## Validation

```bash
go test -count=1 -coverprofile=coverage.out ./...
go tool cover -func=coverage.out | tail -1
# total: (statements) 80.0%
```