### PR TITLE
fix: price gain --quota from the shared economics tier table

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -113,7 +113,7 @@ func Run(args []string) int {
 			return 1
 		}
 		defer func() { _ = tracker.Close() }()
-		if err := display.RunGain(tracker, cmdArgs); err != nil {
+		if err := display.RunGain(tracker, cfg.Economics, cmdArgs); err != nil {
 			display.PrintError(err.Error())
 			return 1
 		}

--- a/internal/config/tiers.go
+++ b/internal/config/tiers.go
@@ -1,15 +1,21 @@
-package economics
+package config
 
 import (
 	"sort"
 	"strings"
-
-	"github.com/edouard-claude/snip/internal/config"
 )
+
+// Tier holds a model tier name and its input price per 1M tokens.
+type Tier struct {
+	Name   string
+	PriceM float64 // price per 1M input tokens
+}
 
 // defaultTiers are current Anthropic list prices, $ per 1M input tokens
 // (as of 2026-08). Overridable via [economics.tiers] in config.toml for
-// negotiated or non-Anthropic rates.
+// negotiated or non-Anthropic rates. Single source of truth: both
+// `cc-economics` and `gain --quota` price saved tokens from this table
+// (issue #186).
 var defaultTiers = []Tier{
 	{Name: "Haiku", PriceM: 1.00},
 	{Name: "Sonnet", PriceM: 3.00},
@@ -20,7 +26,7 @@ var defaultTiers = []Tier{
 // ActiveTiers returns the pricing tiers to report on: the [economics.tiers]
 // entries from the config when present (sorted by ascending price), the
 // built-in defaults otherwise.
-func ActiveTiers(cfg config.EconomicsConfig) []Tier {
+func ActiveTiers(cfg EconomicsConfig) []Tier {
 	if len(cfg.Tiers) == 0 {
 		return defaultTiers
 	}

--- a/internal/config/tiers_test.go
+++ b/internal/config/tiers_test.go
@@ -1,13 +1,9 @@
-package economics
+package config
 
-import (
-	"testing"
-
-	"github.com/edouard-claude/snip/internal/config"
-)
+import "testing"
 
 func TestActiveTiersDefaults(t *testing.T) {
-	tiers := ActiveTiers(config.EconomicsConfig{})
+	tiers := ActiveTiers(EconomicsConfig{})
 	if len(tiers) != 4 {
 		t.Fatalf("expected 4 default tiers, got %v", tiers)
 	}
@@ -20,7 +16,7 @@ func TestActiveTiersDefaults(t *testing.T) {
 }
 
 func TestActiveTiersFromConfigSortedByPrice(t *testing.T) {
-	tiers := ActiveTiers(config.EconomicsConfig{Tiers: map[string]float64{
+	tiers := ActiveTiers(EconomicsConfig{Tiers: map[string]float64{
 		"premium": 9.99, "budget": 0.50, "standard": 2.00,
 	}})
 	if len(tiers) != 3 {
@@ -32,7 +28,7 @@ func TestActiveTiersFromConfigSortedByPrice(t *testing.T) {
 }
 
 func TestFindTierCaseInsensitive(t *testing.T) {
-	tiers := ActiveTiers(config.EconomicsConfig{Tiers: map[string]float64{"Negotiated": 2.75}})
+	tiers := ActiveTiers(EconomicsConfig{Tiers: map[string]float64{"Negotiated": 2.75}})
 	if tier := FindTier(tiers, "negotiated"); tier == nil || tier.PriceM != 2.75 {
 		t.Errorf("FindTier(negotiated): got %v", tier)
 	}

--- a/internal/display/gain.go
+++ b/internal/display/gain.go
@@ -6,12 +6,15 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/edouard-claude/snip/internal/config"
 	"github.com/edouard-claude/snip/internal/tracking"
 	"github.com/edouard-claude/snip/internal/utils"
 )
 
-// RunGain executes the gain (token savings report) command.
-func RunGain(tracker *tracking.Tracker, args []string) error {
+// RunGain executes the gain (token savings report) command. ecoCfg supplies
+// the pricing tiers used by --quota, the same table cc-economics reports on
+// ([economics.tiers] in config.toml, or the built-in defaults).
+func RunGain(tracker *tracking.Tracker, ecoCfg config.EconomicsConfig, args []string) error {
 	if tracker == nil {
 		PrintError("no tracking data (run some commands first)")
 		return nil
@@ -102,7 +105,7 @@ func RunGain(tracker *tracking.Tracker, args []string) error {
 		printSummary(summary)
 		err := showByCommand(tracker, topN, noTruncate)
 		if err == nil && showQuota {
-			printQuotaProjection(tracker)
+			printQuotaProjection(tracker, ecoCfg)
 		}
 		return err
 	}
@@ -111,7 +114,7 @@ func RunGain(tracker *tracking.Tracker, args []string) error {
 		printSummary(summary)
 		err := showPeriodReport(tracker, "weekly")
 		if err == nil && showQuota {
-			printQuotaProjection(tracker)
+			printQuotaProjection(tracker, ecoCfg)
 		}
 		return err
 	}
@@ -120,7 +123,7 @@ func RunGain(tracker *tracking.Tracker, args []string) error {
 		printSummary(summary)
 		err := showPeriodReport(tracker, "monthly")
 		if err == nil && showQuota {
-			printQuotaProjection(tracker)
+			printQuotaProjection(tracker, ecoCfg)
 		}
 		return err
 	}
@@ -128,7 +131,7 @@ func RunGain(tracker *tracking.Tracker, args []string) error {
 	if showDaily {
 		err := showDailyReport(tracker, days, summary)
 		if err == nil && showQuota {
-			printQuotaProjection(tracker)
+			printQuotaProjection(tracker, ecoCfg)
 		}
 		return err
 	}
@@ -139,7 +142,7 @@ func RunGain(tracker *tracking.Tracker, args []string) error {
 	_ = showByCommand(tracker, 10, noTruncate)
 
 	if showQuota {
-		printQuotaProjection(tracker)
+		printQuotaProjection(tracker, ecoCfg)
 	}
 
 	return nil
@@ -315,20 +318,7 @@ func showUnfilteredCommands(tracker *tracking.Tracker, limit int, noTruncate boo
 	return nil
 }
 
-// quotaTier holds a model tier name and its price per 1M input tokens.
-type quotaTier struct {
-	name   string
-	priceM float64
-}
-
-// quotaTiers lists model tiers for the --quota projection.
-var quotaTiers = []quotaTier{
-	{"Haiku", 0.25},
-	{"Sonnet", 3.00},
-	{"Opus", 15.00},
-}
-
-func printQuotaProjection(tracker *tracking.Tracker) {
+func printQuotaProjection(tracker *tracking.Tracker, ecoCfg config.EconomicsConfig) {
 	daily, err := tracker.GetDaily(30)
 	if err != nil || len(daily) == 0 {
 		return
@@ -365,9 +355,16 @@ func printQuotaProjection(tracker *tracking.Tracker) {
 
 	printRow("Tokens saved/month", "~"+utils.FormatTokens(monthlySaved))
 
-	for _, tier := range quotaTiers {
-		cost := float64(monthlySaved) / 1_000_000 * tier.priceM
-		printRow(tier.name+" savings", formatQuotaCost(cost)+"/month")
+	for _, tier := range config.ActiveTiers(ecoCfg) {
+		cost := float64(monthlySaved) / 1_000_000 * tier.PriceM
+		printRow(tier.Name+" savings", formatQuotaCost(cost)+"/month")
+	}
+
+	assumption := "  Assumes saved tokens are input tokens (filtered output fed back to LLM context)."
+	if tty {
+		fmt.Println(DimStyle.Render(assumption))
+	} else {
+		fmt.Println(assumption)
 	}
 
 	fmt.Println()

--- a/internal/display/gain_test.go
+++ b/internal/display/gain_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/edouard-claude/snip/internal/config"
 	"github.com/edouard-claude/snip/internal/tracking"
 )
 
@@ -34,7 +35,7 @@ func seedTracker(t *testing.T, tracker *tracking.Tracker) {
 
 func TestRunGainNoData(t *testing.T) {
 	tracker := newTestTracker(t)
-	err := RunGain(tracker, nil)
+	err := RunGain(tracker, config.EconomicsConfig{}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -44,7 +45,7 @@ func TestRunGainWithData(t *testing.T) {
 	tracker := newTestTracker(t)
 	seedTracker(t, tracker)
 
-	err := RunGain(tracker, nil)
+	err := RunGain(tracker, config.EconomicsConfig{}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -54,7 +55,7 @@ func TestRunGainDaily(t *testing.T) {
 	tracker := newTestTracker(t)
 	seedTracker(t, tracker)
 
-	err := RunGain(tracker, []string{"--daily"})
+	err := RunGain(tracker, config.EconomicsConfig{}, []string{"--daily"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -64,7 +65,7 @@ func TestRunGainWeekly(t *testing.T) {
 	tracker := newTestTracker(t)
 	seedTracker(t, tracker)
 
-	err := RunGain(tracker, []string{"--weekly"})
+	err := RunGain(tracker, config.EconomicsConfig{}, []string{"--weekly"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -74,7 +75,7 @@ func TestRunGainMonthly(t *testing.T) {
 	tracker := newTestTracker(t)
 	seedTracker(t, tracker)
 
-	err := RunGain(tracker, []string{"--monthly"})
+	err := RunGain(tracker, config.EconomicsConfig{}, []string{"--monthly"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -84,7 +85,7 @@ func TestRunGainTop(t *testing.T) {
 	tracker := newTestTracker(t)
 	seedTracker(t, tracker)
 
-	err := RunGain(tracker, []string{"--top", "5"})
+	err := RunGain(tracker, config.EconomicsConfig{}, []string{"--top", "5"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -94,7 +95,7 @@ func TestRunGainTopDefault(t *testing.T) {
 	tracker := newTestTracker(t)
 	seedTracker(t, tracker)
 
-	err := RunGain(tracker, []string{"--top"})
+	err := RunGain(tracker, config.EconomicsConfig{}, []string{"--top"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -104,7 +105,7 @@ func TestRunGainHistory(t *testing.T) {
 	tracker := newTestTracker(t)
 	seedTracker(t, tracker)
 
-	err := RunGain(tracker, []string{"--history", "5"})
+	err := RunGain(tracker, config.EconomicsConfig{}, []string{"--history", "5"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -114,7 +115,7 @@ func TestRunGainHistoryDefault(t *testing.T) {
 	tracker := newTestTracker(t)
 	seedTracker(t, tracker)
 
-	err := RunGain(tracker, []string{"--history"})
+	err := RunGain(tracker, config.EconomicsConfig{}, []string{"--history"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -124,7 +125,7 @@ func TestRunGainJSON(t *testing.T) {
 	tracker := newTestTracker(t)
 	seedTracker(t, tracker)
 
-	err := RunGain(tracker, []string{"--json"})
+	err := RunGain(tracker, config.EconomicsConfig{}, []string{"--json"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -134,14 +135,14 @@ func TestRunGainCSV(t *testing.T) {
 	tracker := newTestTracker(t)
 	seedTracker(t, tracker)
 
-	err := RunGain(tracker, []string{"--csv"})
+	err := RunGain(tracker, config.EconomicsConfig{}, []string{"--csv"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
 func TestRunGainNilTracker(t *testing.T) {
-	err := RunGain(nil, nil)
+	err := RunGain(nil, config.EconomicsConfig{}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -183,7 +184,7 @@ func TestRunGainNoTruncate(t *testing.T) {
 	}
 	os.Stdout = w
 
-	runErr := RunGain(tracker, []string{"--top", "1", "--no-truncate"})
+	runErr := RunGain(tracker, config.EconomicsConfig{}, []string{"--top", "1", "--no-truncate"})
 
 	_ = w.Close()
 	var buf bytes.Buffer
@@ -210,7 +211,7 @@ func TestRunGainQuota(t *testing.T) {
 	}
 	os.Stdout = w
 
-	runErr := RunGain(tracker, []string{"--quota"})
+	runErr := RunGain(tracker, config.EconomicsConfig{}, []string{"--quota"})
 
 	_ = w.Close()
 	var buf bytes.Buffer
@@ -254,7 +255,7 @@ func TestRunGainQuotaWithDaily(t *testing.T) {
 	}
 	os.Stdout = w
 
-	runErr := RunGain(tracker, []string{"--daily", "--quota"})
+	runErr := RunGain(tracker, config.EconomicsConfig{}, []string{"--daily", "--quota"})
 
 	_ = w.Close()
 	var buf bytes.Buffer
@@ -286,7 +287,7 @@ func TestRunGainQuotaNoData(t *testing.T) {
 	}
 	os.Stdout = w
 
-	runErr := RunGain(tracker, []string{"--quota"})
+	runErr := RunGain(tracker, config.EconomicsConfig{}, []string{"--quota"})
 
 	_ = w.Close()
 	var buf bytes.Buffer
@@ -334,7 +335,7 @@ func TestRunGainUnfilteredEmpty(t *testing.T) {
 	}
 	os.Stdout = w
 
-	runErr := RunGain(tracker, []string{"--unfiltered"})
+	runErr := RunGain(tracker, config.EconomicsConfig{}, []string{"--unfiltered"})
 
 	_ = w.Close()
 	var buf bytes.Buffer
@@ -371,7 +372,7 @@ func TestRunGainUnfilteredWithData(t *testing.T) {
 	}
 	os.Stdout = w
 
-	runErr := RunGain(tracker, []string{"--unfiltered", "10"})
+	runErr := RunGain(tracker, config.EconomicsConfig{}, []string{"--unfiltered", "10"})
 
 	_ = w.Close()
 	var buf bytes.Buffer
@@ -389,4 +390,76 @@ func TestRunGainUnfilteredWithData(t *testing.T) {
 	if !strings.Contains(output, "make") {
 		t.Error("expected 'make' in unfiltered output")
 	}
+}
+
+// TestRunGainQuotaUsesEconomicsPricing pins the --quota projection to the
+// shared tier table (issue #186): it used to carry its own stale prices,
+// reporting Opus savings 3x above what cc-economics computed from the same
+// database. seedTracker saves 3220 tokens on a single active day, so the
+// projection is 96_600 tokens/month.
+func TestRunGainQuotaUsesEconomicsPricing(t *testing.T) {
+	tracker := newTestTracker(t)
+	seedTracker(t, tracker)
+
+	output := captureGain(t, tracker, config.EconomicsConfig{}, []string{"--quota"})
+
+	want := map[string]string{
+		"Haiku":  "$0.10", // 1.00/M, not the stale 0.25/M ($0.02)
+		"Sonnet": "$0.29",
+		"Opus":   "$0.48", // 5.00/M, not the stale 15.00/M ($1.45)
+		"Fable":  "$0.97", // tier was missing from the quota table entirely
+	}
+	for name, cost := range want {
+		line := name + " savings"
+		if !strings.Contains(output, line) {
+			t.Errorf("expected %q in output", line)
+			continue
+		}
+		if !strings.Contains(output, cost+"/month") {
+			t.Errorf("%s: expected %s/month in output, got:\n%s", name, cost, output)
+		}
+	}
+	if !strings.Contains(output, "Assumes saved tokens are input tokens") {
+		t.Error("expected the pricing assumption disclosure cc-economics prints")
+	}
+}
+
+// TestRunGainQuotaHonorsConfigTiers verifies --quota reads [economics.tiers]
+// instead of a hardcoded table.
+func TestRunGainQuotaHonorsConfigTiers(t *testing.T) {
+	tracker := newTestTracker(t)
+	seedTracker(t, tracker)
+
+	ecoCfg := config.EconomicsConfig{Tiers: map[string]float64{"Negotiated": 2.00}}
+	output := captureGain(t, tracker, ecoCfg, []string{"--quota"})
+
+	if !strings.Contains(output, "Negotiated savings") {
+		t.Errorf("expected configured tier in output, got:\n%s", output)
+	}
+	if strings.Contains(output, "Opus savings") {
+		t.Errorf("expected configured tiers to replace the defaults, got:\n%s", output)
+	}
+}
+
+// captureGain runs RunGain with stdout redirected and returns what it printed.
+func captureGain(t *testing.T, tracker *tracking.Tracker, ecoCfg config.EconomicsConfig, args []string) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	runErr := RunGain(tracker, ecoCfg, args)
+
+	_ = w.Close()
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	os.Stdout = old
+
+	if runErr != nil {
+		t.Fatalf("unexpected error: %v", runErr)
+	}
+	return buf.String()
 }

--- a/internal/economics/economics.go
+++ b/internal/economics/economics.go
@@ -10,12 +10,6 @@ import (
 	"github.com/edouard-claude/snip/internal/utils"
 )
 
-// Tier holds a model tier name and its input price per 1M tokens.
-type Tier struct {
-	Name   string
-	PriceM float64 // price per 1M input tokens
-}
-
 // CostForTokens returns the dollar cost for the given token count at the tier price.
 func CostForTokens(tokens int, pricePerM float64) float64 {
 	return float64(tokens) / 1_000_000 * pricePerM
@@ -40,7 +34,7 @@ func Run(tracker *tracking.Tracker, ecoCfg config.EconomicsConfig, args []string
 		return nil
 	}
 
-	activeTiers := ActiveTiers(ecoCfg)
+	activeTiers := config.ActiveTiers(ecoCfg)
 
 	// Parse --tier flag
 	var filterTier string
@@ -51,8 +45,8 @@ func Run(tracker *tracking.Tracker, ecoCfg config.EconomicsConfig, args []string
 		}
 	}
 
-	if filterTier != "" && FindTier(activeTiers, filterTier) == nil {
-		return fmt.Errorf("unknown tier %q (valid: %s)", filterTier, strings.Join(TierNames(activeTiers), ", "))
+	if filterTier != "" && config.FindTier(activeTiers, filterTier) == nil {
+		return fmt.Errorf("unknown tier %q (valid: %s)", filterTier, strings.Join(config.TierNames(activeTiers), ", "))
 	}
 
 	summary, err := tracker.GetSummary()
@@ -99,8 +93,8 @@ func Run(tracker *tracking.Tracker, ecoCfg config.EconomicsConfig, args []string
 
 	tiers := activeTiers
 	if filterTier != "" {
-		t := FindTier(activeTiers, filterTier)
-		tiers = []Tier{*t}
+		t := config.FindTier(activeTiers, filterTier)
+		tiers = []config.Tier{*t}
 	}
 
 	nameWidth := 8

--- a/internal/economics/economics_test.go
+++ b/internal/economics/economics_test.go
@@ -99,10 +99,10 @@ func TestTierByName(t *testing.T) {
 		{"opus", "Opus"},
 	}
 
-	defaults := ActiveTiers(config.EconomicsConfig{})
+	defaults := config.ActiveTiers(config.EconomicsConfig{})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tier := FindTier(defaults, tt.name)
+			tier := config.FindTier(defaults, tt.name)
 			if tier == nil {
 				t.Fatalf("FindTier(%q) returned nil", tt.name)
 			}
@@ -114,7 +114,7 @@ func TestTierByName(t *testing.T) {
 }
 
 func TestTierByNameUnknown(t *testing.T) {
-	tier := FindTier(ActiveTiers(config.EconomicsConfig{}), "unknown")
+	tier := config.FindTier(config.ActiveTiers(config.EconomicsConfig{}), "unknown")
 	if tier != nil {
 		t.Errorf("FindTier(\"unknown\") = %v, want nil", tier)
 	}
@@ -128,7 +128,7 @@ func TestTierPricing(t *testing.T) {
 		"Opus":   5.00,
 		"Fable":  10.00,
 	}
-	for _, tier := range ActiveTiers(config.EconomicsConfig{}) {
+	for _, tier := range config.ActiveTiers(config.EconomicsConfig{}) {
 		want, ok := expected[tier.Name]
 		if !ok {
 			t.Errorf("unexpected tier %q", tier.Name)
@@ -240,7 +240,7 @@ func TestActiveTiersCustom(t *testing.T) {
 			"ClaudeY": 2.00,
 		},
 	}
-	tiers := ActiveTiers(cfg)
+	tiers := config.ActiveTiers(cfg)
 	if len(tiers) != 2 {
 		t.Fatalf("expected 2 tiers, got %d", len(tiers))
 	}


### PR DESCRIPTION
## Why

`gain --quota` carried its own hardcoded price table (Haiku $0.25, Opus $15.00 per 1M input tokens) while `cc-economics` priced the same `SUM(saved_tokens)` from `internal/economics` defaults (Haiku $1.00, Opus $5.00). Same database, dollar figures 3x to 4x apart, and `--quota` ignored `[economics.tiers]` overrides.

## What

- Tier table moved to `internal/config` (the only package both `economics` and `display` already import; `economics` imports `display`, so the reverse is impossible)
- `display.RunGain` takes `config.EconomicsConfig`; `--quota` now reports the Fable tier too and prints the same input-price assumption line as `cc-economics`
- Regression tests pin the projected amounts ($0.10 / $0.48 with the shared table vs $0.02 / $1.45 with the stale one) and the config override

Fixes #186
