### PR TITLE
fix: quote the snip path for the agent's shell, not the host's

### DIFF
--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -67,8 +67,10 @@ func Run(r io.Reader, w io.Writer, commands []string, prefixes []TransparentPref
 		cmdSet[c] = struct{}{}
 	}
 
-	// Rewrite every runnable segment whose base command snip supports.
-	res := RewriteCommand(ti.Command, cmdSet, prefixes, snipBin)
+	// Rewrite every runnable segment whose base command snip supports. The
+	// Bash tool is a POSIX shell on every OS (Git Bash on Windows), so the
+	// binary path must survive bash quoting rather than PowerShell's (#187).
+	res := RewriteCommandFor(ShellPOSIX, ti.Command, cmdSet, prefixes, snipBin)
 	if !res.Changed {
 		// Audit: nothing matched (or already rewritten).
 		if audit {

--- a/internal/hook/quote.go
+++ b/internal/hook/quote.go
@@ -14,36 +14,62 @@ import (
 // which does not inherit the hook's environment. Embedding the path as a
 // flag keeps the plugin layer alive at run time (issue #169). A flag is
 // used instead of a `VAR=x` env prefix so PowerShell keeps working (#150).
-func runInvocation(quotedBin string) string {
+func runInvocation(quotedBin string, shell Shell) string {
 	inv := quotedBin
 	if p := os.Getenv("SNIP_PLUGIN_CONFIG"); p != "" {
-		inv += " --plugin-config " + quoteSnipBin(p)
+		inv += " --plugin-config " + quoteBin(p, shell)
 	}
 	return inv + " run -- "
 }
 
-// quoteSnipBin renders the snip binary path for inclusion in a rewritten
-// command, so a path containing spaces still executes as one word.
+// Shell is the shell a rewritten command will execute in. The agent decides
+// it, not the host OS: Claude Code's Bash tool runs Git Bash on Windows, while
+// Codex hands the command to PowerShell or cmd.exe there.
+type Shell int
+
+const (
+	// ShellHost is the shell agents use on the host OS: PowerShell or cmd.exe
+	// on Windows, a POSIX shell elsewhere.
+	ShellHost Shell = iota
+	// ShellPOSIX is a POSIX shell whatever the host OS (issue #187).
+	ShellPOSIX
+)
+
+// hostGOOS is runtime.GOOS, overridable in tests to exercise the Windows
+// branches from any host.
+var hostGOOS = runtime.GOOS
+
+// quoteSnipBin renders the snip binary path for the host shell.
 func quoteSnipBin(path string) string {
-	return QuoteBinFor(path, runtime.GOOS)
+	return quoteBin(path, ShellHost)
 }
 
-// QuoteBinFor is quoteSnipBin with the target OS injected, so both branches are
+// quoteBin renders a path for inclusion in a rewritten command targeting
+// shell, so a path containing spaces still executes as one word.
+func quoteBin(path string, shell Shell) string {
+	return QuoteBinFor(path, hostGOOS, shell)
+}
+
+// QuoteBinFor is quoteBin with the host OS injected, so every branch is
 // testable from any host.
 //
-// Go's %q is a Go string literal, not a shell word, and on Windows it is wrong
-// twice over: it doubles every backslash of a native path
-// (`"C:\\Users\\me\\snip.exe"`), and the quotes it adds make PowerShell parse
-// the result as a string expression rather than a command, which fails with
-// "Unexpected token 'run' in expression or statement" (issue #150).
+// Go's %q is a Go string literal, not a shell word. For a POSIX shell that is
+// harmless: double quotes turn the doubled backslashes of a native Windows
+// path back into single ones, so `"C:\\Users\\me\\snip.exe"` executes
+// `C:\Users\me\snip.exe` in Git Bash. The bare path would not: bash eats an
+// unquoted backslash (`\U` -> `U`), which is how issue #187 produced exit 127.
 //
-// A Windows path with no space needs no quoting at all, and unquoted is the one
-// form that runs in PowerShell, cmd.exe and a POSIX shell alike. A path that
-// does contain a space still needs the quotes; PowerShell would additionally
-// need its call operator there, which cmd.exe rejects, so the quotes are
-// emitted without guessing which shell is on the other side.
-func QuoteBinFor(path, goos string) string {
-	if goos == "windows" {
+// For a Windows shell the same literal is wrong twice over: it names no
+// existing file (the backslashes stay doubled), and the quotes make
+// PowerShell parse the result as a string expression rather than a command,
+// which fails with "Unexpected token 'run' in expression or statement"
+// (issue #150). A Windows path with no space needs no quoting at all, and
+// unquoted is the one form PowerShell and cmd.exe both run. A path that does
+// contain a space still needs the quotes; PowerShell would additionally need
+// its call operator there, which cmd.exe rejects, so the quotes are emitted
+// without guessing which of the two is on the other side.
+func QuoteBinFor(path, goos string, shell Shell) string {
+	if goos == "windows" && shell == ShellHost {
 		if !strings.ContainsAny(path, " \t\"") {
 			return path
 		}

--- a/internal/hook/quote_shell_test.go
+++ b/internal/hook/quote_shell_test.go
@@ -1,0 +1,54 @@
+package hook
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestWindowsBinQuotingPerAgent pins issue #187: the shell a rewritten command
+// runs in is the agent's, not the host's. On Windows, Claude Code's Bash tool
+// is Git Bash, where a bare `C:\Users\...` path loses its backslashes and
+// fails with exit 127, while Codex hands the command to PowerShell or cmd.exe,
+// where the quoted literal is the form that fails (#150, #174).
+func TestWindowsBinQuotingPerAgent(t *testing.T) {
+	const bin = `C:\Users\me\.local\bin\snip.exe`
+	commands := []string{"git"}
+
+	old := hostGOOS
+	hostGOOS = "windows"
+	t.Cleanup(func() { hostGOOS = old })
+
+	t.Run("claude code gets a bash-safe literal", func(t *testing.T) {
+		var out bytes.Buffer
+		if err := Run(strings.NewReader(makePayload("Bash", "git status")), &out, commands, nil, bin); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		got := extractRewrittenCommand(t, out.String())
+		want := `"C:\\Users\\me\\.local\\bin\\snip.exe" run -- git status`
+		if got != want {
+			t.Errorf("command = %q, want %q", got, want)
+		}
+
+		// Re-running the hook on its own output must not wrap it twice.
+		out.Reset()
+		if err := Run(strings.NewReader(makePayload("Bash", got)), &out, commands, nil, bin); err != nil {
+			t.Fatalf("Run (second pass): %v", err)
+		}
+		if out.Len() != 0 {
+			t.Errorf("second pass rewrote again: %s", out.String())
+		}
+	})
+
+	t.Run("codex keeps the bare windows path", func(t *testing.T) {
+		var out bytes.Buffer
+		if err := RunCodex(strings.NewReader(makePayload("Bash", "git status")), &out, commands, nil, bin); err != nil {
+			t.Fatalf("RunCodex: %v", err)
+		}
+		_, updated := extractCodexRewrite(t, out.String())
+		want := `C:\Users\me\.local\bin\snip.exe run -- git status`
+		if updated["command"] != want {
+			t.Errorf("command = %q, want %q", updated["command"], want)
+		}
+	})
+}

--- a/internal/hook/quote_test.go
+++ b/internal/hook/quote_test.go
@@ -8,16 +8,41 @@ import "testing"
 // ("Unexpected token 'run' in expression or statement").
 func TestQuoteBinFor(t *testing.T) {
 	cases := []struct {
-		name string
-		path string
-		goos string
-		want string
+		name  string
+		path  string
+		goos  string
+		shell Shell
+		want  string
 	}{
 		{
 			name: "windows path without spaces is bare",
 			path: `C:\Users\Administrator\.snip\snip.exe`,
 			goos: "windows",
 			want: `C:\Users\Administrator\.snip\snip.exe`,
+		},
+		{
+			// Issue #187: Git Bash eats the backslashes of a bare path
+			// (`\U` -> `U`, exit 127). Inside double quotes `\` is `\`, so
+			// the Go literal is exactly what bash needs.
+			name:  "windows path for a posix shell is a quoted literal",
+			path:  `C:\Users\Administrator\.snip\snip.exe`,
+			goos:  "windows",
+			shell: ShellPOSIX,
+			want:  `"C:\\Users\\Administrator\\.snip\\snip.exe"`,
+		},
+		{
+			name:  "windows path with a space for a posix shell",
+			path:  `C:\Program Files\snip\snip.exe`,
+			goos:  "windows",
+			shell: ShellPOSIX,
+			want:  `"C:\\Program Files\\snip\\snip.exe"`,
+		},
+		{
+			name:  "posix path for a posix shell is unchanged by the target",
+			path:  "/usr/local/bin/snip",
+			goos:  "linux",
+			shell: ShellPOSIX,
+			want:  `"/usr/local/bin/snip"`,
 		},
 		{
 			// Quotes are still required, and the backslashes must survive
@@ -43,8 +68,8 @@ func TestQuoteBinFor(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := QuoteBinFor(tc.path, tc.goos); got != tc.want {
-				t.Errorf("QuoteBinFor(%q, %q) = %q, want %q", tc.path, tc.goos, got, tc.want)
+			if got := QuoteBinFor(tc.path, tc.goos, tc.shell); got != tc.want {
+				t.Errorf("QuoteBinFor(%q, %q, %d) = %q, want %q", tc.path, tc.goos, tc.shell, got, tc.want)
 			}
 		})
 	}
@@ -56,7 +81,7 @@ func TestRewriteCommandWindowsBin(t *testing.T) {
 	const bin = `C:\Users\Administrator\.snip\snip.exe`
 	cmdSet := map[string]struct{}{"git": {}}
 
-	got, known, _ := rewriteGroup("git diff --check", cmdSet, nil, QuoteBinFor(bin, "windows"), bin)
+	got, known, _ := rewriteGroup("git diff --check", cmdSet, nil, QuoteBinFor(bin, "windows", ShellHost), bin, ShellHost)
 	want := `C:\Users\Administrator\.snip\snip.exe run -- git diff --check`
 	if got != want {
 		t.Errorf("rewritten = %q, want %q", got, want)
@@ -66,7 +91,7 @@ func TestRewriteCommandWindowsBin(t *testing.T) {
 	}
 
 	// Re-running the hook on its own output must not wrap it twice.
-	again, _, _ := rewriteGroup(want, cmdSet, nil, QuoteBinFor(bin, "windows"), bin)
+	again, _, _ := rewriteGroup(want, cmdSet, nil, QuoteBinFor(bin, "windows", ShellHost), bin, ShellHost)
 	if again != want {
 		t.Errorf("second pass = %q, want it unchanged", again)
 	}

--- a/internal/hook/rewrite.go
+++ b/internal/hook/rewrite.go
@@ -52,7 +52,14 @@ type RewriteResult struct {
 // (HasUnverifiableConstruct) before calling this, so cmd here is free of command
 // substitution and carriage returns.
 func RewriteCommand(cmd string, cmdSet map[string]struct{}, prefixes []TransparentPrefix, snipBin string) RewriteResult {
-	quotedBin := quoteSnipBin(snipBin)
+	return RewriteCommandFor(ShellHost, cmd, cmdSet, prefixes, snipBin)
+}
+
+// RewriteCommandFor is RewriteCommand for a command that will execute in
+// shell rather than in the host shell. Claude Code's Bash tool is Git Bash on
+// Windows, so its hook passes ShellPOSIX (issue #187).
+func RewriteCommandFor(shell Shell, cmd string, cmdSet map[string]struct{}, prefixes []TransparentPrefix, snipBin string) RewriteResult {
+	quotedBin := quoteBin(snipBin, shell)
 
 	var b strings.Builder
 	b.Grow(len(cmd) + 32)
@@ -72,7 +79,7 @@ func RewriteCommand(cmd string, cmdSet map[string]struct{}, prefixes []Transpare
 				allKnown = false
 			}
 		} else {
-			out, headKnown, hasTail := rewriteGroup(group, cmdSet, prefixes, quotedBin, snipBin)
+			out, headKnown, hasTail := rewriteGroup(group, cmdSet, prefixes, quotedBin, snipBin, shell)
 			b.WriteString(out)
 			if out != group {
 				changed = true
@@ -240,7 +247,7 @@ func RewriteCommand(cmd string, cmdSet map[string]struct{}, prefixes []Transpare
 // between two sequential boundaries). It returns the rewritten group, whether
 // the head is a known/attested base command, and whether the group has a
 // non-empty pipeline tail (extra stages that were left uninspected).
-func rewriteGroup(group string, cmdSet map[string]struct{}, prefixes []TransparentPrefix, quotedBin, snipBin string) (out string, headKnown, hasTail bool) {
+func rewriteGroup(group string, cmdSet map[string]struct{}, prefixes []TransparentPrefix, quotedBin, snipBin string, shell Shell) (out string, headKnown, hasTail bool) {
 	head, tail := splitFirstPipe(group)
 	hasTail = strings.TrimSpace(tail) != ""
 
@@ -281,7 +288,7 @@ func rewriteGroup(group string, cmdSet map[string]struct{}, prefixes []Transpare
 			if feedsConsumer {
 				return group, true, hasTail
 			}
-			wrappedHead := prefix + envVars + tp.Prefix + " " + before + runInvocation(quotedBin) + rest[len(before):]
+			wrappedHead := prefix + envVars + tp.Prefix + " " + before + runInvocation(quotedBin, shell) + rest[len(before):]
 			return wrappedHead + tail, true, hasTail
 		}
 	}
@@ -295,7 +302,7 @@ func rewriteGroup(group string, cmdSet map[string]struct{}, prefixes []Transpare
 		return group, true, hasTail
 	}
 
-	wrappedHead := prefix + envVars + runInvocation(quotedBin) + bareCmd
+	wrappedHead := prefix + envVars + runInvocation(quotedBin, shell) + bareCmd
 	return wrappedHead + tail, true, hasTail
 }
 

--- a/internal/hook/suggest.go
+++ b/internal/hook/suggest.go
@@ -46,7 +46,7 @@ func suggestSnipRerun(command string, cmdSet map[string]struct{}, prefixes []Tra
 	var suggested string
 	if tp, restAfter, ok := matchTransparentPrefix(bareCmd, prefixes); ok {
 		if before, _, found := LocateInner(restAfter, cmdSet, tp.ValueFlags, tp.SkipFlags); found {
-			suggested = prefix + envVars + tp.Prefix + " " + before + runInvocation(quotedBin) + restAfter[len(before):] + restOfCmd
+			suggested = prefix + envVars + tp.Prefix + " " + before + runInvocation(quotedBin, ShellHost) + restAfter[len(before):] + restOfCmd
 		}
 	}
 
@@ -54,7 +54,7 @@ func suggestSnipRerun(command string, cmdSet map[string]struct{}, prefixes []Tra
 		if _, ok := cmdSet[base]; !ok {
 			return snipSuggestion{base: base}
 		}
-		suggested = prefix + envVars + runInvocation(quotedBin) + bareCmd + restOfCmd
+		suggested = prefix + envVars + runInvocation(quotedBin, ShellHost) + bareCmd + restOfCmd
 	}
 
 	return snipSuggestion{command: suggested, base: base}

--- a/internal/initcmd/antigravity.go
+++ b/internal/initcmd/antigravity.go
@@ -24,7 +24,7 @@ func initAntigravity(snipBin, filterDir string) error {
 		}
 	}
 
-	hookCommand := hook.QuoteBinFor(snipBin, runtime.GOOS) + " hook antigravity"
+	hookCommand := hook.QuoteBinFor(snipBin, runtime.GOOS, hook.ShellHost) + " hook antigravity"
 	hooksPath := filepath.Join(agyBase, "config", "hooks.json")
 	if err := patchAntigravityHooks(hooksPath, hookCommand); err != nil {
 		return fmt.Errorf("patch settings: %w", err)

--- a/internal/initcmd/antigravity_test.go
+++ b/internal/initcmd/antigravity_test.go
@@ -13,7 +13,7 @@ import (
 func TestPatchAntigravityHooksNew(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "hooks.json")
-	hookCommand := hook.QuoteBinFor("/usr/local/bin/snip", runtime.GOOS) + " hook antigravity"
+	hookCommand := hook.QuoteBinFor("/usr/local/bin/snip", runtime.GOOS, hook.ShellHost) + " hook antigravity"
 
 	err := patchAntigravityHooks(path, hookCommand)
 	if err != nil {
@@ -54,7 +54,7 @@ func TestPatchAntigravityHooksNew(t *testing.T) {
 func TestPatchAntigravityHooksExisting(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "hooks.json")
-	hookCommand := hook.QuoteBinFor("/usr/local/bin/snip", runtime.GOOS) + " hook antigravity"
+	hookCommand := hook.QuoteBinFor("/usr/local/bin/snip", runtime.GOOS, hook.ShellHost) + " hook antigravity"
 
 	// Write existing hooks with other hooks
 	existing := map[string]any{
@@ -150,7 +150,7 @@ func TestPatchAntigravityHooksIdempotent(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			hookCommand := hook.QuoteBinFor(tc.path, tc.runtimeOS) + " hook antigravity"
+			hookCommand := hook.QuoteBinFor(tc.path, tc.runtimeOS, hook.ShellHost) + " hook antigravity"
 
 			// Patch twice
 			_ = patchAntigravityHooks(path, hookCommand)
@@ -196,7 +196,7 @@ func TestUnpatchAntigravityHooks(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			hookCommand := hook.QuoteBinFor(tc.path, tc.runtimeOS) + " hook antigravity"
+			hookCommand := hook.QuoteBinFor(tc.path, tc.runtimeOS, hook.ShellHost) + " hook antigravity"
 
 			// Patch first
 			_ = patchAntigravityHooks(path, hookCommand)
@@ -247,7 +247,7 @@ func TestUnpatchAntigravityHooksPreservesOtherHooks(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			hookCommand := hook.QuoteBinFor(tc.path, tc.runtimeOS) + " hook antigravity"
+			hookCommand := hook.QuoteBinFor(tc.path, tc.runtimeOS, hook.ShellHost) + " hook antigravity"
 
 			// Create settings with snip + another hook
 			existing := map[string]any{
@@ -296,7 +296,7 @@ func TestPatchAntigravityHooksWindowsPath(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "hooks.json")
 	// Simulate a Windows-style snip hook command
-	hookCommand := hook.QuoteBinFor(`C:\Users\joedoe\go\bin\snip.exe`, runtime.GOOS) + ` hook antigravity`
+	hookCommand := hook.QuoteBinFor(`C:\Users\joedoe\go\bin\snip.exe`, runtime.GOOS, hook.ShellHost) + ` hook antigravity`
 
 	err := patchAntigravityHooks(path, hookCommand)
 	if err != nil {

--- a/internal/initcmd/codex.go
+++ b/internal/initcmd/codex.go
@@ -46,7 +46,7 @@ func initCodex(snipBin, home, filterDir string) error {
 
 	// Reuse the command-rewrite quoting so the installed hook works with the
 	// platform shell, including cmd.exe on Windows.
-	hookCommand := hook.QuoteBinFor(snipBin, runtime.GOOS) + " " + codexHookSubcommand
+	hookCommand := hook.QuoteBinFor(snipBin, runtime.GOOS, hook.ShellHost) + " " + codexHookSubcommand
 
 	hooksPath := codexHooksPath(home)
 	if err := patchCodexHooks(hooksPath, hookCommand); err != nil {


### PR DESCRIPTION
## Why

Since 0.25.0 a Windows path with no space is emitted bare in every rewritten command. That is the one form PowerShell and cmd.exe both run (#150, #174), but Claude Code's Bash tool is Git Bash on Windows, and bash eats the backslashes of an unquoted path: `C:\Users\me\snip.exe` becomes `C:Usersmesnip.exe`, exit 127, on every filtered command.

## What

The shell is the agent's choice, not the OS's:

- `RewriteCommandFor(shell, ...)` takes a `Shell`. The Claude Code hook passes `ShellPOSIX` and gets the Go literal back (`"C:\\Users\\me\\snip.exe"`, which bash reads as the native path, the 0.24.1 form). Codex, Copilot, Grok, Pi and Antigravity keep `ShellHost` and the bare path, so #150 and #174 stay fixed.
- The `--plugin-config` path follows the same rule.
- `TestWindowsBinQuotingPerAgent` drives both hooks with `hostGOOS = "windows"` and pins the two forms plus idempotency on a second pass. It fails on master.

Not verified on a real Windows box: @Plumvery, if you can run the `snip hook` repro from the issue against this branch in Git Bash, that would settle it.

Fixes #187
